### PR TITLE
feat(integrations): extract Resend into @nexaas/email-provider-resend (#88 Phase 2)

### DIFF
--- a/.changeset/initial-resend-extraction.md
+++ b/.changeset/initial-resend-extraction.md
@@ -1,0 +1,5 @@
+---
+"@nexaas/email-provider-resend": minor
+---
+
+Initial release. Resend implementation of the `email-outbound` capability, migrated from `mcp/servers/email-outbound/src/providers/resend.ts`. Capability compat: `>=0.2 <1`.

--- a/integrations/email-provider-resend/README.md
+++ b/integrations/email-provider-resend/README.md
@@ -1,0 +1,38 @@
+# `@nexaas/email-provider-resend`
+
+Resend implementation of the `email-outbound` capability.
+
+Reference integration — maintained by the Nexaas team. See [issue #88](https://github.com/Systemsaholic/nexaas/issues/88) for the architecture and `/integrations/README.md` for the authoring contract.
+
+## Install
+
+In the workspace manifest:
+
+```yaml
+integrations:
+  - "@nexaas/email-provider-resend"
+```
+
+In `.env`:
+
+```
+RESEND_API_KEY=re_...
+```
+
+## Capability
+
+| Field | Value |
+|---|---|
+| Implements | `email-outbound` |
+| Compat range | `>=0.2 <1` |
+| Provider name (in WAL/logs) | `resend` |
+
+## Quirks (vs other email providers)
+
+- **Per-message tracking toggles are no-op.** Resend configures opens/clicks at the API-key and domain level. The integration accepts `tracking.opens` / `tracking.clicks` for cross-provider symmetry but does not pass them through — flip the toggles in the Resend dashboard instead.
+- **No per-recipient rejection on send.** Resend bundles all rejections into a single error. On send failure, the integration returns `accepted: []` and `rejected: [{ email, reason: providerMessage }]` for every recipient.
+- **No engagement counts on `track`.** `GET /emails/:id` returns last-known delivery state but open/click counts are webhook-delivered. Skills needing precise engagement counts should subscribe to a Resend webhook drawer and aggregate themselves.
+
+## Migration note
+
+Code originally lived in `mcp/servers/email-outbound/src/providers/resend.ts`. Moved here in #88 Phase 2 to separate vendor implementations from the framework's MCP shell. The shell still imports `ResendProvider` (now `createResendProvider`) statically until Phase 3 introduces the manifest-driven loader; from a runtime perspective nothing changed.

--- a/integrations/email-provider-resend/nexaas-integration.yaml
+++ b/integrations/email-provider-resend/nexaas-integration.yaml
@@ -1,0 +1,9 @@
+name: email-provider-resend
+implements:
+  - capability: email-outbound
+    version: ">=0.2 <1"
+    provider_name: resend
+env:
+  required: [RESEND_API_KEY]
+  optional: []
+entry: "./src/index.ts"

--- a/integrations/email-provider-resend/package.json
+++ b/integrations/email-provider-resend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nexaas/email-provider-resend",
+  "version": "0.1.0",
+  "description": "Resend implementation of the Nexaas email-outbound capability. Reference integration (#88).",
+  "type": "module",
+  "main": "src/index.ts",
+  "files": [
+    "src",
+    "nexaas-integration.yaml"
+  ],
+  "dependencies": {
+    "@nexaas/integration-sdk": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/integrations/email-provider-resend/src/index.ts
+++ b/integrations/email-provider-resend/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Resend provider plugin.
+ * @nexaas/email-provider-resend — Resend implementation of email-outbound.
  *
  * Resend's HTTP API is small enough that a fetch-based client is simpler
  * than pulling in their SDK. Two endpoints used:
@@ -13,12 +13,23 @@
  * The GET endpoint returns last-known status but engagement counts come
  * via webhooks — we surface what the email-fetch endpoint exposes
  * (`last_event` / `created_at` / `delivered_at`) and leave count granularity
- * to a future webhook-receiver task. This keeps the framework-side
- * implementation stateless; skills that need precise open/click counts
- * should listen to the webhook drawer and aggregate themselves.
+ * to a future webhook-receiver task. This keeps the integration stateless;
+ * skills that need precise open/click counts should listen to the webhook
+ * drawer and aggregate themselves.
+ *
+ * Migrated from `mcp/servers/email-outbound/src/providers/resend.ts` in
+ * #88 Phase 2 — first reference integration to land under the new
+ * `integrations/` layout.
  */
 
-import type { EmailProvider, SendInput, SendOutput, TrackOutput } from "../types.js";
+import {
+  asArray,
+  withTimeout,
+  type EmailProvider,
+  type SendInput,
+  type SendOutput,
+  type TrackOutput,
+} from "@nexaas/integration-sdk";
 
 const RESEND_API = "https://api.resend.com";
 const SEND_TIMEOUT_MS = 10_000;
@@ -45,21 +56,8 @@ interface ResendEmailLookup {
   bounce?: { type?: string; message?: string };
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
-    ),
-  ]);
-}
-
 function formatFrom(input: SendInput["from"]): string {
   return input.name ? `${input.name} <${input.email}>` : input.email;
-}
-
-function asArray<T>(v: T | T[]): T[] {
-  return Array.isArray(v) ? v : [v];
 }
 
 function normalizeStatus(lastEvent?: string): TrackOutput["status"] {
@@ -135,7 +133,7 @@ export class ResendProvider implements EmailProvider {
       // Resend bundles all rejections into a single error — we surface as
       // "all recipients rejected with the provider message" since per-
       // recipient rejection is not in the API response. `message_id` is
-      // omitted (undefined) — there is no message to track. PR #79 review.
+      // omitted (undefined) — there is no message to track.
       const reason = parsed.message ?? `HTTP ${res.status}`;
       return {
         accepted: [],
@@ -190,4 +188,13 @@ export class ResendProvider implements EmailProvider {
     // capability spec contract.
     return out;
   }
+}
+
+/**
+ * Stable factory export consumed by the email-outbound MCP shell and (in
+ * Phase 3) by the manifest-driven loader. Kept as a named export so the
+ * loader can pluck it via `(await import(pkg)).createResendProvider`.
+ */
+export function createResendProvider(apiKey: string): EmailProvider {
+  return new ResendProvider(apiKey);
 }

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -6,6 +6,8 @@
   "main": "src/index.ts",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@nexaas/integration-sdk": "0.1.0",
+    "@nexaas/email-provider-resend": "0.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/mcp/servers/email-outbound/src/provider-select.ts
+++ b/mcp/servers/email-outbound/src/provider-select.ts
@@ -15,7 +15,7 @@
  */
 
 import type { EmailProvider } from "./types.js";
-import { ResendProvider } from "./providers/resend.js";
+import { createResendProvider } from "@nexaas/email-provider-resend";
 import { PostmarkProvider } from "./providers/postmark.js";
 import { SendGridProvider } from "./providers/sendgrid.js";
 
@@ -35,7 +35,7 @@ export function selectProvider(): SelectedProvider {
     if (!resendKey) {
       throw new Error("EMAIL_OUTBOUND_PROVIDER=resend but RESEND_API_KEY is unset");
     }
-    return { provider: new ResendProvider(resendKey), name: "resend", reason: "env_pin" };
+    return { provider: createResendProvider(resendKey), name: "resend", reason: "env_pin" };
   }
 
   if (explicitName === "postmark") {
@@ -62,7 +62,7 @@ export function selectProvider(): SelectedProvider {
   // Auto-detect — first key wins. Order is documented in the README so
   // behavior is predictable when multiple keys are present.
   if (resendKey) {
-    return { provider: new ResendProvider(resendKey), name: "resend", reason: "auto_detect" };
+    return { provider: createResendProvider(resendKey), name: "resend", reason: "auto_detect" };
   }
   if (postmarkToken) {
     return { provider: new PostmarkProvider(postmarkToken), name: "postmark", reason: "auto_detect" };

--- a/mcp/servers/email-outbound/src/types.ts
+++ b/mcp/servers/email-outbound/src/types.ts
@@ -1,52 +1,17 @@
 /**
- * Shared types between the MCP entry point and provider plugins.
+ * Capability types for the email-outbound MCP shell.
  *
- * Mirrors the email-outbound capability v0.2 spec in
- * capabilities/_registry.yaml. The MCP entry point validates input via zod
- * before handing off to a provider; the provider's job is to translate
- * these framework-canonical fields into whatever the underlying API
- * expects, then translate the response back into the canonical output
- * shape. Skills never see provider-specific shapes.
+ * The canonical definitions now live in `@nexaas/integration-sdk` (#88
+ * Phase 2). This file re-exports them so the shell's existing imports
+ * (`./types.js`) keep working — Postmark and SendGrid still live in
+ * `./providers/` and import from here. They'll switch to importing
+ * directly from `@nexaas/integration-sdk` when each gets extracted in a
+ * follow-up PR.
  */
 
-export interface SendInput {
-  from: { email: string; name?: string };
-  reply_to?: string;
-  to: string | string[];
-  subject: string;
-  body_text: string;
-  body_html?: string;
-  headers?: Record<string, string>;
-  tracking?: { opens?: boolean; clicks?: boolean };
-  tags?: string[];
-  attachments?: Array<{ filename: string; content_base64: string }>;
-}
-
-export interface SendOutput {
-  /**
-   * Provider's native id for the accepted message. Undefined when *all*
-   * recipients were rejected (no message exists to track). Skills should
-   * guard before passing to `track`. PR #79 review.
-   */
-  message_id?: string;
-  accepted: string[];
-  rejected: Array<{ email: string; reason: string }>;
-}
-
-export interface TrackOutput {
-  message_id: string;
-  status: "queued" | "sent" | "delivered" | "bounced" | "complained" | "unknown";
-  delivered_at?: string;
-  opened?: { count: number; last_at?: string };
-  clicked?: { count: number; last_at?: string };
-  bounced?: { at: string; type: string; reason?: string };
-}
-
-export interface EmailProvider {
-  /** Stable identifier — `resend`, `postmark`, `sendgrid`, `aws_ses`. Surfaces in WAL & logs. */
-  readonly name: string;
-
-  send(input: SendInput): Promise<SendOutput>;
-
-  track(messageId: string): Promise<TrackOutput>;
-}
+export type {
+  EmailProvider,
+  SendInput,
+  SendOutput,
+  TrackOutput,
+} from "@nexaas/integration-sdk";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,37 @@
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "packages/*",
-        "integrations/*"
+        "integrations/*",
+        "mcp/servers/email-outbound"
       ],
       "devDependencies": {
         "@changesets/cli": "^2.27.0",
         "tsx": "^4.21.0"
+      }
+    },
+    "integrations/email-provider-resend": {
+      "name": "@nexaas/email-provider-resend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@nexaas/integration-sdk": "0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "mcp/servers/email-outbound": {
+      "name": "@nexaas/mcp-email-outbound",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@nexaas/email-provider-resend": "0.1.0",
+        "@nexaas/integration-sdk": "0.1.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1063,6 +1089,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -1180,6 +1218,346 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -1262,12 +1640,20 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/@nexaas/email-provider-resend": {
+      "resolved": "integrations/email-provider-resend",
+      "link": true
+    },
     "node_modules/@nexaas/factory": {
       "resolved": "packages/factory",
       "link": true
     },
     "node_modules/@nexaas/integration-sdk": {
       "resolved": "packages/integration-sdk",
+      "link": true
+    },
+    "node_modules/@nexaas/mcp-email-outbound": {
+      "resolved": "mcp/servers/email-outbound",
       "link": true
     },
     "node_modules/@nexaas/ops-console-core": {
@@ -1481,6 +1867,39 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -1698,6 +2117,23 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cron-parser": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
@@ -1714,7 +2150,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1984,6 +2419,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -2030,11 +2486,35 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2053,6 +2533,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -2343,6 +2839,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2457,6 +2962,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2532,8 +3046,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -2559,6 +3081,18 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2827,6 +3361,15 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3007,7 +3550,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3146,6 +3688,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postgres-array": {
@@ -3363,6 +3914,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3560,7 +4120,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3573,7 +4132,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3924,7 +4482,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3958,6 +4515,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/cli": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "workspaces": [
     "packages/*",
-    "integrations/*"
+    "integrations/*",
+    "mcp/servers/email-outbound"
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",

--- a/packages/integration-sdk/src/capabilities/email-outbound.ts
+++ b/packages/integration-sdk/src/capabilities/email-outbound.ts
@@ -1,0 +1,55 @@
+/**
+ * `email-outbound` capability contract (#88).
+ *
+ * Mirrors the spec in `capabilities/_registry.yaml` (currently v0.2).
+ * Integration authors implement `EmailProvider`; the framework's MCP
+ * shell handles transport and validation. Skills never see vendor-
+ * specific shapes — that's the whole point of the abstraction.
+ *
+ * Capability-version contract:
+ *   This module ships with the framework. An integration declares a
+ *   compat range (e.g. ">=0.2 <1") in its nexaas-integration.yaml; the
+ *   loader rejects mismatches against the registry's live version.
+ */
+
+export interface SendInput {
+  from: { email: string; name?: string };
+  reply_to?: string;
+  to: string | string[];
+  subject: string;
+  body_text: string;
+  body_html?: string;
+  headers?: Record<string, string>;
+  tracking?: { opens?: boolean; clicks?: boolean };
+  tags?: string[];
+  attachments?: Array<{ filename: string; content_base64: string }>;
+}
+
+export interface SendOutput {
+  /**
+   * Provider's native id for the accepted message. Undefined when *all*
+   * recipients were rejected (no message exists to track). Skills should
+   * guard before passing to `track`.
+   */
+  message_id?: string;
+  accepted: string[];
+  rejected: Array<{ email: string; reason: string }>;
+}
+
+export interface TrackOutput {
+  message_id: string;
+  status: "queued" | "sent" | "delivered" | "bounced" | "complained" | "unknown";
+  delivered_at?: string;
+  opened?: { count: number; last_at?: string };
+  clicked?: { count: number; last_at?: string };
+  bounced?: { at: string; type: string; reason?: string };
+}
+
+export interface EmailProvider {
+  /** Stable identifier — `resend`, `postmark`, `sendgrid`, `aws_ses`. Surfaces in WAL & logs. */
+  readonly name: string;
+
+  send(input: SendInput): Promise<SendOutput>;
+
+  track(messageId: string): Promise<TrackOutput>;
+}

--- a/packages/integration-sdk/src/index.ts
+++ b/packages/integration-sdk/src/index.ts
@@ -17,3 +17,10 @@ export type {
 } from "./manifest.js";
 
 export { withTimeout, asArray } from "./helpers.js";
+
+export type {
+  EmailProvider,
+  SendInput,
+  SendOutput,
+  TrackOutput,
+} from "./capabilities/email-outbound.js";


### PR DESCRIPTION
## Summary

First reference integration migration under the layout from #88 / #89. Resend moves out of the framework MCP shell into its own independently-versioned package. Validates the pattern; Postmark and SendGrid follow mechanically in subsequent PRs.

## What moves

| From | To |
|---|---|
| \`mcp/servers/email-outbound/src/providers/resend.ts\` | \`integrations/email-provider-resend/src/index.ts\` |

Git tracks it as a rename (84% similarity) — history is preserved.

## What lands in `@nexaas/integration-sdk`

Capability shapes for `email-outbound` (`EmailProvider`, `SendInput`, `SendOutput`, `TrackOutput`) move into `packages/integration-sdk/src/capabilities/email-outbound.ts` and re-export flat from the SDK index. The shell's `src/types.ts` becomes a thin re-export from the SDK so Postmark and SendGrid keep compiling without any changes — they switch to importing directly from the SDK when each gets extracted.

## Shell wiring

- `mcp/servers/email-outbound` is now a workspace package (added by specific path to `workspaces[]` so palace and memory MCP servers stay untouched).
- New deps: `@nexaas/integration-sdk@0.1.0` and `@nexaas/email-provider-resend@0.1.0`.
- `provider-select.ts` swaps `new ResendProvider(key)` → `createResendProvider(key)` from the new package — one line at each of the two call sites.
- The `createResendProvider` named factory is the stable export shape the Phase 3 manifest-driven loader will pluck via `(await import(pkg)).createResendProvider`.

## Changeset

`.changeset/initial-resend-extraction.md` registers `@nexaas/email-provider-resend@0.1.0` (initial release). The framework `fixed` group is untouched.

## Behavioral guarantees

- Same provider class, same selection logic, same env-var probe order. Only the package boundary moved.
- Both `tsc --noEmit` runs (root + shell) clean.
- Both PRs above (#79, #85) and #89 land the same end-state for Resend regardless of merge order — this PR simply adopts the new path.

## Stack

\`main\` ← #79 ← #85 ← #89 ← **this**

Will retarget to `main` automatically as each parent merges.

## Test plan

- [ ] Root `tsc --noEmit` clean — verified
- [ ] `mcp/servers/email-outbound` `tsc --noEmit` clean — verified
- [ ] `npm install` resolves `@nexaas/email-provider-resend` via workspace symlink — verified (root `node_modules/@nexaas/email-provider-resend` is the linked workspace)
- [ ] `EMAIL_OUTBOUND_PROVIDER=resend` selection still works (unchanged code path through `createResendProvider`)
- [ ] Auto-detect with only `RESEND_API_KEY` still picks Resend
- [ ] Smoke send through the workspace's existing Resend setup once stack lands

## Follow-up PRs (Phase 2 continued)

- `@nexaas/email-provider-postmark` — same pattern, mechanical
- `@nexaas/email-provider-sendgrid` — same pattern, mechanical
- After all three: Phase 3 (manifest-driven loader), Phase 4 (`mcp/servers/email-outbound` → `mcp/shells/email-outbound` rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)