### PR TITLE
feat(email-outbound): MCP server v0.2 + Resend provider (#78 PR A)

### DIFF
--- a/capabilities/_registry.yaml
+++ b/capabilities/_registry.yaml
@@ -105,19 +105,52 @@ capabilities:
 
   email-outbound:
     stage: experimental
-    interface_version: "0.1"
-    description: Send transactional email
-    implementations: []
+    interface_version: "0.2"
+    description: Send transactional or marketing email
+    implementations: [resend]
+    # Bumped v0.1 → v0.2 for #78 (Email Autopilot). v0.1 had a single-recipient
+    # `to: string` and a flat `from: string`; v0.2 supports multi-recipient,
+    # structured sender (display-name), reply_to, custom headers, provider-side
+    # tracking flags, and per-recipient delivery outcome. Zero v0.1 implementations
+    # existed at the time of bump, so this is a free re-spec, not a migration.
     tools:
       - name: send
         input:
-          to: "string"
-          from: "string"
+          from:
+            email: "string"                # sender address
+            name: "string?"                # display name — provider may render as "Name <email>"
+          reply_to: "string?"              # sets the Reply-To header
+          to: "string | string[]"          # one or many; provider splits into separate sends if needed
           subject: "string"
-          html: "string?"
-          text: "string?"
-          attachments: "attachment[]?"   # attachment := { filename: string, content_base64: string }
-        output: { message_id: "string", status: "string" }
+          body_text: "string"              # required for deliverability — providers reject html-only
+          body_html: "string?"
+          headers: "{ [k: string]: string }?"   # custom headers; provider may reject reserved ones (List-Unsubscribe etc are fine)
+          tracking:
+            opens: "boolean?"              # opt-in tracking; default is provider's default
+            clicks: "boolean?"
+          tags: "string[]?"                # provider-side analytics tag (Resend tags, SendGrid categories, etc.)
+          attachments: "attachment[]?"     # attachment := { filename: string, content_base64: string }
+        output:
+          message_id: "string"             # provider's native id; opaque to skills, used by `track`
+          accepted: "string[]"              # recipients accepted by the provider for delivery
+          rejected:                        # zero entries = all accepted
+            - email: "string"
+              reason: "string"
+
+      - name: track
+        # Fetch delivery / engagement state for a previously-sent message.
+        # Implementations may return partial data — provider tracking is
+        # eventually-consistent (webhook-driven on most platforms). Skills
+        # should treat absent fields as "not yet known", not "did not happen".
+        input:
+          message_id: "string"             # from a prior send response
+        output:
+          message_id: "string"
+          status: "string"                 # queued | sent | delivered | bounced | complained | unknown
+          delivered_at: "string?"          # ISO; absent until provider confirms
+          opened: "{ count: number, last_at: string? }?"
+          clicked: "{ count: number, last_at: string? }?"
+          bounced: "{ at: string, type: string, reason: string? }?"
 
   messaging-inbound:
     stage: experimental

--- a/capabilities/_registry.yaml
+++ b/capabilities/_registry.yaml
@@ -146,7 +146,7 @@ capabilities:
           message_id: "string"             # from a prior send response
         output:
           message_id: "string"
-          status: "string"                 # queued | sent | delivered | bounced | complained | unknown
+          status: "queued | sent | delivered | bounced | complained | unknown"
           delivered_at: "string?"          # ISO; absent until provider confirms
           opened: "{ count: number, last_at: string? }?"
           clicked: "{ count: number, last_at: string? }?"

--- a/mcp/servers/email-outbound/README.md
+++ b/mcp/servers/email-outbound/README.md
@@ -1,0 +1,108 @@
+# `@nexaas/mcp-email-outbound`
+
+MCP server implementing the **email-outbound** capability (capabilities/_registry.yaml v0.2).
+
+Filed against issue #78 (Nexmatic Email Autopilot). Ships with **Resend** today; Postmark, SendGrid, and AWS SES follow in a separate PR.
+
+## Wiring into a skill
+
+In the skill's `skill.yaml`:
+
+```yaml
+mcp_servers:
+  - email-outbound
+```
+
+In the workspace's `.mcp.json`:
+
+```json
+{
+  "email-outbound": {
+    "command": "node",
+    "args": ["/opt/nexaas/mcp/servers/email-outbound/src/index.ts"],
+    "env": {
+      "RESEND_API_KEY": "${env:RESEND_API_KEY}"
+    }
+  }
+}
+```
+
+The skill agentic loop now sees `send` and `track` tools.
+
+## Provider selection
+
+Order of resolution at server start:
+
+1. **`EMAIL_OUTBOUND_PROVIDER`** env var — explicit pin (`resend`, future: `postmark` | `sendgrid` | `aws_ses`).
+2. **Auto-detect** — first known provider key wins. Today: `RESEND_API_KEY`.
+
+The chosen provider name is logged on stderr at startup and surfaces in every tool response as `provider:`.
+
+`workspace_kv.email_outbound_provider` is reserved for a future per-workspace override; not honored in PR A because the MCP runs as its own subprocess without a palace session in scope. Operators wanting per-workspace pinning today should set the env var in `.env`.
+
+## Adding a provider
+
+1. Implement `EmailProvider` in `src/providers/<name>.ts`.
+2. Add the env-key probe in `src/provider-select.ts`.
+3. Update this README's "Provider selection" section.
+4. Bump `implementations:` in `capabilities/_registry.yaml`.
+
+The `EmailProvider` interface (in `src/types.ts`) is the contract. Providers translate framework-canonical send/track shapes to whatever their underlying API expects, then translate the response back. Skills never see provider-specific shapes.
+
+## Tool reference
+
+### `send`
+
+```json
+{
+  "from": { "email": "ops@bsbc.test", "name": "BSBC Ops" },
+  "reply_to": "noreply@bsbc.test",
+  "to": ["a@example.com", "b@example.com"],
+  "subject": "Hello",
+  "body_text": "Plain-text body — required for deliverability.",
+  "body_html": "<p>Optional HTML.</p>",
+  "headers": { "List-Unsubscribe": "<mailto:unsub@bsbc.test>" },
+  "tracking": { "opens": true, "clicks": true },
+  "tags": ["welcome-sequence"]
+}
+```
+
+Returns:
+
+```json
+{
+  "ok": true,
+  "provider": "resend",
+  "message_id": "01HZ...",
+  "accepted": ["a@example.com", "b@example.com"],
+  "rejected": []
+}
+```
+
+### `track`
+
+```json
+{ "message_id": "01HZ..." }
+```
+
+Returns:
+
+```json
+{
+  "ok": true,
+  "provider": "resend",
+  "message_id": "01HZ...",
+  "status": "delivered",
+  "delivered_at": "2026-05-01T14:22:14Z"
+}
+```
+
+`opened` / `clicked` counts come via webhook on most providers and aren't exposed by the synchronous track endpoint. Skills needing precise engagement counts should subscribe to a webhook drawer; the MCP's `track` returns last-known synchronous state only.
+
+## Provider notes
+
+### Resend
+
+- Tracking flags (`tracking.opens` / `tracking.clicks`) are configured at the API-key / domain level in the Resend dashboard. Per-message toggles are accepted by this MCP for cross-provider symmetry but **no-op** for Resend — flip the dashboard toggles instead.
+- `track` uses `GET /emails/:id` for last-known state. Open/click counts require webhook ingestion (out of scope for PR A).
+- Per-recipient rejection isn't returned by Resend's `POST /emails`. On error, all recipients are reported as `rejected` with the provider's error message as the reason.

--- a/mcp/servers/email-outbound/package-lock.json
+++ b/mcp/servers/email-outbound/package-lock.json
@@ -1,0 +1,1174 @@
+{
+  "name": "@nexaas/mcp-email-outbound",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nexaas/mcp-email-outbound",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@nexaas/mcp-email-outbound",
+  "version": "0.1.0",
+  "description": "Outbound email MCP server — implements the email-outbound capability (#78). Provider-pluggable; ships with Resend.",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/mcp/servers/email-outbound/src/index.ts
+++ b/mcp/servers/email-outbound/src/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Nexaas Email-Outbound MCP Server (#78 PR A).
+ *
+ * Implements the `email-outbound` capability defined in
+ * capabilities/_registry.yaml. Skills declaring `mcp_servers: [email-outbound]`
+ * receive `send` and `track` tools for transactional and marketing email.
+ *
+ * Provider-pluggable. PR A ships with Resend; Postmark, SendGrid, AWS SES
+ * follow in a separate PR (issue #78 step 2). All providers conform to the
+ * EmailProvider interface in `types.ts`, so the MCP entry point stays
+ * provider-agnostic — selection happens once at server start (see
+ * `provider-select.ts`) and is logged on stderr.
+ *
+ * Transport: stdio. Wire into a workspace's `.mcp.json` and reference by
+ * name from a skill manifest's `mcp_servers` array.
+ *
+ * Environment:
+ *   RESEND_API_KEY                 — Resend bearer token (PR A)
+ *   EMAIL_OUTBOUND_PROVIDER        — pin a specific provider (optional)
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { selectProvider } from "./provider-select.js";
+
+const selected = selectProvider();
+console.error(`[email-outbound] provider=${selected.name} (${selected.reason})`);
+
+const server = new McpServer({
+  name: "nexaas-email-outbound",
+  version: "0.1.0",
+});
+
+function jsonResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+const sendSchema = {
+  from: z.object({
+    email: z.string().email(),
+    name: z.string().optional(),
+  }).describe("Sender address. `name` becomes the display-name in the From header."),
+  reply_to: z.string().email().optional().describe("Sets the Reply-To header. Optional."),
+  to: z.union([z.string().email(), z.array(z.string().email()).min(1)])
+    .describe("One recipient or many. Provider splits into separate sends if needed."),
+  subject: z.string().min(1).describe("Subject line."),
+  body_text: z.string().min(1).describe(
+    "Plain-text body. Required for deliverability — providers reject html-only sends.",
+  ),
+  body_html: z.string().optional().describe("Optional HTML body."),
+  headers: z.record(z.string()).optional().describe(
+    "Custom headers (e.g., List-Unsubscribe). Provider may reject reserved ones.",
+  ),
+  tracking: z.object({
+    opens: z.boolean().optional(),
+    clicks: z.boolean().optional(),
+  }).optional().describe(
+    "Provider-side tracking flags. Some providers configure this at the domain/key level " +
+    "(Resend) and ignore per-message toggles — see provider docs.",
+  ),
+  tags: z.array(z.string()).optional().describe(
+    "Provider-side analytics labels (Resend tags, SendGrid categories, etc.).",
+  ),
+  attachments: z.array(z.object({
+    filename: z.string(),
+    content_base64: z.string(),
+  })).optional(),
+};
+
+server.tool(
+  "send",
+  "Send a transactional or marketing email through the workspace's configured provider. " +
+  "Returns a `message_id` you can pass to `track` later. Per-recipient rejection (if any) " +
+  "is in the `rejected` array; an empty array means the provider accepted all recipients.",
+  sendSchema,
+  async (input) => {
+    try {
+      const result = await selected.provider.send(input);
+      return jsonResult({ ok: true, provider: selected.name, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return jsonResult({ ok: false, provider: selected.name, error: message });
+    }
+  },
+);
+
+server.tool(
+  "track",
+  "Fetch delivery / engagement state for a previously-sent message. Open and click counts " +
+  "are eventually-consistent (webhook-driven on most providers); absent fields mean " +
+  "'not yet known', not 'did not happen'.",
+  {
+    message_id: z.string().min(1).describe("From a prior send response."),
+  },
+  async (input) => {
+    try {
+      const result = await selected.provider.track(input.message_id);
+      return jsonResult({ ok: true, provider: selected.name, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return jsonResult({ ok: false, provider: selected.name, error: message });
+    }
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/servers/email-outbound/src/index.ts
+++ b/mcp/servers/email-outbound/src/index.ts
@@ -71,8 +71,8 @@ const sendSchema = {
 server.tool(
   "send",
   "Send a transactional or marketing email through the workspace's configured provider. " +
-  "Returns a `message_id` you can pass to `track` later. Per-recipient rejection (if any) " +
-  "is in the `rejected` array; an empty array means the provider accepted all recipients.",
+  "Returns `message_id` (omitted when *all* recipients were rejected — guard before passing to `track`), " +
+  "`accepted` (recipients the provider took), and `rejected` (per-recipient failures with reason).",
   sendSchema,
   async (input) => {
     try {

--- a/mcp/servers/email-outbound/src/provider-select.ts
+++ b/mcp/servers/email-outbound/src/provider-select.ts
@@ -1,0 +1,53 @@
+/**
+ * Provider selection — env-driven with optional workspace override.
+ *
+ * Order of resolution:
+ *   1. `EMAIL_OUTBOUND_PROVIDER` env var — explicit operator pin
+ *   2. `workspace_kv.email_outbound_provider` — runtime override per workspace
+ *      (deferred to a follow-up: the MCP runs as its own process and doesn't
+ *      have a palace session in scope; for now operators set the env var)
+ *   3. First provider whose API key env is present — auto-detect
+ *
+ * Returns the provider instance, the provider name (for WAL / logs), and
+ * the reason the provider was picked.
+ */
+
+import type { EmailProvider } from "./types.js";
+import { ResendProvider } from "./providers/resend.js";
+
+export interface SelectedProvider {
+  provider: EmailProvider;
+  name: string;
+  reason: "env_pin" | "auto_detect";
+}
+
+export function selectProvider(): SelectedProvider {
+  const explicitName = (process.env.EMAIL_OUTBOUND_PROVIDER ?? "").toLowerCase();
+  const resendKey = process.env.RESEND_API_KEY;
+
+  if (explicitName === "resend") {
+    if (!resendKey) {
+      throw new Error("EMAIL_OUTBOUND_PROVIDER=resend but RESEND_API_KEY is unset");
+    }
+    return { provider: new ResendProvider(resendKey), name: "resend", reason: "env_pin" };
+  }
+
+  if (explicitName) {
+    throw new Error(
+      `EMAIL_OUTBOUND_PROVIDER=${explicitName} not yet supported by this build. ` +
+      `Available: resend. Postmark, SendGrid, AWS SES are tracked in #78 follow-up PR B.`,
+    );
+  }
+
+  // Auto-detect — first key wins. Resend is the only implementation today;
+  // additional providers will be probed in a stable order documented in the
+  // server README so behavior is predictable when multiple keys are present.
+  if (resendKey) {
+    return { provider: new ResendProvider(resendKey), name: "resend", reason: "auto_detect" };
+  }
+
+  throw new Error(
+    "No email-outbound provider configured. Set RESEND_API_KEY (or set EMAIL_OUTBOUND_PROVIDER " +
+    "and the matching key) in the workspace .env. See #78.",
+  );
+}

--- a/mcp/servers/email-outbound/src/providers/resend.ts
+++ b/mcp/servers/email-outbound/src/providers/resend.ts
@@ -134,10 +134,10 @@ export class ResendProvider implements EmailProvider {
     if (!res.ok) {
       // Resend bundles all rejections into a single error — we surface as
       // "all recipients rejected with the provider message" since per-
-      // recipient rejection is not in the API response.
+      // recipient rejection is not in the API response. `message_id` is
+      // omitted (undefined) — there is no message to track. PR #79 review.
       const reason = parsed.message ?? `HTTP ${res.status}`;
       return {
-        message_id: "",
         accepted: [],
         rejected: recipients.map((email) => ({ email, reason })),
       };

--- a/mcp/servers/email-outbound/src/providers/resend.ts
+++ b/mcp/servers/email-outbound/src/providers/resend.ts
@@ -1,0 +1,193 @@
+/**
+ * Resend provider plugin.
+ *
+ * Resend's HTTP API is small enough that a fetch-based client is simpler
+ * than pulling in their SDK. Two endpoints used:
+ *
+ *   POST https://api.resend.com/emails        — send a single email
+ *   GET  https://api.resend.com/emails/:id    — fetch state for tracking
+ *
+ * Auth: bearer `RESEND_API_KEY`.
+ *
+ * Tracking: Resend tracks opens/clicks server-side when toggles are passed.
+ * The GET endpoint returns last-known status but engagement counts come
+ * via webhooks — we surface what the email-fetch endpoint exposes
+ * (`last_event` / `created_at` / `delivered_at`) and leave count granularity
+ * to a future webhook-receiver task. This keeps the framework-side
+ * implementation stateless; skills that need precise open/click counts
+ * should listen to the webhook drawer and aggregate themselves.
+ */
+
+import type { EmailProvider, SendInput, SendOutput, TrackOutput } from "../types.js";
+
+const RESEND_API = "https://api.resend.com";
+const SEND_TIMEOUT_MS = 10_000;
+const TRACK_TIMEOUT_MS = 5_000;
+
+interface ResendSendResponse {
+  id?: string;
+  // Resend's error envelope
+  name?: string;
+  message?: string;
+  statusCode?: number;
+}
+
+interface ResendEmailLookup {
+  id: string;
+  created_at?: string;
+  // last_event values: queued | sent | delivered | delivery_delayed |
+  // bounced | complained | failed
+  last_event?: string;
+  // delivered_at present once the provider confirms delivery
+  delivered_at?: string;
+  // bounce details when last_event = bounced
+  bounced_at?: string;
+  bounce?: { type?: string; message?: string };
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+function formatFrom(input: SendInput["from"]): string {
+  return input.name ? `${input.name} <${input.email}>` : input.email;
+}
+
+function asArray<T>(v: T | T[]): T[] {
+  return Array.isArray(v) ? v : [v];
+}
+
+function normalizeStatus(lastEvent?: string): TrackOutput["status"] {
+  switch (lastEvent) {
+    case "queued":
+    case "sent":
+    case "delivered":
+    case "bounced":
+    case "complained":
+      return lastEvent;
+    case "delivery_delayed":
+    case "failed":
+      return "bounced";
+    default:
+      return "unknown";
+  }
+}
+
+export class ResendProvider implements EmailProvider {
+  readonly name = "resend";
+
+  constructor(private readonly apiKey: string) {
+    if (!apiKey) throw new Error("RESEND_API_KEY required");
+  }
+
+  async send(input: SendInput): Promise<SendOutput> {
+    const recipients = asArray(input.to);
+
+    const body: Record<string, unknown> = {
+      from: formatFrom(input.from),
+      to: recipients,
+      subject: input.subject,
+      text: input.body_text,
+    };
+    if (input.body_html) body.html = input.body_html;
+    if (input.reply_to) body.reply_to = input.reply_to;
+    if (input.headers && Object.keys(input.headers).length > 0) body.headers = input.headers;
+    if (input.tags && input.tags.length > 0) {
+      body.tags = input.tags.map((name) => ({ name }));
+    }
+    if (input.attachments && input.attachments.length > 0) {
+      body.attachments = input.attachments.map((a) => ({
+        filename: a.filename,
+        content: a.content_base64,
+      }));
+    }
+    // Resend doesn't accept per-message tracking toggles — opens & clicks
+    // are configured at the API-key / domain level. We accept the fields
+    // for cross-provider symmetry but no-op them here. Documented in the
+    // server README so adopters know to flip toggles in the Resend dashboard.
+
+    const res = await withTimeout(
+      fetch(`${RESEND_API}/emails`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+      SEND_TIMEOUT_MS,
+      "Resend send",
+    );
+
+    let parsed: ResendSendResponse;
+    try {
+      parsed = await res.json() as ResendSendResponse;
+    } catch {
+      throw new Error(`Resend returned non-JSON response (HTTP ${res.status})`);
+    }
+
+    if (!res.ok) {
+      // Resend bundles all rejections into a single error — we surface as
+      // "all recipients rejected with the provider message" since per-
+      // recipient rejection is not in the API response.
+      const reason = parsed.message ?? `HTTP ${res.status}`;
+      return {
+        message_id: "",
+        accepted: [],
+        rejected: recipients.map((email) => ({ email, reason })),
+      };
+    }
+
+    if (!parsed.id) {
+      throw new Error("Resend response missing id");
+    }
+
+    return {
+      message_id: parsed.id,
+      accepted: recipients,
+      rejected: [],
+    };
+  }
+
+  async track(messageId: string): Promise<TrackOutput> {
+    const res = await withTimeout(
+      fetch(`${RESEND_API}/emails/${encodeURIComponent(messageId)}`, {
+        headers: { "Authorization": `Bearer ${this.apiKey}` },
+      }),
+      TRACK_TIMEOUT_MS,
+      "Resend track",
+    );
+
+    if (res.status === 404) {
+      return { message_id: messageId, status: "unknown" };
+    }
+    if (!res.ok) {
+      throw new Error(`Resend track HTTP ${res.status}`);
+    }
+
+    const data = await res.json() as ResendEmailLookup;
+    const status = normalizeStatus(data.last_event);
+
+    const out: TrackOutput = {
+      message_id: messageId,
+      status,
+    };
+    if (data.delivered_at) out.delivered_at = data.delivered_at;
+    if (status === "bounced" && data.bounced_at) {
+      out.bounced = {
+        at: data.bounced_at,
+        type: data.bounce?.type ?? "unknown",
+        reason: data.bounce?.message,
+      };
+    }
+    // Open / click counts are webhook-delivered; not exposed by GET /emails/:id.
+    // Leave `opened` / `clicked` undefined to signal "not yet known" per the
+    // capability spec contract.
+    return out;
+  }
+}

--- a/mcp/servers/email-outbound/src/types.ts
+++ b/mcp/servers/email-outbound/src/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared types between the MCP entry point and provider plugins.
+ *
+ * Mirrors the email-outbound capability v0.2 spec in
+ * capabilities/_registry.yaml. The MCP entry point validates input via zod
+ * before handing off to a provider; the provider's job is to translate
+ * these framework-canonical fields into whatever the underlying API
+ * expects, then translate the response back into the canonical output
+ * shape. Skills never see provider-specific shapes.
+ */
+
+export interface SendInput {
+  from: { email: string; name?: string };
+  reply_to?: string;
+  to: string | string[];
+  subject: string;
+  body_text: string;
+  body_html?: string;
+  headers?: Record<string, string>;
+  tracking?: { opens?: boolean; clicks?: boolean };
+  tags?: string[];
+  attachments?: Array<{ filename: string; content_base64: string }>;
+}
+
+export interface SendOutput {
+  message_id: string;
+  accepted: string[];
+  rejected: Array<{ email: string; reason: string }>;
+}
+
+export interface TrackOutput {
+  message_id: string;
+  status: "queued" | "sent" | "delivered" | "bounced" | "complained" | "unknown";
+  delivered_at?: string;
+  opened?: { count: number; last_at?: string };
+  clicked?: { count: number; last_at?: string };
+  bounced?: { at: string; type: string; reason?: string };
+}
+
+export interface EmailProvider {
+  /** Stable identifier — `resend`, `postmark`, `sendgrid`, `aws_ses`. Surfaces in WAL & logs. */
+  readonly name: string;
+
+  send(input: SendInput): Promise<SendOutput>;
+
+  track(messageId: string): Promise<TrackOutput>;
+}

--- a/mcp/servers/email-outbound/src/types.ts
+++ b/mcp/servers/email-outbound/src/types.ts
@@ -23,7 +23,12 @@ export interface SendInput {
 }
 
 export interface SendOutput {
-  message_id: string;
+  /**
+   * Provider's native id for the accepted message. Undefined when *all*
+   * recipients were rejected (no message exists to track). Skills should
+   * guard before passing to `track`. PR #79 review.
+   */
+  message_id?: string;
   accepted: string[];
   rejected: Array<{ email: string; reason: string }>;
 }

--- a/mcp/servers/email-outbound/tsconfig.json
+++ b/mcp/servers/email-outbound/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
First of three PRs against #78 (Nexmatic Email Autopilot). PR A ships the **`email-outbound` MCP server with Resend support** — enough to unblock the dashboard's "Delivery pending setup" badge on any workspace with `RESEND_API_KEY`.

## What lands

### Capability v0.2

`capabilities/_registry.yaml` `email-outbound` bumped from v0.1 → v0.2. v0.1 was minimal — single recipient, flat `from`, no tracking or reply-to. v0.2 adds:

- `from: { email, name? }` for display-name rendering
- `reply_to` for the Reply-To header
- `to: string | string[]` multi-recipient
- `body_text` + `body_html` split (text required for deliverability)
- `headers` for custom headers like List-Unsubscribe
- `tracking: { opens?, clicks? }` flags
- `tags` for provider-side analytics labels
- structured `rejected: [{ email, reason }]` per-recipient outcome
- new `track` tool for synchronous delivery state

Zero v0.1 implementations existed at bump time, so this is a free re-spec, not a migration.

### MCP server at `mcp/servers/email-outbound/`

```
src/
├── index.ts            # MCP entry; registers `send` + `track` with zod
├── types.ts            # EmailProvider interface; canonical shapes
├── provider-select.ts  # env-driven provider resolution
└── providers/
    └── resend.ts       # Resend HTTP client (no SDK dep)
README.md               # wiring guide + per-provider notes
```

**Provider selection** (resolved at server start, logged on stderr):

1. `EMAIL_OUTBOUND_PROVIDER` env var — explicit operator pin
2. Auto-detect — first known API key wins (today: `RESEND_API_KEY`)

The `EmailProvider` interface in `types.ts` is the contract. Each provider translates framework-canonical fields to its native API and back. Skills never see provider-specific shapes. Adding a new provider is: implement the interface, wire it into `provider-select.ts`, bump `implementations:` in the registry.

### Wiring example

Skill `skill.yaml`:

```yaml
mcp_servers:
  - email-outbound
```

Workspace `.mcp.json`:

```json
{
  "email-outbound": {
    "command": "node",
    "args": ["/opt/nexaas/mcp/servers/email-outbound/src/index.ts"],
    "env": { "RESEND_API_KEY": "${env:RESEND_API_KEY}" }
  }
}
```

Skill agentic loop now has `send` and `track` tools.

## Resend implementation notes

- Uses HTTP API directly (POST `/emails`, GET `/emails/:id`) — no SDK dependency. Smaller surface area to keep in sync with their release cadence.
- Tracking flags are configured at the API-key / domain level in Resend's dashboard, not per-message. The MCP accepts `tracking.opens` / `tracking.clicks` for cross-provider symmetry but **no-ops them for Resend**. Documented in the server README.
- `track` returns synchronous last-known state from `GET /emails/:id`. Open/click counts arrive via webhooks; skills needing precise engagement should subscribe to a webhook drawer.
- Per-recipient rejection isn't surfaced by Resend's `POST /emails`. On HTTP error all recipients are reported as `rejected` with the provider's error message as the reason; on success all are reported as `accepted`.

## What's NOT in this PR (and why)

- **Postmark / SendGrid / AWS SES providers** — separate PR (#78 step 2). Same provider plugin pattern. Decoupled so PR A can land fast and unblock Email Autopilot smoke tests; the provider extension is mechanical.
- **`scheduled-drawer` trigger type** — separate PR (#78 step 3). New framework primitive that also unblocks the Phoenix HR welcome-from-seb T+1h pattern called out in #65. Wider scope than email; deserves its own design pass.
- **`workspace_kv.email_outbound_provider`** per-workspace runtime override — the MCP runs as its own stdio subprocess without a palace session in scope. Operators wanting per-workspace pinning today should set the env var. Documented in the server README as a deferred follow-up.
- **Webhook ingestion** for engagement events — workspace-side concern, orthogonal to the framework primitive.

## Test plan

- [x] `tsc --noEmit` clean against the new MCP package's tsconfig
- [x] Capability registry parses (yaml syntax check)
- [ ] Manual smoke test on BSBC: wire the MCP into a synthetic skill, fire a send to a test inbox, confirm `accepted: [...]`, then call `track` with the returned `message_id` and confirm `status: "delivered"` (post-merge, after Nexmatic's dashboard wiring lands)
- [ ] Phoenix smoke once a Phoenix workspace has Email Autopilot turned on (Nexmatic add-on rollout)

## Issue thread

Posting on #78 noting PR A is up + linking to PR B/C scope so the issue tracks the staging plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email capability upgraded to v0.2: now supports transactional and marketing emails with multi-recipient sending.
  * Added message tracking tool to retrieve delivery status and engagement metrics.
  * Enhanced send options: structured sender info, reply-to address, headers, tags, and provider tracking flags.
  * Resend provider implementation available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->