### PR TITLE
feat(inbound-match): room_match_mode for glob / regex room_pattern (#74)

### DIFF
--- a/packages/runtime/src/ai-skill-framework-tools.ts
+++ b/packages/runtime/src/ai-skill-framework-tools.ts
@@ -116,7 +116,12 @@ export function buildFrameworkTools(manifest: AiSkillManifest): McpTool[] {
       properties: {
         channel_role: {
           type: "string",
-          description: "Framework channel_role to watch — the inbox.messaging.<role> room adapter writes to. Must be declared in workspace manifest's channel_bindings.",
+          description: "Framework channel_role to watch — the inbox.messaging.<role> room adapter writes to. Must be declared in workspace manifest's channel_bindings. Interpreted per `room_match_mode` (exact by default).",
+        },
+        room_match_mode: {
+          type: "string",
+          enum: ["exact", "glob", "regex"],
+          description: "How to match `channel_role` against the drawer's room name. `exact` (default) compares literally. `glob` allows `*` (one segment, no dots) and `?` (one char) — useful for sub-namespaced rooms like `dashboard.*` matching `dashboard.al-nexmatic-ca`. `regex` is full regex with the same backtracking guard as content_regex; use `.*` to span dots. The `*` channel_role sentinel always matches any room regardless of this flag.",
         },
         content_pattern: {
           type: "string",
@@ -290,10 +295,17 @@ async function requestMatch(
 
   // Pass-through params to registerWaitpoint, letting its own validation
   // handle named-vs-raw-vs-missing decisions.
+  const roomMatchMode = (() => {
+    const raw = input.room_match_mode;
+    if (raw === "exact" || raw === "glob" || raw === "regex") return raw;
+    return undefined;  // registerWaitpoint defaults to exact
+  })();
+
   const reg = await registerWaitpoint({
     workspace: ctx.workspace,
     match: {
       room_pattern: channelRole,
+      room_match_mode: roomMatchMode,
       content_pattern: input.content_pattern as string | undefined,
       content_regex: input.content_regex as string | undefined,
       raw: input.raw === true,

--- a/packages/runtime/src/tasks/inbound-match-waitpoint.ts
+++ b/packages/runtime/src/tasks/inbound-match-waitpoint.ts
@@ -36,11 +36,22 @@ const NAMED_PATTERNS: Record<string, string> = {
 
 export type ExtractMode = "first_regex_match" | "first_capture_group" | "full_content";
 
+export type RoomMatchMode = "exact" | "glob" | "regex";
+
 export interface RegisterParams {
   workspace: string;
   match: {
-    /** `inbox.messaging.<room_pattern>` — use exact role or `*` for any. */
+    /**
+     * Room scope. `*` matches any inbox.messaging.* drawer. Otherwise
+     * interpreted per `room_match_mode`:
+     *   - `exact` (default) — literal string compare
+     *   - `glob` — `*` matches one path segment (no dots), `?` matches one char.
+     *   - `regex` — full regex, validated through the same backtracking guard
+     *     as `content_regex`.
+     */
     room_pattern?: string;
+    /** How to interpret `room_pattern` when not `*`. Default `exact` for back-compat. See #74. */
+    room_match_mode?: RoomMatchMode;
     /** Named pattern key, or omit in favor of `content_regex`. */
     content_pattern?: keyof typeof NAMED_PATTERNS | string;
     /** Raw regex — requires `raw: true`. */
@@ -110,6 +121,23 @@ const WAITPOINT_ROOM = { wing: "waitpoints", hall: "inbound_match", room: "activ
  * named patterns. Sufficient to keep typos and copy-pastes from wedging
  * the event loop.
  */
+/**
+ * Compile a glob to an anchored regex (#74). Conventions:
+ *   `*` → `[^.]*` (one path segment — does not cross dots)
+ *   `?` → `.`     (one character)
+ *   everything else regex-escaped literal
+ *
+ * Segment-bounded `*` is the more useful default for hierarchical room
+ * names like `dashboard.al-nexmatic-ca` — `dashboard.*` matches that
+ * room without sweeping `dashboard.foo.bar`. Adopters that want
+ * "match across dots" should use `room_match_mode: regex` with `.*`.
+ */
+function compileGlob(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const re = escaped.replace(/\*/g, "[^.]*").replace(/\?/g, ".");
+  return new RegExp(`^${re}$`);
+}
+
 function validateRawRegex(pattern: string): { ok: true } | { ok: false; reason: string } {
   if (pattern.length > MAX_RAW_REGEX_LENGTH) {
     return { ok: false, reason: `pattern too long (max ${MAX_RAW_REGEX_LENGTH} chars)` };
@@ -163,6 +191,25 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
   const resolved = resolvePattern(params.match);
   if ("error" in resolved) return { error: resolved.error };
 
+  // Validate room_match_mode + room_pattern combo at registration time so
+  // operators get an immediate error instead of a silent never-match (#74).
+  // The `*` sentinel always means "any room" regardless of mode.
+  const roomPattern = params.match.room_pattern ?? "*";
+  const roomMatchMode: RoomMatchMode = params.match.room_match_mode ?? "exact";
+  if (roomMatchMode !== "exact" && roomMatchMode !== "glob" && roomMatchMode !== "regex") {
+    return { error: `room_match_mode must be one of: exact, glob, regex (got '${roomMatchMode}')` };
+  }
+  if (roomPattern !== "*" && roomMatchMode === "regex") {
+    const check = validateRawRegex(roomPattern);
+    if (!check.ok) return { error: `room_pattern regex rejected: ${check.reason}` };
+    try { new RegExp(`^${roomPattern}$`); }
+    catch (err) { return { error: `room_pattern regex invalid: ${(err as Error).message}` }; }
+  }
+  if (roomPattern !== "*" && roomMatchMode === "glob") {
+    try { compileGlob(roomPattern); }
+    catch (err) { return { error: `room_pattern glob invalid: ${(err as Error).message}` }; }
+  }
+
   const timeoutSec = Math.min(
     MAX_TIMEOUT_SECONDS,
     Math.max(1, params.timeout_seconds ?? DEFAULT_TIMEOUT_SECONDS),
@@ -185,7 +232,8 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
     state: {
       waitpoint_id: waitpointId,
       match: {
-        room_pattern: params.match.room_pattern ?? "*",
+        room_pattern: roomPattern,
+        room_match_mode: roomMatchMode,
         content_pattern: params.match.content_pattern,
         content_regex: params.match.content_regex,
         raw: params.match.raw === true,
@@ -206,7 +254,8 @@ export async function registerWaitpoint(params: RegisterParams): Promise<Registe
     actor: "inbound-match-waitpoint",
     payload: {
       waitpoint_id: waitpointId,
-      room_pattern: params.match.room_pattern ?? "*",
+      room_pattern: roomPattern,
+      room_match_mode: roomMatchMode === "exact" ? undefined : roomMatchMode,
       content_pattern: params.match.content_pattern,
       content_regex_raw: params.match.raw === true,
       sender_id: params.match.sender_id,
@@ -366,9 +415,31 @@ export async function matchDrawerAgainstWaitpoints(
     const match = state.match as Record<string, unknown> | undefined;
     if (!match) continue;
 
-    // Room scope check. `*` or missing matches any inbox.messaging.* room.
+    // Room scope check (#74). `*` or missing matches any inbox.messaging.*
+    // room regardless of mode. Otherwise interpret per `room_match_mode`:
+    //   exact (default) — literal string compare
+    //   glob            — segment-bounded `*` / single-char `?`
+    //   regex           — full regex (validated at registration)
     const roomPattern = typeof match.room_pattern === "string" ? match.room_pattern : "*";
-    if (roomPattern !== "*" && roomPattern !== drawer.room) continue;
+    const roomMatchMode = (typeof match.room_match_mode === "string" ? match.room_match_mode : "exact") as RoomMatchMode;
+    if (roomPattern !== "*") {
+      let roomMatched = false;
+      try {
+        if (roomMatchMode === "exact") {
+          roomMatched = roomPattern === drawer.room;
+        } else if (roomMatchMode === "glob") {
+          roomMatched = compileGlob(roomPattern).test(drawer.room);
+        } else if (roomMatchMode === "regex") {
+          roomMatched = new RegExp(`^${roomPattern}$`).test(drawer.room);
+        }
+      } catch {
+        // Compile failed at match time — registration validated this, so a
+        // failure here implies state corruption. Skip the waitpoint to keep
+        // matching other open ones.
+        continue;
+      }
+      if (!roomMatched) continue;
+    }
 
     // Sender scope check.
     if (typeof match.sender_id === "string" && match.sender_id && drawerFrom !== match.sender_id) continue;


### PR DESCRIPTION
Closes #74. Implements `room_match_mode` per Al's spec in the issue body.

## What lands

Optional `room_match_mode: "exact" | "glob" | "regex"` on the inbound-match-waitpoint registration `match` block. Default `"exact"` — pure additive, zero behavior change for existing callers.

```yaml
match:
  room_pattern: "dashboard.*"     # any dashboard sub-namespace
  room_match_mode: "glob"
```

## Files

- `packages/runtime/src/tasks/inbound-match-waitpoint.ts` — new `RoomMatchMode` type, `compileGlob` helper, registration-time validation per mode, match-time evaluation in `matchDrawerAgainstWaitpoints`. Persisted in waitpoint state and surfaced in the `inbound_match_waitpoint_registered` WAL payload (omitted when `exact` to keep payloads compact).
- `packages/runtime/src/ai-skill-framework-tools.ts` — `framework__request_match` tool gains `room_match_mode` in its input_schema and passes through to `registerWaitpoint`. Description spells out the glob convention so AI skills don't have to spelunk source.

## Glob convention

`*` → `[^.]*` (one path segment — does not cross dots), `?` → `.`. Chosen because hierarchical room names like `dashboard.<sanitized-email>` benefit from segment-bounded matching:

- `dashboard.*` matches `dashboard.al-nexmatic-ca` ✓
- `dashboard.*` does **not** match `dashboard.foo.bar` ✗ — use `room_match_mode: "regex"` with `.*` if you need cross-dot wildcards.

## Validation

At registration:

- Unknown mode → error (`exact, glob, regex (got 'X')`).
- `glob` + bad pattern → compile error.
- `regex` + pattern that fails `validateRawRegex` (the existing nested-quantifier guard used for `content_regex`) → rejected with reason.
- `regex` + pattern that's not a valid `RegExp` → error.

Operators get an immediate registration error instead of the silent never-match that motivated #74.

## Match-time

`matchDrawerAgainstWaitpoints` reads `match.room_match_mode` from persisted state, defaults to `exact`, evaluates per mode. If a stored regex fails to recompile at match time (state corruption — would have failed registration), the waitpoint is skipped rather than crashing the dispatcher.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` clean
- [ ] **Post-merge BSBC smoke**: register a glob waitpoint (`room_pattern: "dashboard.*"`, `room_match_mode: "glob"`), write inbound drawers to two different dashboard rooms + one non-dashboard room, confirm only the two dashboard drawers match.
- [ ] **Post-merge**: register a regex waitpoint with a deliberately catastrophic pattern (`(.*)*`) and confirm registration rejects with the existing nested-quantifier reason.
- [ ] **Post-merge**: confirm existing waitpoints (no `room_match_mode` set) keep their exact behavior across the upgrade.

## What's NOT in this PR

- **Adoption-pattern doc update** for `docs/adoption-patterns/2fa-code-intercept.md` — that file is touched by PR #76 (sender_id warn). Doc update for `room_match_mode` will land as a follow-up once both this PR and #76 merge, to avoid trivial conflicts.
- **Multi-room arrays** (`rooms: ["a", "b"]`) — listed as out-of-scope in #74. Glob covers most cases; arrays can land later if a real adopter asks.
- **Server-side regex caching** — a fresh `new RegExp(...)` per match is cheap relative to the per-drawer SQL roundtrip (#54 watchpoint). Premature without benchmarks showing it's hot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
