### PR TITLE
feat(email-outbound): Postmark + SendGrid providers (#78 PR B)

### DIFF
--- a/mcp/servers/email-outbound/README.md
+++ b/mcp/servers/email-outbound/README.md
@@ -2,7 +2,7 @@
 
 MCP server implementing the **email-outbound** capability (capabilities/_registry.yaml v0.2).
 
-Filed against issue #78 (Nexmatic Email Autopilot). Ships with **Resend** today; Postmark, SendGrid, and AWS SES follow in a separate PR.
+Filed against issue #78 (Nexmatic Email Autopilot). Ships with **Resend**, **Postmark**, and **SendGrid**. AWS SES follows in a separate PR (needs SDK choice approval — manual SigV4 vs `@aws-sdk/client-sesv2`).
 
 ## Wiring into a skill
 
@@ -21,11 +21,15 @@ In the workspace's `.mcp.json`:
     "command": "node",
     "args": ["/opt/nexaas/mcp/servers/email-outbound/src/index.ts"],
     "env": {
-      "RESEND_API_KEY": "${env:RESEND_API_KEY}"
+      "RESEND_API_KEY": "${env:RESEND_API_KEY}",
+      "POSTMARK_SERVER_TOKEN": "${env:POSTMARK_SERVER_TOKEN}",
+      "SENDGRID_API_KEY": "${env:SENDGRID_API_KEY}"
     }
   }
 }
 ```
+
+Set whichever provider's credentials apply for the workspace; the MCP only requires one to be present.
 
 The skill agentic loop now sees `send` and `track` tools.
 
@@ -33,8 +37,13 @@ The skill agentic loop now sees `send` and `track` tools.
 
 Order of resolution at server start:
 
-1. **`EMAIL_OUTBOUND_PROVIDER`** env var — explicit pin (`resend`, future: `postmark` | `sendgrid` | `aws_ses`).
-2. **Auto-detect** — first known provider key wins. Today: `RESEND_API_KEY`.
+1. **`EMAIL_OUTBOUND_PROVIDER`** env var — explicit pin (`resend` | `postmark` | `sendgrid`; future: `aws_ses`).
+2. **Auto-detect** — first key present wins, in this fixed probe order:
+   1. `RESEND_API_KEY` → Resend
+   2. `POSTMARK_SERVER_TOKEN` → Postmark
+   3. `SENDGRID_API_KEY` → SendGrid
+
+The order is fixed (not "first env-var defined") so workspaces with multiple keys configured get deterministic behavior. Operators wanting a non-default pick must use `EMAIL_OUTBOUND_PROVIDER` to pin explicitly.
 
 The chosen provider name is logged on stderr at startup and surfaces in every tool response as `provider:`.
 
@@ -106,3 +115,20 @@ Returns:
 - Tracking flags (`tracking.opens` / `tracking.clicks`) are configured at the API-key / domain level in the Resend dashboard. Per-message toggles are accepted by this MCP for cross-provider symmetry but **no-op** for Resend — flip the dashboard toggles instead.
 - `track` uses `GET /emails/:id` for last-known state. Open/click counts require webhook ingestion (out of scope for PR A).
 - Per-recipient rejection isn't returned by Resend's `POST /emails`. On error, all recipients are reported as `rejected` with the provider's error message as the reason.
+
+### Postmark
+
+- Auth: `X-Postmark-Server-Token` (per-server token from the Postmark UI).
+- Multi-recipient sends use a single `POST /email` with comma-separated `To` and yield one `MessageID` for the batch. Per-recipient outcomes need `POST /email/batch` — deferred to a follow-up; for now `rejected[]` is empty on accept and contains all recipients on reject (mirroring the framework's coarse-grained shape).
+- `tags`: Postmark exposes a singular `Tag` field. The first entry from `tags[]` is sent as `Tag`; remaining entries land in `Metadata` as `tag_1`, `tag_2`, … so they remain filterable in the Postmark Activity view.
+- `tracking.clicks`: mapped to Postmark's `TrackLinks` enum — `true` → `"HtmlAndText"`, `false` → `"None"`. For per-format control, configure server defaults in Postmark and leave the framework flag unset.
+- `track` reads `GET /messages/outbound/<id>/details` and prefers the most-specific `MessageEvents[]` entry over the top-level `Status`. Open/click counts require separate `/opens` and `/clicks` calls (one per recipient) — skipped here to keep `track` cheap; subscribe to Postmark webhooks for engagement data.
+
+### SendGrid
+
+- Auth: bearer `SENDGRID_API_KEY`.
+- `POST /v3/mail/send` returns **202 with no body**; the message id arrives in the `X-Message-Id` response header. Some SendGrid subuser configurations elide the header — when that happens the MCP still returns `accepted`, but `message_id` is omitted, so callers can't `track` that specific send. (SendGrid known quirk.)
+- `tags`: mapped to SendGrid `categories[]`. SendGrid caps categories at 10 per send; entries past index 9 are silently dropped (the framework slices defensively).
+- `tracking.opens` / `tracking.clicks`: mapped to `tracking_settings.{open_tracking,click_tracking}.enable` per send.
+- Plain-text content is required *before* HTML in the `content[]` array (SendGrid schema rule); the provider already orders correctly regardless of caller order.
+- `track` calls `GET /v3/messages/<id>` which is part of SendGrid's **paid Email Activity feed**. On 401/403/404 the provider returns `status: "unknown"` rather than throwing, so non-paid accounts get a graceful degradation. For reliable engagement state, subscribe to SendGrid Event Webhooks regardless of plan tier.

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/mcp-email-outbound",
   "version": "0.1.0",
-  "description": "Outbound email MCP server — implements the email-outbound capability (#78). Provider-pluggable; ships with Resend.",
+  "description": "Outbound email MCP server — implements the email-outbound capability (#78). Provider-pluggable; ships with Resend, Postmark, and SendGrid.",
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {

--- a/mcp/servers/email-outbound/src/index.ts
+++ b/mcp/servers/email-outbound/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * Nexaas Email-Outbound MCP Server (#78 PR A).
+ * Nexaas Email-Outbound MCP Server (#78).
  *
  * Implements the `email-outbound` capability defined in
  * capabilities/_registry.yaml. Skills declaring `mcp_servers: [email-outbound]`
  * receive `send` and `track` tools for transactional and marketing email.
  *
- * Provider-pluggable. PR A ships with Resend; Postmark, SendGrid, AWS SES
- * follow in a separate PR (issue #78 step 2). All providers conform to the
+ * Provider-pluggable. Today: Resend, Postmark, SendGrid. AWS SES is tracked
+ * as a follow-up (needs SDK choice). All providers conform to the
  * EmailProvider interface in `types.ts`, so the MCP entry point stays
  * provider-agnostic — selection happens once at server start (see
  * `provider-select.ts`) and is logged on stderr.
@@ -15,7 +15,9 @@
  * name from a skill manifest's `mcp_servers` array.
  *
  * Environment:
- *   RESEND_API_KEY                 — Resend bearer token (PR A)
+ *   RESEND_API_KEY                 — Resend bearer token
+ *   POSTMARK_SERVER_TOKEN          — Postmark per-server token
+ *   SENDGRID_API_KEY               — SendGrid bearer token
  *   EMAIL_OUTBOUND_PROVIDER        — pin a specific provider (optional)
  */
 

--- a/mcp/servers/email-outbound/src/provider-select.ts
+++ b/mcp/servers/email-outbound/src/provider-select.ts
@@ -7,6 +7,8 @@
  *      (deferred to a follow-up: the MCP runs as its own process and doesn't
  *      have a palace session in scope; for now operators set the env var)
  *   3. First provider whose API key env is present — auto-detect
+ *      Probe order: Resend → Postmark → SendGrid (documented & stable so
+ *      multi-key workspaces get predictable behavior).
  *
  * Returns the provider instance, the provider name (for WAL / logs), and
  * the reason the provider was picked.
@@ -14,6 +16,8 @@
 
 import type { EmailProvider } from "./types.js";
 import { ResendProvider } from "./providers/resend.js";
+import { PostmarkProvider } from "./providers/postmark.js";
+import { SendGridProvider } from "./providers/sendgrid.js";
 
 export interface SelectedProvider {
   provider: EmailProvider;
@@ -24,6 +28,8 @@ export interface SelectedProvider {
 export function selectProvider(): SelectedProvider {
   const explicitName = (process.env.EMAIL_OUTBOUND_PROVIDER ?? "").toLowerCase();
   const resendKey = process.env.RESEND_API_KEY;
+  const postmarkToken = process.env.POSTMARK_SERVER_TOKEN;
+  const sendgridKey = process.env.SENDGRID_API_KEY;
 
   if (explicitName === "resend") {
     if (!resendKey) {
@@ -32,22 +38,41 @@ export function selectProvider(): SelectedProvider {
     return { provider: new ResendProvider(resendKey), name: "resend", reason: "env_pin" };
   }
 
+  if (explicitName === "postmark") {
+    if (!postmarkToken) {
+      throw new Error("EMAIL_OUTBOUND_PROVIDER=postmark but POSTMARK_SERVER_TOKEN is unset");
+    }
+    return { provider: new PostmarkProvider(postmarkToken), name: "postmark", reason: "env_pin" };
+  }
+
+  if (explicitName === "sendgrid") {
+    if (!sendgridKey) {
+      throw new Error("EMAIL_OUTBOUND_PROVIDER=sendgrid but SENDGRID_API_KEY is unset");
+    }
+    return { provider: new SendGridProvider(sendgridKey), name: "sendgrid", reason: "env_pin" };
+  }
+
   if (explicitName) {
     throw new Error(
       `EMAIL_OUTBOUND_PROVIDER=${explicitName} not yet supported by this build. ` +
-      `Available: resend. Postmark, SendGrid, AWS SES are tracked in #78 follow-up PR B.`,
+      `Available: resend, postmark, sendgrid. AWS SES is tracked as a follow-up to #78.`,
     );
   }
 
-  // Auto-detect — first key wins. Resend is the only implementation today;
-  // additional providers will be probed in a stable order documented in the
-  // server README so behavior is predictable when multiple keys are present.
+  // Auto-detect — first key wins. Order is documented in the README so
+  // behavior is predictable when multiple keys are present.
   if (resendKey) {
     return { provider: new ResendProvider(resendKey), name: "resend", reason: "auto_detect" };
   }
+  if (postmarkToken) {
+    return { provider: new PostmarkProvider(postmarkToken), name: "postmark", reason: "auto_detect" };
+  }
+  if (sendgridKey) {
+    return { provider: new SendGridProvider(sendgridKey), name: "sendgrid", reason: "auto_detect" };
+  }
 
   throw new Error(
-    "No email-outbound provider configured. Set RESEND_API_KEY (or set EMAIL_OUTBOUND_PROVIDER " +
-    "and the matching key) in the workspace .env. See #78.",
+    "No email-outbound provider configured. Set one of RESEND_API_KEY, POSTMARK_SERVER_TOKEN, " +
+    "or SENDGRID_API_KEY (or set EMAIL_OUTBOUND_PROVIDER and the matching key) in the workspace .env. See #78.",
   );
 }

--- a/mcp/servers/email-outbound/src/providers/postmark.ts
+++ b/mcp/servers/email-outbound/src/providers/postmark.ts
@@ -1,0 +1,241 @@
+/**
+ * Postmark provider plugin (#78 PR B).
+ *
+ * Postmark's HTTP API:
+ *   POST /email                              — send a single message
+ *   GET  /messages/outbound/<id>/details     — fetch delivery state
+ *
+ * Auth: `X-Postmark-Server-Token` header (per-server-token API).
+ *
+ * Multi-recipient handling: Postmark accepts a comma-separated `To`
+ * field on /email and returns one MessageID for the batch. For richer
+ * per-recipient outcomes we'd use /email/batch — deferred to a follow-up
+ * since the framework's `rejected` shape can be derived from the
+ * single-call response when ErrorCode != 0.
+ *
+ * Tracking: Postmark exposes per-message metadata at
+ * /messages/outbound/<id>/details — including last status, recorded
+ * delivery time, and bounce details. Open/click counts come from
+ * /opens and /clicks endpoints; we return aggregate state only here
+ * to avoid three round-trips per `track` call.
+ */
+
+import type { EmailProvider, SendInput, SendOutput, TrackOutput } from "../types.js";
+
+const POSTMARK_API = "https://api.postmarkapp.com";
+const SEND_TIMEOUT_MS = 10_000;
+const TRACK_TIMEOUT_MS = 5_000;
+
+interface PostmarkSendResponse {
+  To?: string;
+  MessageID?: string;
+  ErrorCode?: number;
+  Message?: string;
+  SubmittedAt?: string;
+}
+
+interface PostmarkMessageDetails {
+  MessageID: string;
+  Status?: string;        // "Sent" | "Bounced" | "Spam" | "Inactive" | "Pending"
+  ReceivedAt?: string;
+  Recipients?: string[];
+  MessageEvents?: Array<{
+    Recipient?: string;
+    Type?: string;        // "Delivered" | "Opened" | "LinkClicked" | "Bounced" | "Transient" | "SpamComplaint" | etc.
+    ReceivedAt?: string;
+    Details?: { Type?: string; Description?: string };
+  }>;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+function asArray<T>(v: T | T[]): T[] {
+  return Array.isArray(v) ? v : [v];
+}
+
+function formatFrom(input: SendInput["from"]): string {
+  return input.name ? `${input.name} <${input.email}>` : input.email;
+}
+
+/**
+ * Postmark's tracking flag for clicks is a string enum:
+ *   "None" | "HtmlAndText" | "HtmlOnly" | "TextOnly"
+ * We map our boolean to "HtmlAndText" (the most permissive useful value)
+ * when enabled. Adopters needing finer control bypass tracking input and
+ * configure the Postmark server defaults.
+ */
+function trackLinksValue(enabled: boolean | undefined): string | undefined {
+  if (enabled === undefined) return undefined;
+  return enabled ? "HtmlAndText" : "None";
+}
+
+/**
+ * Map Postmark's last-known message Status to the framework's enum.
+ * Postmark uses different vocabulary; the framework normalizes so skills
+ * don't need provider-specific switch statements.
+ */
+function normalizeStatus(status?: string, events?: PostmarkMessageDetails["MessageEvents"]): TrackOutput["status"] {
+  // Prefer the most specific event in the timeline.
+  if (events && events.length > 0) {
+    const lastEvent = events[events.length - 1];
+    if (lastEvent.Type === "Delivered") return "delivered";
+    if (lastEvent.Type === "Bounced" || lastEvent.Type === "Transient") return "bounced";
+    if (lastEvent.Type === "SpamComplaint") return "complained";
+  }
+  // Fall back to the top-level Status field.
+  switch ((status ?? "").toLowerCase()) {
+    case "sent": return "sent";
+    case "bounced": return "bounced";
+    case "spam": return "complained";
+    case "pending": return "queued";
+    case "inactive": return "bounced";
+    default: return "unknown";
+  }
+}
+
+export class PostmarkProvider implements EmailProvider {
+  readonly name = "postmark";
+
+  constructor(private readonly serverToken: string) {
+    if (!serverToken) throw new Error("POSTMARK_SERVER_TOKEN required");
+  }
+
+  async send(input: SendInput): Promise<SendOutput> {
+    const recipients = asArray(input.to);
+
+    const body: Record<string, unknown> = {
+      From: formatFrom(input.from),
+      To: recipients.join(", "),     // comma-separated per Postmark API
+      Subject: input.subject,
+      TextBody: input.body_text,
+    };
+    if (input.body_html) body.HtmlBody = input.body_html;
+    if (input.reply_to) body.ReplyTo = input.reply_to;
+    if (input.headers && Object.keys(input.headers).length > 0) {
+      body.Headers = Object.entries(input.headers).map(([Name, Value]) => ({ Name, Value }));
+    }
+    if (input.tracking?.opens !== undefined) body.TrackOpens = input.tracking.opens;
+    const tl = trackLinksValue(input.tracking?.clicks);
+    if (tl !== undefined) body.TrackLinks = tl;
+    // Postmark's `Tag` field is singular (one string). We use the first
+    // entry from the framework's tags array; additional tags are dropped
+    // with a comment since Postmark provides Metadata instead — we put
+    // the rest there for filterability.
+    if (input.tags && input.tags.length > 0) {
+      body.Tag = input.tags[0];
+      if (input.tags.length > 1) {
+        body.Metadata = Object.fromEntries(
+          input.tags.slice(1).map((t, i) => [`tag_${i + 1}`, t]),
+        );
+      }
+    }
+    if (input.attachments && input.attachments.length > 0) {
+      body.Attachments = input.attachments.map((a) => ({
+        Name: a.filename,
+        Content: a.content_base64,
+        ContentType: "application/octet-stream",
+      }));
+    }
+
+    const res = await withTimeout(
+      fetch(`${POSTMARK_API}/email`, {
+        method: "POST",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          "X-Postmark-Server-Token": this.serverToken,
+        },
+        body: JSON.stringify(body),
+      }),
+      SEND_TIMEOUT_MS,
+      "Postmark send",
+    );
+
+    let parsed: PostmarkSendResponse;
+    try {
+      parsed = await res.json() as PostmarkSendResponse;
+    } catch {
+      throw new Error(`Postmark returned non-JSON response (HTTP ${res.status})`);
+    }
+
+    // Postmark uses ErrorCode = 0 for success, non-zero for failure. The
+    // top-level HTTP status mirrors this in most cases.
+    if (!res.ok || (parsed.ErrorCode !== undefined && parsed.ErrorCode !== 0)) {
+      const reason = parsed.Message ?? `HTTP ${res.status} (Postmark ErrorCode ${parsed.ErrorCode ?? "unknown"})`;
+      return {
+        accepted: [],
+        rejected: recipients.map((email) => ({ email, reason })),
+      };
+    }
+
+    if (!parsed.MessageID) {
+      throw new Error("Postmark response missing MessageID");
+    }
+
+    return {
+      message_id: parsed.MessageID,
+      accepted: recipients,
+      rejected: [],
+    };
+  }
+
+  async track(messageId: string): Promise<TrackOutput> {
+    const res = await withTimeout(
+      fetch(`${POSTMARK_API}/messages/outbound/${encodeURIComponent(messageId)}/details`, {
+        headers: {
+          "Accept": "application/json",
+          "X-Postmark-Server-Token": this.serverToken,
+        },
+      }),
+      TRACK_TIMEOUT_MS,
+      "Postmark track",
+    );
+
+    if (res.status === 404) {
+      return { message_id: messageId, status: "unknown" };
+    }
+    if (!res.ok) {
+      throw new Error(`Postmark track HTTP ${res.status}`);
+    }
+
+    const data = await res.json() as PostmarkMessageDetails;
+    const status = normalizeStatus(data.Status, data.MessageEvents);
+
+    const out: TrackOutput = {
+      message_id: messageId,
+      status,
+    };
+
+    // Find the Delivered event timestamp, if any.
+    const deliveredEvent = data.MessageEvents?.find((e) => e.Type === "Delivered");
+    if (deliveredEvent?.ReceivedAt) {
+      out.delivered_at = deliveredEvent.ReceivedAt;
+    } else if (data.ReceivedAt && status === "sent") {
+      out.delivered_at = data.ReceivedAt;
+    }
+
+    if (status === "bounced") {
+      const bounceEvent = data.MessageEvents?.find((e) => e.Type === "Bounced" || e.Type === "Transient");
+      if (bounceEvent) {
+        out.bounced = {
+          at: bounceEvent.ReceivedAt ?? new Date().toISOString(),
+          type: bounceEvent.Details?.Type ?? "unknown",
+          reason: bounceEvent.Details?.Description,
+        };
+      }
+    }
+
+    // Open / click counts require separate /opens and /clicks endpoint
+    // calls per recipient — three round-trips per `track`. Skipped here
+    // to keep `track` cheap; skills needing engagement should subscribe
+    // to Postmark webhooks. Documented in the server README.
+    return out;
+  }
+}

--- a/mcp/servers/email-outbound/src/providers/sendgrid.ts
+++ b/mcp/servers/email-outbound/src/providers/sendgrid.ts
@@ -1,0 +1,187 @@
+/**
+ * SendGrid provider plugin (#78 PR B).
+ *
+ * SendGrid's v3 API:
+ *   POST /v3/mail/send                       — send (returns 202; no body)
+ *
+ * Auth: bearer `SENDGRID_API_KEY`.
+ *
+ * Per-recipient rejection: not surfaced synchronously on send. Bounces
+ * and spam complaints arrive via webhook — adopters needing precise
+ * outcome should subscribe to SendGrid Event Webhooks. The synchronous
+ * call returns 202 + an `X-Message-Id` header on accept, or 4xx with
+ * an error body on rejection.
+ *
+ * Tracking: SendGrid's /v3/messages/<id> endpoint is part of the paid
+ * "Email Activity" feature. For a baseline implementation that works
+ * without that subscription, `track` returns `status: "unknown"` after
+ * confirming the message was queued. Skills needing live engagement
+ * should consume webhook events.
+ */
+
+import type { EmailProvider, SendInput, SendOutput, TrackOutput } from "../types.js";
+
+const SENDGRID_API = "https://api.sendgrid.com";
+const SEND_TIMEOUT_MS = 10_000;
+const TRACK_TIMEOUT_MS = 5_000;
+
+interface SendGridErrorResponse {
+  errors?: Array<{ message?: string; field?: string }>;
+}
+
+interface SendGridMessageDetails {
+  msg_id: string;
+  status?: string;        // "processed" | "delivered" | "deferred" | "bounce" | "blocked" | "spam_report" | etc.
+  last_event_time?: string;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+function asArray<T>(v: T | T[]): T[] {
+  return Array.isArray(v) ? v : [v];
+}
+
+function normalizeStatus(status?: string): TrackOutput["status"] {
+  switch ((status ?? "").toLowerCase()) {
+    case "delivered": return "delivered";
+    case "processed":
+    case "deferred": return "queued";
+    case "bounce":
+    case "blocked": return "bounced";
+    case "spam_report": return "complained";
+    default: return "unknown";
+  }
+}
+
+export class SendGridProvider implements EmailProvider {
+  readonly name = "sendgrid";
+
+  constructor(private readonly apiKey: string) {
+    if (!apiKey) throw new Error("SENDGRID_API_KEY required");
+  }
+
+  async send(input: SendInput): Promise<SendOutput> {
+    const recipients = asArray(input.to);
+
+    const personalizations: Array<Record<string, unknown>> = [{
+      to: recipients.map((email) => ({ email })),
+    }];
+
+    const content: Array<{ type: string; value: string }> = [
+      // SendGrid requires text/plain BEFORE text/html when both present.
+      { type: "text/plain", value: input.body_text },
+    ];
+    if (input.body_html) content.push({ type: "text/html", value: input.body_html });
+
+    const body: Record<string, unknown> = {
+      personalizations,
+      from: { email: input.from.email, ...(input.from.name ? { name: input.from.name } : {}) },
+      subject: input.subject,
+      content,
+    };
+    if (input.reply_to) body.reply_to = { email: input.reply_to };
+    if (input.headers && Object.keys(input.headers).length > 0) body.headers = input.headers;
+    if (input.tags && input.tags.length > 0) {
+      // SendGrid caps categories at 10 per send — slice defensively.
+      body.categories = input.tags.slice(0, 10);
+    }
+    if (input.tracking) {
+      const ts: Record<string, unknown> = {};
+      if (input.tracking.opens !== undefined) ts.open_tracking = { enable: input.tracking.opens };
+      if (input.tracking.clicks !== undefined) ts.click_tracking = { enable: input.tracking.clicks };
+      if (Object.keys(ts).length > 0) body.tracking_settings = ts;
+    }
+    if (input.attachments && input.attachments.length > 0) {
+      body.attachments = input.attachments.map((a) => ({
+        content: a.content_base64,
+        filename: a.filename,
+        // SendGrid requires an explicit type; default to octet-stream when
+        // unknown so attachments don't fail the schema check.
+        type: "application/octet-stream",
+      }));
+    }
+
+    const res = await withTimeout(
+      fetch(`${SENDGRID_API}/v3/mail/send`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+      SEND_TIMEOUT_MS,
+      "SendGrid send",
+    );
+
+    if (res.status === 202) {
+      const messageId = res.headers.get("x-message-id") ?? "";
+      if (!messageId) {
+        // Some SendGrid responses elide the header; record-of-send still
+        // succeeded. Fall back to "" — caller can't `track` but the email
+        // is in flight. This is a known SendGrid quirk on subuser keys.
+        return { accepted: recipients, rejected: [] };
+      }
+      return {
+        message_id: messageId,
+        accepted: recipients,
+        rejected: [],
+      };
+    }
+
+    // Non-202 → SendGrid rejected the request. Body shape: {errors: [{message, field}]}
+    let reason = `HTTP ${res.status}`;
+    try {
+      const parsed = await res.json() as SendGridErrorResponse;
+      if (parsed.errors && parsed.errors.length > 0) {
+        reason = parsed.errors.map((e) => e.message ?? "unknown error").join("; ");
+      }
+    } catch {
+      // body not JSON — keep HTTP status as the reason
+    }
+    return {
+      accepted: [],
+      rejected: recipients.map((email) => ({ email, reason })),
+    };
+  }
+
+  async track(messageId: string): Promise<TrackOutput> {
+    // SendGrid's /v3/messages/<id> requires the paid Email Activity feed.
+    // We try it once; on 4xx (likely 401/403/404) we fall back to "unknown"
+    // with a hint in the WAL via the caller's logging — same shape regardless
+    // of whether the account has Activity enabled.
+    const res = await withTimeout(
+      fetch(`${SENDGRID_API}/v3/messages/${encodeURIComponent(messageId)}`, {
+        headers: { "Authorization": `Bearer ${this.apiKey}` },
+      }),
+      TRACK_TIMEOUT_MS,
+      "SendGrid track",
+    );
+
+    if (!res.ok) {
+      // 401/403 = no Activity feed access; 404 = id unknown; either way the
+      // caller gets a graceful "we don't know" instead of an exception.
+      return { message_id: messageId, status: "unknown" };
+    }
+
+    const data = await res.json() as SendGridMessageDetails;
+    const status = normalizeStatus(data.status);
+
+    const out: TrackOutput = {
+      message_id: messageId,
+      status,
+    };
+    if (status === "delivered" && data.last_event_time) {
+      out.delivered_at = data.last_event_time;
+    }
+    // Open / click counts come via webhook events; not exposed by this endpoint.
+    return out;
+  }
+}


### PR DESCRIPTION
## Summary

PR B for issue #78 (Email Autopilot). Adds two more `EmailProvider` implementations to the email-outbound MCP server, following the pattern Resend established in PR A (#79).

- **Postmark** — `POST /email` + `GET /messages/outbound/<id>/details`. Tag/Metadata mapping for the framework's `tags[]` array. `TrackLinks` enum mapping for `tracking.clicks`. Normalizes by preferring `MessageEvents[]` tail over top-level `Status`.
- **SendGrid** — `POST /v3/mail/send` + `GET /v3/messages/<id>`. Handles SendGrid's 202-with-empty-body + `X-Message-Id` header response. `tags[]` → `categories[]` (capped at 10). Graceful fallback to `status: "unknown"` for non-paid Activity-feed accounts on `track`.

Both wired into `provider-select.ts` with explicit-pin handling and a documented auto-detect probe order: **Resend → Postmark → SendGrid**.

## Stacks on #79

This branch was cut from `feat/email-outbound-mcp-78` (PR #79's tip). Base is set accordingly. Once #79 merges, GitHub will retarget this PR onto `main` automatically.

## AWS SES — intentionally deferred

AWS SES needs an SDK choice (manual SigV4 vs `@aws-sdk/client-sesv2`) — adding `@aws-sdk/client-sesv2` pulls a sizable dep tree that's worth a separate review pass, and a hand-rolled SigV4 implementation is also worth its own PR for the credential-handling surface area. Filing as a follow-up rather than bundling.

## Provider notes (also in README)

### Postmark
- Singular `Tag` field — first of `tags[]` becomes `Tag`, rest go to `Metadata` as `tag_1`, `tag_2`, … (still filterable in Activity).
- `TrackLinks` is an enum: \`true\` → \`\"HtmlAndText\"\`, \`false\` → \`\"None\"\`.
- `track` skips per-recipient `/opens` and `/clicks` to keep the call cheap; webhooks are the supported path for engagement counts.

### SendGrid
- Send response is **202 with no body**; message id arrives in `X-Message-Id`. Some subuser configurations elide it — when that happens the MCP returns `accepted` but omits `message_id` (caller can't `track` that send).
- `categories[]` is capped at 10 per send; entries past index 9 are sliced defensively.
- Plain-text content must precede HTML in `content[]` — provider always orders correctly regardless of caller order.
- `track` calls `GET /v3/messages/<id>` which is part of the **paid Email Activity feed**. Returns `status: \"unknown\"` on 401/403/404 instead of throwing.

## Test plan

- [ ] Typecheck (`tsc --noEmit`) clean — verified locally
- [ ] `EMAIL_OUTBOUND_PROVIDER=postmark` + `POSTMARK_SERVER_TOKEN` selects PostmarkProvider
- [ ] `EMAIL_OUTBOUND_PROVIDER=sendgrid` + `SENDGRID_API_KEY` selects SendGridProvider
- [ ] Auto-detect picks first key in documented order (Resend → Postmark → SendGrid)
- [ ] Bogus pin (`EMAIL_OUTBOUND_PROVIDER=mailgun`) fails with the updated error mentioning AWS SES as the remaining gap
- [ ] Smoke send via Postmark sandbox token in a workspace .env and verify `track` round-trip
- [ ] Smoke send via SendGrid free-tier key and verify graceful `unknown` fallback on `track`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Postmark and SendGrid email providers alongside Resend.
  * Implemented provider selection via explicit environment variable pinning or automatic detection based on configured credentials.

* **Documentation**
  * Updated configuration examples and environment variable documentation for all supported providers.
  * Added provider-specific notes including authentication and tracking behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->