### PR TITLE
fix: silent migration drift + dispatcher schema-missing detection (#72)

### DIFF
--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -118,6 +118,7 @@ export async function run(args: string[]) {
       const sqlPath = join(nexaasRoot, "database/migrations", migration);
       const sqlContent = readFileSync(sqlPath, "utf-8");
       const client = await pool.connect();
+      let migrationFailed = false;
       try {
         await client.query("BEGIN");
         await client.query(sqlContent);
@@ -131,10 +132,14 @@ export async function run(args: string[]) {
         await client.query("ROLLBACK").catch(() => { /* best effort */ });
         console.error(`    ✗ ${migration}: ${(e as Error).message}`);
         console.error("  Migration failed — stopping. Fix the issue and run 'nexaas upgrade --migrate'");
+        migrationFailed = true;
+      } finally {
         client.release();
-        process.exit(1);
       }
-      client.release();
+      // Exit AFTER release so the connection always returns to the pool —
+      // process.exit doesn't run finally on the *outer* scope, but we already
+      // released in the inner finally. Belt and suspenders: see PR #77 review.
+      if (migrationFailed) process.exit(1);
     }
   } else {
     console.log("  Migrations: up to date");

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -104,25 +104,37 @@ export async function run(args: string[]) {
     }
   }
 
-  // Step 5: Apply pending migrations
+  // Step 5: Apply pending migrations.
+  //
+  // Each migration runs inside its own transaction with the schema_migrations
+  // marker INSERT — atomic apply + record. If the SQL fails partway, the
+  // marker rolls back too. This prevents the failure mode in #72 where the
+  // marker outlasted a failed apply and the dispatcher silently broke for
+  // days waiting on a table that was recorded as created but didn't exist.
   const pending = await getPendingMigrations(pool, nexaasRoot);
   if (pending.length > 0) {
     console.log(`\n  Applying ${pending.length} migration(s)...`);
     for (const migration of pending) {
+      const sqlPath = join(nexaasRoot, "database/migrations", migration);
+      const sqlContent = readFileSync(sqlPath, "utf-8");
+      const client = await pool.connect();
       try {
-        const sqlPath = join(nexaasRoot, "database/migrations", migration);
-        const sqlContent = readFileSync(sqlPath, "utf-8");
-        await pool.query(sqlContent);
-        await pool.query(
+        await client.query("BEGIN");
+        await client.query(sqlContent);
+        await client.query(
           `INSERT INTO nexaas_memory.schema_migrations (filename, applied_at) VALUES ($1, now()) ON CONFLICT DO NOTHING`,
           [migration],
         );
+        await client.query("COMMIT");
         console.log(`    ✓ ${migration}`);
       } catch (e) {
+        await client.query("ROLLBACK").catch(() => { /* best effort */ });
         console.error(`    ✗ ${migration}: ${(e as Error).message}`);
         console.error("  Migration failed — stopping. Fix the issue and run 'nexaas upgrade --migrate'");
+        client.release();
         process.exit(1);
       }
+      client.release();
     }
   } else {
     console.log("  Migrations: up to date");
@@ -211,7 +223,7 @@ async function getPendingMigrations(pool: pg.Pool, nexaasRoot: string): Promise<
 
   let applied: Set<string>;
   try {
-    // Ensure tracking table exists
+    // Ensure tracking table exists.
     await pool.query(`
       CREATE TABLE IF NOT EXISTS nexaas_memory.schema_migrations (
         filename TEXT PRIMARY KEY,
@@ -219,22 +231,14 @@ async function getPendingMigrations(pool: pg.Pool, nexaasRoot: string): Promise<
       )
     `);
 
-    // If tracking is empty but tables exist, seed with all existing migrations
-    const trackCount = await pool.query(`SELECT count(*) FROM nexaas_memory.schema_migrations`);
-    if (parseInt(trackCount.rows[0].count, 10) === 0) {
-      const tableCount = await pool.query(
-        `SELECT count(*) FROM information_schema.tables WHERE table_schema = 'nexaas_memory'`,
-      );
-      if (parseInt(tableCount.rows[0].count, 10) > 5) {
-        // Tables exist — seed tracking with all migrations
-        for (const f of allFiles) {
-          await pool.query(
-            `INSERT INTO nexaas_memory.schema_migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
-            [f],
-          );
-        }
-      }
-    }
+    // No seed-all heuristic. The previous "if schema_migrations is empty and
+    // nexaas_memory has >5 tables, mark every migration as applied" path was
+    // the root cause of #72 — it stamped migrations that init.ts never ran
+    // (e.g. 016/017 added after the workspace was set up) as applied without
+    // executing their SQL. All migrations use CREATE TABLE/INDEX IF NOT
+    // EXISTS, so re-running them on a workspace whose tables were created by
+    // init.ts is safe (idempotent) and self-heals the schema_migrations row
+    // set on the first post-fix upgrade.
 
     const result = await pool.query(`SELECT filename FROM nexaas_memory.schema_migrations`);
     applied = new Set(result.rows.map(r => r.filename));

--- a/packages/runtime/src/tasks/_consistency-warning.ts
+++ b/packages/runtime/src/tasks/_consistency-warning.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared helper for surfacing schema-drift errors loudly-once.
+ *
+ * Background — #72: a migration was recorded in `schema_migrations` without
+ * its SQL having actually run, so the inbound-dispatcher silently exception-
+ * logged for ~7 days while every poll cycle threw "relation
+ * inbound_dispatches does not exist". The dispatcher caught the error,
+ * `console.error`'d it, and slept. No WAL signal, no operator-visible
+ * indication that anything was wrong — the only symptom was that 2FA
+ * waitpoints mysteriously timed out.
+ *
+ * This helper:
+ *   - Detects the Postgres "relation does not exist" code (42P01).
+ *   - Emits a `framework_consistency_warning` WAL op exactly once per
+ *     (source, relation) pair per process lifetime so silent failure
+ *     becomes observable without flooding WAL on every poll tick.
+ *   - Returns `true` when the error was a schema-drift error (caller
+ *     should suppress the generic console.error to avoid double-logging).
+ *
+ * The dedup Set resets on worker restart — warnings re-fire on the next
+ * deploy if the underlying drift hasn't been repaired. Operators looking
+ * for stuck dispatchers can grep WAL for `framework_consistency_warning`
+ * (or wire it into the silent-failure watchdog from #69 via
+ * `NEXAAS_SILENT_FAILURE_CHANNEL_ROLE`).
+ */
+
+import { appendWal } from "@nexaas/palace";
+
+const PG_UNDEFINED_TABLE = "42P01";
+
+const _warnedMissingRelations = new Set<string>();
+
+export async function reportMissingRelation(
+  workspace: string,
+  source: string,
+  err: unknown,
+): Promise<boolean> {
+  const e = err as { code?: string; message?: string } | undefined;
+  if (!e || e.code !== PG_UNDEFINED_TABLE) return false;
+  const message = e.message ?? "";
+  const m = message.match(/relation "([^"]+)" does not exist/);
+  const relation = m?.[1] ?? "<unknown>";
+  const key = `${source}:${relation}`;
+  if (_warnedMissingRelations.has(key)) return true;
+  _warnedMissingRelations.add(key);
+  console.error(
+    `[nexaas] ${source}: relation ${relation} does not exist — schema drift, ` +
+    `likely a recorded-but-not-applied migration (see #72). ` +
+    `Re-run \`nexaas upgrade --migrate\` to repair.`,
+  );
+  await appendWal({
+    workspace,
+    op: "framework_consistency_warning",
+    actor: source,
+    payload: {
+      kind: "missing_relation",
+      relation,
+      pg_error_code: PG_UNDEFINED_TABLE,
+      remediation: "nexaas upgrade --migrate",
+    },
+  }).catch(() => { /* WAL itself might be missing — best effort */ });
+  return true;
+}

--- a/packages/runtime/src/tasks/inbound-dispatcher.ts
+++ b/packages/runtime/src/tasks/inbound-dispatcher.ts
@@ -42,6 +42,7 @@ import { load as yamlLoad } from "js-yaml";
 import { sql, appendWal } from "@nexaas/palace";
 import { enqueueSkillStep, type SkillJobData } from "../bullmq/queues.js";
 import { matchDrawerAgainstWaitpoints } from "./inbound-match-waitpoint.js";
+import { reportMissingRelation } from "./_consistency-warning.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 3_000;
 const POLL_BATCH_SIZE = 50;
@@ -297,7 +298,8 @@ export function startInboundDispatcher(
         );
       }
     } catch (err) {
-      console.error("[nexaas] inbound dispatcher error:", err);
+      const handled = await reportMissingRelation(workspace, "inbound-dispatcher", err);
+      if (!handled) console.error("[nexaas] inbound dispatcher error:", err);
     } finally {
       _polling = false;
     }

--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -26,6 +26,7 @@ import { sql, appendWal, palace } from "@nexaas/palace";
 import { McpClient, loadMcpConfigs } from "../mcp/client.js";
 import { loadWorkspaceManifest } from "../schemas/load-manifest.js";
 import type { WorkspaceManifest, ChannelBinding } from "../schemas/workspace-manifest.js";
+import { reportMissingRelation } from "./_consistency-warning.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const MAX_ATTEMPTS = 5;
@@ -373,7 +374,8 @@ export function startNotificationDispatcher(
         );
       }
     } catch (err) {
-      console.error("[nexaas] notification dispatcher error:", err);
+      const handled = await reportMissingRelation(workspace, "notification-dispatcher", err);
+      if (!handled) console.error("[nexaas] notification dispatcher error:", err);
     } finally {
       _polling = false;
     }


### PR DESCRIPTION
Closes #72.

## Root cause (A)

`getPendingMigrations` in `packages/cli/src/upgrade.ts` had a "seed-all" heuristic: when `schema_migrations` was empty AND `nexaas_memory` had more than 5 tables, every migration filename was inserted into `schema_migrations` without running its SQL. The reasoning was "init.ts created the schema directly, so retroactively record everything as applied." That assumption breaks the moment a migration lands *after* a workspace is initialized — the new migration gets stamped as applied without its `CREATE TABLE` ever running.

This is exactly what bit BSBC. Migrations 016 (`notification_dispatches`) and 017 (`inbound_dispatches`) were added to the codebase after the workspace was set up. On the next `nexaas upgrade`, the seed-all path fired and recorded both as applied. The `inbound-dispatcher` then silently exception-logged for ~7 days because the table it joins against didn't exist.

**Evidence on BSBC:**

```
            filename             |          applied_at
---------------------------------+-------------------------------
 000_schema_migrations.sql       | 2026-04-20 17:09:12.158430+00
 ... (15 more migrations) ...
 017_inbound_dispatches.sql      | 2026-04-20 17:09:12.171710+00
 018_inbound_match_waitpoint_index.sql | 2026-04-27 13:30:44.775819+00
```

Migrations 000-017 stamped within 13ms of each other = seed-all loop. Migration 018 a week later = the proper apply loop.

## Fix (A)

Two changes in `packages/cli/src/upgrade.ts`:

1. **Remove the seed-all branch.** Workspaces with currently-empty `schema_migrations` will re-run all migrations on next upgrade. All migrations use `CREATE TABLE / INDEX IF NOT EXISTS` (verified via grep — no `CONCURRENTLY`), so re-running on a workspace whose tables already exist from init.ts is safe and self-heals the `schema_migrations` row set.

2. **Wrap each migration's SQL apply + marker INSERT in a transaction.** If the SQL fails partway, the marker rolls back too. Closes the failure mode where a partial apply could otherwise leave a marker behind.

## Fix (C) — schema-drift detection

Both dispatchers (`inbound-dispatcher`, `notification-dispatcher`) caught their poll errors into `console.error` and slept. No WAL signal. New helper at `packages/runtime/src/tasks/_consistency-warning.ts`:

- Detects Postgres error code `42P01` (relation does not exist).
- Emits a `framework_consistency_warning` WAL op exactly once per `(source, relation)` pair per process lifetime — loud-once, not loud-forever.
- Tells the operator to re-run `nexaas upgrade --migrate`.

The dedup Set resets on worker restart, so warnings re-fire on the next deploy if the underlying drift hasn't been repaired. Plays cleanly with the silent-failure watchdog (#69) when `NEXAAS_SILENT_FAILURE_CHANNEL_ROLE` is bound — schema drift becomes a paged operator alert instead of a multi-day silent gap.

Wired into both dispatchers via the same helper so a future `outbox-relay` or other Postgres-touching subsystem can pick it up trivially.

## What does NOT change

- `init.ts` — unchanged. New workspaces still work identically; the seed-all path only ever fired on existing workspaces with non-empty schemas.
- Migration files, ordering, naming, or storage location — all untouched.
- Existing valid `schema_migrations` rows — preserved. This fix affects future upgrades only.

## What WILL change for adopters

- The next `nexaas upgrade` on a workspace that previously hit the seed-all path will re-run all migrations idempotently. On BSBC this would be ~17 fast `CREATE TABLE IF NOT EXISTS` calls; takes seconds, not minutes.
- Any workspace currently sitting on schema drift (recorded-but-not-applied migration) will see one `framework_consistency_warning` WAL row per affected relation when the worker next polls. Recommend operators sweep `WHERE op = 'framework_consistency_warning'` after deploying this.

## Test plan

- [x] Typecheck passes (`tsc --noEmit -p tsconfig.json` clean)
- [x] Manual repro on BSBC: 016/017 schema drift confirmed, manually re-applied, dispatcher recovered (matches the issue's repro)
- [ ] Post-merge: deploy to BSBC, confirm `nexaas upgrade --migrate` is a no-op now that all migrations are properly recorded + tables exist
- [ ] Post-merge: confirm `framework_consistency_warning` does NOT fire on BSBC (no drift remaining)
- [ ] Phoenix manual verification on next upgrade window — same code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection and reporting of schema inconsistencies to help identify database configuration issues

* **Bug Fixes**
  * Improved database migration execution with per-migration transaction safety
  * Enhanced error handling for schema drift scenarios across system components
  * Added deduplication of consistency warning messages to reduce log noise

<!-- end of auto-generated comment: release notes by coderabbit.ai -->