### PR TITLE
feat(integrations): extract Postmark into @nexaas/email-provider-postmark (#88 Phase 2)

### DIFF
--- a/.changeset/initial-postmark-extraction.md
+++ b/.changeset/initial-postmark-extraction.md
@@ -1,0 +1,5 @@
+---
+"@nexaas/email-provider-postmark": minor
+---
+
+Initial release. Postmark implementation of the `email-outbound` capability, migrated from `mcp/servers/email-outbound/src/providers/postmark.ts`. Capability compat: `>=0.2 <1`.

--- a/integrations/email-provider-postmark/README.md
+++ b/integrations/email-provider-postmark/README.md
@@ -1,0 +1,39 @@
+# `@nexaas/email-provider-postmark`
+
+Postmark implementation of the `email-outbound` capability.
+
+Reference integration — maintained by the Nexaas team. See [issue #88](https://github.com/Systemsaholic/nexaas/issues/88) for the architecture and `/integrations/README.md` for the authoring contract.
+
+## Install
+
+In the workspace manifest:
+
+```yaml
+integrations:
+  - "@nexaas/email-provider-postmark"
+```
+
+In `.env`:
+
+```
+POSTMARK_SERVER_TOKEN=...
+```
+
+## Capability
+
+| Field | Value |
+|---|---|
+| Implements | `email-outbound` |
+| Compat range | `>=0.2 <1` |
+| Provider name (in WAL/logs) | `postmark` |
+
+## Quirks (vs other email providers)
+
+- **Singular `Tag` field.** Postmark's API has one tag per message. The integration sends `tags[0]` as `Tag` and the remainder as `Metadata` (`tag_1`, `tag_2`, …) so they remain filterable in the Postmark Activity view.
+- **`TrackLinks` is an enum, not a boolean.** `tracking.clicks: true` → `"HtmlAndText"` (most permissive useful value); `tracking.clicks: false` → `"None"`. For per-format control (HTML-only or text-only), configure the Postmark server defaults and leave the framework flag unset.
+- **Single MessageID per send.** Postmark accepts comma-separated `To` and returns one MessageID for the batch. Per-recipient outcomes need `POST /email/batch` — deferred to a follow-up. For now `rejected[]` is empty on accept and contains all recipients on reject (mirroring the framework's coarse-grained shape).
+- **`track` skips engagement counts.** `/messages/outbound/<id>/details` returns delivery state, not open/click counts — those need separate `/opens` and `/clicks` calls per recipient. Subscribe to Postmark webhooks for engagement data; the integration prefers the most-specific `MessageEvents[]` entry over the top-level `Status` when normalizing.
+
+## Migration note
+
+Code originally lived in `mcp/servers/email-outbound/src/providers/postmark.ts`. Moved here in #88 Phase 2 to separate vendor implementations from the framework's MCP shell. The shell still imports `createPostmarkProvider` statically; the manifest-driven loader lands in Phase 3.

--- a/integrations/email-provider-postmark/nexaas-integration.yaml
+++ b/integrations/email-provider-postmark/nexaas-integration.yaml
@@ -1,0 +1,9 @@
+name: email-provider-postmark
+implements:
+  - capability: email-outbound
+    version: ">=0.2 <1"
+    provider_name: postmark
+env:
+  required: [POSTMARK_SERVER_TOKEN]
+  optional: []
+entry: "./src/index.ts"

--- a/integrations/email-provider-postmark/package.json
+++ b/integrations/email-provider-postmark/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nexaas/email-provider-postmark",
+  "version": "0.1.0",
+  "description": "Postmark implementation of the Nexaas email-outbound capability. Reference integration (#88).",
+  "type": "module",
+  "main": "src/index.ts",
+  "files": [
+    "src",
+    "nexaas-integration.yaml"
+  ],
+  "dependencies": {
+    "@nexaas/integration-sdk": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/integrations/email-provider-postmark/src/index.ts
+++ b/integrations/email-provider-postmark/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Postmark provider plugin (#78 PR B).
+ * @nexaas/email-provider-postmark — Postmark implementation of email-outbound.
  *
  * Postmark's HTTP API:
  *   POST /email                              — send a single message
@@ -18,9 +18,19 @@
  * delivery time, and bounce details. Open/click counts come from
  * /opens and /clicks endpoints; we return aggregate state only here
  * to avoid three round-trips per `track` call.
+ *
+ * Migrated from `mcp/servers/email-outbound/src/providers/postmark.ts`
+ * in #88 Phase 2.
  */
 
-import type { EmailProvider, SendInput, SendOutput, TrackOutput } from "../types.js";
+import {
+  asArray,
+  withTimeout,
+  type EmailProvider,
+  type SendInput,
+  type SendOutput,
+  type TrackOutput,
+} from "@nexaas/integration-sdk";
 
 const POSTMARK_API = "https://api.postmarkapp.com";
 const SEND_TIMEOUT_MS = 10_000;
@@ -45,19 +55,6 @@ interface PostmarkMessageDetails {
     ReceivedAt?: string;
     Details?: { Type?: string; Description?: string };
   }>;
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
-    ),
-  ]);
-}
-
-function asArray<T>(v: T | T[]): T[] {
-  return Array.isArray(v) ? v : [v];
 }
 
 function formatFrom(input: SendInput["from"]): string {
@@ -235,7 +232,15 @@ export class PostmarkProvider implements EmailProvider {
     // Open / click counts require separate /opens and /clicks endpoint
     // calls per recipient — three round-trips per `track`. Skipped here
     // to keep `track` cheap; skills needing engagement should subscribe
-    // to Postmark webhooks. Documented in the server README.
+    // to Postmark webhooks. Documented in the integration README.
     return out;
   }
+}
+
+/**
+ * Stable factory export consumed by the email-outbound MCP shell and (in
+ * Phase 3) by the manifest-driven loader.
+ */
+export function createPostmarkProvider(serverToken: string): EmailProvider {
+  return new PostmarkProvider(serverToken);
 }

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@nexaas/integration-sdk": "0.1.0",
+    "@nexaas/email-provider-postmark": "0.1.0",
     "@nexaas/email-provider-resend": "0.1.0",
     "zod": "^3.23.0"
   },

--- a/mcp/servers/email-outbound/src/provider-select.ts
+++ b/mcp/servers/email-outbound/src/provider-select.ts
@@ -16,7 +16,7 @@
 
 import type { EmailProvider } from "./types.js";
 import { createResendProvider } from "@nexaas/email-provider-resend";
-import { PostmarkProvider } from "./providers/postmark.js";
+import { createPostmarkProvider } from "@nexaas/email-provider-postmark";
 import { SendGridProvider } from "./providers/sendgrid.js";
 
 export interface SelectedProvider {
@@ -42,7 +42,7 @@ export function selectProvider(): SelectedProvider {
     if (!postmarkToken) {
       throw new Error("EMAIL_OUTBOUND_PROVIDER=postmark but POSTMARK_SERVER_TOKEN is unset");
     }
-    return { provider: new PostmarkProvider(postmarkToken), name: "postmark", reason: "env_pin" };
+    return { provider: createPostmarkProvider(postmarkToken), name: "postmark", reason: "env_pin" };
   }
 
   if (explicitName === "sendgrid") {
@@ -65,7 +65,7 @@ export function selectProvider(): SelectedProvider {
     return { provider: createResendProvider(resendKey), name: "resend", reason: "auto_detect" };
   }
   if (postmarkToken) {
-    return { provider: new PostmarkProvider(postmarkToken), name: "postmark", reason: "auto_detect" };
+    return { provider: createPostmarkProvider(postmarkToken), name: "postmark", reason: "auto_detect" };
   }
   if (sendgridKey) {
     return { provider: new SendGridProvider(sendgridKey), name: "sendgrid", reason: "auto_detect" };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,17 @@
         "tsx": "^4.21.0"
       }
     },
+    "integrations/email-provider-postmark": {
+      "name": "@nexaas/email-provider-postmark",
+      "version": "0.1.0",
+      "dependencies": {
+        "@nexaas/integration-sdk": "0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
     "integrations/email-provider-resend": {
       "name": "@nexaas/email-provider-resend",
       "version": "0.1.0",
@@ -34,6 +45,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@nexaas/email-provider-postmark": "0.1.0",
         "@nexaas/email-provider-resend": "0.1.0",
         "@nexaas/integration-sdk": "0.1.0",
         "zod": "^3.23.0"
@@ -1638,6 +1650,10 @@
     },
     "node_modules/@nexaas/cli": {
       "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/@nexaas/email-provider-postmark": {
+      "resolved": "integrations/email-provider-postmark",
       "link": true
     },
     "node_modules/@nexaas/email-provider-resend": {


### PR DESCRIPTION
## Summary

Second reference integration migration — Postmark moves out of the framework MCP shell into `@nexaas/email-provider-postmark`. Mechanical follow-up to #90 (Resend) since the pattern is now validated.

## What moves

| From | To |
|---|---|
| \`mcp/servers/email-outbound/src/providers/postmark.ts\` | \`integrations/email-provider-postmark/src/index.ts\` |

Git tracks as a rename (92% similarity).

## Diff vs Resend extraction (#90)

Same shape, same approach. Notable Postmark-specific behavior preserved:

- **Tag/Metadata mapping** — `tags[0]` → `Tag`, rest → `Metadata.tag_N` (Postmark exposes a singular `Tag` field)
- **`TrackLinks` enum mapping** — `tracking.clicks: true` → `"HtmlAndText"`, `false` → `"None"`
- **Single MessageID per send** — single-call `/email` only; per-recipient outcomes via `/email/batch` deferred
- **MessageEvents-tail preference on track** — most-specific event wins over top-level `Status`

## Shell wiring

- Adds `@nexaas/email-provider-postmark@0.1.0` to the shell's workspace deps
- `provider-select.ts`: `new PostmarkProvider(token)` → `createPostmarkProvider(token)` at both call sites (env-pin + auto-detect)
- `src/types.ts` re-export still in place for SendGrid (extracts in the next PR)

## Changeset

`.changeset/initial-postmark-extraction.md` registers `@nexaas/email-provider-postmark@0.1.0` (initial release).

## Behavioral guarantees

- Same provider class, same selection logic, same env-var probe order
- Both `tsc --noEmit` runs (root + shell) clean
- Workspace symlink resolves: `node_modules/@nexaas/email-provider-postmark` is the linked workspace

## Stack

\`main\` ← #79 ← #85 ← #89 ← #90 ← **this**

Auto-retargets to `main` as parents merge.

## Test plan

- [ ] Root `tsc --noEmit` clean — verified
- [ ] `mcp/servers/email-outbound` `tsc --noEmit` clean — verified
- [ ] `EMAIL_OUTBOUND_PROVIDER=postmark` selects via `createPostmarkProvider`
- [ ] Auto-detect with only `POSTMARK_SERVER_TOKEN` picks Postmark
- [ ] Tag/Metadata + TrackLinks behavior unchanged on a smoke send

## Next

SendGrid extraction follows immediately — the `mcp/servers/email-outbound/src/providers/` directory is empty after that, which clears the path for Phase 3 (manifest-driven loader) and Phase 4 (`mcp/servers/email-outbound` → `mcp/shells/email-outbound` rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)