### PR TITLE
feat(inbound-match): warn when credential-tagged waitpoint omits sender_id

### DIFF
--- a/docs/adoption-patterns/2fa-code-intercept.md
+++ b/docs/adoption-patterns/2fa-code-intercept.md
@@ -159,8 +159,22 @@ to the expected human. Without it, an attacker with adapter write
 access could resolve your waitpoint with an arbitrary code.
 
 Framework doesn't enforce this (some patterns are legitimately
-sender-agnostic — e.g., a shared admin channel), but skill prompts
-should consistently require it for credential-adjacent flows.
+sender-agnostic — e.g., a shared admin channel), but it does **warn**.
+When a waitpoint registers with credential-adjacent tags (`2fa`, `mfa`,
+`oauth`, `2-step`, `auth-code`, `verification`) and no `sender_id`, the
+runtime emits a `console.warn` and flags the registration in WAL via
+`payload.sender_id_warn = true`. Sweep with:
+
+```sql
+SELECT created_at, payload->>'waitpoint_id' AS wp, payload->>'tags' AS tags
+  FROM nexaas_memory.wal
+ WHERE op = 'inbound_match_waitpoint_registered'
+   AND (payload->>'sender_id_warn')::boolean
+ ORDER BY created_at DESC;
+```
+
+Skill prompts should still consistently require `sender_id` for
+credential-adjacent flows — the warning surfaces drift, it doesn't fix it.
 
 ## UI rendering hints — the `tags` array
 

--- a/docs/adoption-patterns/2fa-code-intercept.md
+++ b/docs/adoption-patterns/2fa-code-intercept.md
@@ -179,9 +179,15 @@ credential-adjacent flows — the warning surfaces drift, it doesn't fix it.
 ## UI rendering hints — the `tags` array
 
 Waitpoint registrations accept an optional `tags: string[]` field. The
-framework ignores them entirely — they're pure passthrough metadata stored
-in the waitpoint's state JSON. Dashboards and UIs read them to render
-subtype-specific affordances.
+framework treats them as passthrough metadata — stored verbatim in the
+waitpoint's state JSON for dashboards and UIs to read — with one
+exception: the credential-adjacent set called out in
+[Security: always scope by `sender_id`](#security-always-scope-by-sender_id)
+above triggers a registration-time warning when paired with a missing
+`sender_id`. That's the only semantic the framework attaches; everything
+else is purely for adopter use.
+
+Dashboards read tags to render subtype-specific affordances.
 
 Examples:
 

--- a/packages/runtime/src/tasks/inbound-match-waitpoint.ts
+++ b/packages/runtime/src/tasks/inbound-match-waitpoint.ts
@@ -193,23 +193,14 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
     ? params.tags.filter((t): t is string => typeof t === "string" && t.length > 0).slice(0, 16)
     : undefined;
 
-  // Credential-adjacent + missing sender_id = security gap. Warn loudly but
-  // don't refuse — some patterns (shared admin channels) are legitimately
-  // sender-agnostic. Surfaces in console output AND the WAL payload below
-  // so downstream observability can flag risky registrations.
+  // Credential-adjacent + missing sender_id = security gap. Compute the flag
+  // up-front (so the WAL payload can record it), but defer the visible warn
+  // until after createWaitpoint succeeds — otherwise a creation failure
+  // produces a phantom warning for a waitpoint that never existed.
   const credentialAdjacentTagsHit = tags
     ? tags.filter((t) => CREDENTIAL_ADJACENT_TAGS.has(t.toLowerCase()))
     : [];
   const senderIdWarn = credentialAdjacentTagsHit.length > 0 && !params.match.sender_id;
-  if (senderIdWarn) {
-    console.warn(
-      `[nexaas] inbound-match-waitpoint ${waitpointId} registered with credential-adjacent ` +
-      `tags (${credentialAdjacentTagsHit.join(", ")}) but no match.sender_id — anyone with ` +
-      `adapter write access can resolve this waitpoint with an arbitrary value. Pass ` +
-      `match.sender_id to scope to the expected human. ` +
-      `See docs/adoption-patterns/2fa-code-intercept.md#security-always-scope-by-sender_id`,
-    );
-  }
 
   await session.createWaitpoint({
     signal: waitpointId,
@@ -231,6 +222,19 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
     },
     timeout: `${timeoutSec}s`,
   });
+
+  // Waitpoint exists — safe to emit the warning. Don't refuse — some patterns
+  // (shared admin channels, broadcast confirmations) are legitimately
+  // sender-agnostic. Surfaces in console output AND the WAL payload below.
+  if (senderIdWarn) {
+    console.warn(
+      `[nexaas] inbound-match-waitpoint ${waitpointId} registered with credential-adjacent ` +
+      `tags (${credentialAdjacentTagsHit.join(", ")}) but no match.sender_id — anyone with ` +
+      `adapter write access can resolve this waitpoint with an arbitrary value. Pass ` +
+      `match.sender_id to scope to the expected human. ` +
+      `See docs/adoption-patterns/2fa-code-intercept.md#security-always-scope-by-sender_id`,
+    );
+  }
 
   await appendWal({
     workspace: params.workspace,

--- a/packages/runtime/src/tasks/inbound-match-waitpoint.ts
+++ b/packages/runtime/src/tasks/inbound-match-waitpoint.ts
@@ -84,6 +84,19 @@ export interface StatusResult {
 
 const DEFAULT_TIMEOUT_SECONDS = 300;
 
+/**
+ * Tags that imply the waitpoint will resolve with a credential — 2FA codes,
+ * OAuth callbacks, MFA tokens. When any of these appear in `tags` and the
+ * caller did not pass `match.sender_id`, the framework emits a non-blocking
+ * warning and flags the registration in WAL. The waitpoint is *not* refused —
+ * some adopter patterns are legitimately sender-agnostic — but the discipline
+ * documented in `docs/adoption-patterns/2fa-code-intercept.md` is now
+ * observable instead of honor-system. Match is case-insensitive.
+ */
+const CREDENTIAL_ADJACENT_TAGS = new Set([
+  "2fa", "mfa", "oauth", "2-step", "auth-code", "verification",
+]);
+
 // Default cap is 24h. Adopters running state-machine hold patterns (Stripe
 // payment-failed, multi-day approval loops) can raise this via env — e.g.
 // `NEXAAS_WAITPOINT_MAX_TIMEOUT_DAYS=7`. No added load from longer timeouts;
@@ -173,11 +186,30 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
 
   const expiresAt = new Date(Date.now() + timeoutSec * 1000).toISOString();
 
-  // Tags are pure passthrough — framework never reads them. Normalize to
-  // string[] and drop anything non-string so downstream SQL stays clean.
+  // Tags are pure passthrough for downstream UIs — framework reads them
+  // only to detect credential-adjacent registrations missing sender_id
+  // scope (see CREDENTIAL_ADJACENT_TAGS).
   const tags = Array.isArray(params.tags)
     ? params.tags.filter((t): t is string => typeof t === "string" && t.length > 0).slice(0, 16)
     : undefined;
+
+  // Credential-adjacent + missing sender_id = security gap. Warn loudly but
+  // don't refuse — some patterns (shared admin channels) are legitimately
+  // sender-agnostic. Surfaces in console output AND the WAL payload below
+  // so downstream observability can flag risky registrations.
+  const credentialAdjacentTagsHit = tags
+    ? tags.filter((t) => CREDENTIAL_ADJACENT_TAGS.has(t.toLowerCase()))
+    : [];
+  const senderIdWarn = credentialAdjacentTagsHit.length > 0 && !params.match.sender_id;
+  if (senderIdWarn) {
+    console.warn(
+      `[nexaas] inbound-match-waitpoint ${waitpointId} registered with credential-adjacent ` +
+      `tags (${credentialAdjacentTagsHit.join(", ")}) but no match.sender_id — anyone with ` +
+      `adapter write access can resolve this waitpoint with an arbitrary value. Pass ` +
+      `match.sender_id to scope to the expected human. ` +
+      `See docs/adoption-patterns/2fa-code-intercept.md#security-always-scope-by-sender_id`,
+    );
+  }
 
   await session.createWaitpoint({
     signal: waitpointId,
@@ -213,6 +245,7 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
       timeout_seconds: timeoutSec,
       extract,
       tags,
+      sender_id_warn: senderIdWarn || undefined,
     },
   });
 


### PR DESCRIPTION
## Summary

- Promotes the "always scope by `sender_id`" rule in the 2FA adoption pattern from honor-system to observable.
- When a waitpoint registers with credential-adjacent tags (`2fa`, `mfa`, `oauth`, `2-step`, `auth-code`, `verification`) and no `match.sender_id`, the framework now emits a `console.warn` naming the waitpoint, and flags the WAL payload with `sender_id_warn: true`.
- Non-blocking — some patterns (shared admin channels, broadcast confirmations) are legitimately sender-agnostic. The framework shouldn't refuse them, just make the security gap visible.
- Adoption-pattern doc updated with the sweep query and a clarifying note that the warning surfaces drift, it doesn't fix it.

## Why

PR #73 / issue #59 / the BSBC mock-bank-fetch validation surfaced this: an adopter wiring up a 2FA flow with `tags: ["2fa", "mock-bank", "demo"]` and no `sender_id` is one accident away from the documented vulnerability ("anyone with adapter write access can resolve your waitpoint with an arbitrary code"). The doc said "skill prompts should consistently require it" — fine in principle, brittle in practice.

A loud framework warning + a queryable WAL field is the right shape: it doesn't refuse legitimate sender-agnostic patterns, but it stops the omission from being silent.

## What lands

**`packages/runtime/src/tasks/inbound-match-waitpoint.ts`** — new module-level `CREDENTIAL_ADJACENT_TAGS` set; in `registerWaitpoint`, after the tag normalization, check for any matching tag and missing `sender_id`. On hit:

- `console.warn` with the waitpoint id, the offending tag(s), and a link to the doc section
- `sender_id_warn: true` added to the existing `inbound_match_waitpoint_registered` WAL payload (only when warn fires — `undefined` otherwise to keep payloads compact)

**`docs/adoption-patterns/2fa-code-intercept.md`** — security section updated to describe the new warn + the SQL sweep query for finding past offenders.

## Tag list rationale

`2fa`, `mfa`, `oauth`, `2-step`, `auth-code`, `verification` — tight set, low false-positive risk. Match is case-insensitive. If an adopter coins a new tag for a credential-bearing flow (`magic-link`?), the warn won't fire — that's a deliberate trade-off; we'd rather miss a few than false-warn on `["confirmation"]`-style benign flows.

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit -p tsconfig.json` clean)
- [x] Existing waitpoint registrations without tags or with non-credential tags continue to work unchanged (default behavior preserved)
- [x] Warn fires on registration like `tags: ["2fa", "mock-bank"]` + no `sender_id`
- [x] Warn does not fire when `sender_id` is supplied
- [x] WAL payload includes `sender_id_warn: true` exactly when console.warn fires
- [ ] Manual confirmation in BSBC: register a waitpoint with the BSBC `_demo/mock-bank-fetch` skill and observe the new warn line in worker logs (depends on next BSBC dashboard deploy with bumped framework)

## Out of scope

- Configurable tag list via env var — premature; if a second adopter needs custom tags we can add `NEXAAS_CREDENTIAL_ADJACENT_TAGS` then
- Refusing the registration — explicitly rejected; legitimate sender-agnostic patterns exist (admin channels, broadcast confirmations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated adoption patterns documentation with security guidance for credential-adjacent waitpoint registrations and detection patterns.

* **Enhancements**
  * Added detection and console warnings for credential-adjacent waitpoint registrations missing sender identification.
  * Improved observability logging to track identified security gaps in audit logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->