### PR TITLE
feat(runtime): skill concurrency groups (RFC #95, phase 1)

### DIFF
--- a/docs/rfcs/0001-skill-concurrency-groups.md
+++ b/docs/rfcs/0001-skill-concurrency-groups.md
@@ -1,0 +1,173 @@
+# RFC 0001 — Skill Concurrency Groups
+
+**Status:** Proposed
+**Authored:** 2026-05-06 (Phoenix canary)
+**Owners:** Phoenix Voyages (canary), Nexaas core
+**Targets:** `@nexaas/runtime` (worker, shell-skill, ai-skill), `@nexaas/cli` (register-skill)
+
+---
+
+## 1. Problem
+
+Skills that share a backing resource (a SQLite DB, a third-party API rate limit, a single-writer file) collide when their cron schedules align. The runtime currently has two concurrency knobs:
+
+- **Worker-level concurrency** (`NEXAAS_WORKER_CONCURRENCY`, default 5) — how many jobs the BullMQ worker pulls in parallel. Coarse.
+- **BullMQ rate `limiter`** (`{ max, duration }`) — global throttle. Coarser still.
+
+Neither expresses *"these skills must not run at the same time as each other, but may run in parallel with everything else"*. Today the only workarounds are:
+
+1. **Hand-stagger crons** by minute (e.g. `:23 */4` to dodge `*/15`). Brittle — every new skill that lands on the same DB has to rediscover the map.
+2. **Make the script tolerate contention** (longer `busy_timeout`, retries). Hides the issue, doesn't fix it. Long writers still starve short ones.
+3. **Drop worker concurrency to 1.** Sledgehammer — kills throughput for unrelated skills.
+
+Phoenix has hit this three times in the last month on `data/onboarding.db` (writers: `engagement-sync`, `failure-monitor`, `followup-dispatcher`, `stripe-billing-sync`, `welcome-from-{al,mireille,seb}`, `lms-invite`, `moodle-auto-enroll`). Most recent failure: `hr/stripe-billing-sync` died with `sqlite3.OperationalError: database is locked` on 2026-05-06 12:15 UTC, second consecutive run, blocked behind `engagement-sync`'s per-row HTTP+commit loop.
+
+This pattern will recur in any workspace whose skills coalesce around shared state.
+
+## 2. Proposal
+
+Add a manifest-level field that declares mutual-exclusion groups. Skills in the same group serialize within the worker; skills in different groups (or no group) parallelize as today.
+
+```yaml
+# nexaas-skills/hr/stripe-billing-sync/skill.yaml
+id: hr/stripe-billing-sync
+concurrency_groups:
+  - sqlite:data/onboarding.db
+```
+
+Multiple groups per skill are allowed (skill belongs to all of them). A job acquires every declared group lock before executing and releases all on completion or failure.
+
+### Naming convention
+
+Free-form strings. Two reserved prefixes for clarity, neither enforced by the runtime:
+
+- `sqlite:<repo-relative-path>` — file-backed SQLite DBs
+- `api:<vendor>` — third-party rate-limit groups (e.g. `api:moodle-token1`)
+
+Workspaces can invent their own (`mailbox:info@`, `cdn:r2-uploads`).
+
+## 3. Design
+
+### 3.1 Single-worker (Phoenix today)
+
+In-process semaphore keyed on group name. Cheap, no Redis round-trip, fits the current `startWorker(workspaceId, concurrency=5)` model.
+
+```ts
+// packages/runtime/src/concurrency-groups.ts
+const locks = new Map<string, Promise<void>>();
+
+export async function withGroups<T>(
+  groups: string[],
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!groups.length) return fn();
+  // Acquire in sorted order to prevent deadlock on multi-group skills
+  const sorted = [...new Set(groups)].sort();
+  const release: (() => void)[] = [];
+  for (const g of sorted) {
+    const prev = locks.get(g) ?? Promise.resolve();
+    let releaseThis!: () => void;
+    const next = new Promise<void>((r) => (releaseThis = r));
+    locks.set(g, prev.then(() => next));
+    await prev;
+    release.push(() => {
+      releaseThis();
+      // Garbage-collect: if we're the tail, drop the entry
+      if (locks.get(g) === next) locks.delete(g);
+    });
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const r of release) r();
+  }
+}
+```
+
+Wired into `runShellSkill` and `runAiSkill`:
+
+```ts
+// shell-skill.ts
+export async function runShellSkill(workspace, manifest, context) {
+  return withGroups(manifest.concurrency_groups ?? [], async () => {
+    // existing body
+  });
+}
+```
+
+### 3.2 Multi-worker (future)
+
+When a workspace runs >1 worker (horizontal scale), in-process is insufficient. Swap the in-process map for Redis SET-NX locks with TTL refresh:
+
+```ts
+// Same withGroups() signature, Redis-backed
+const key = `nexaas:lock:${workspace}:${group}`;
+// SET key worker-id NX PX 60000, refresh every 30s, DEL on release
+```
+
+The runtime picks based on `NEXAAS_LOCK_BACKEND=memory|redis` (default `memory` for backward compat). Phoenix stays on memory for now; operator-managed deployments flip to redis.
+
+### 3.3 Manifest schema (Zod, `@nexaas/manifest`)
+
+```ts
+concurrency_groups: z.array(z.string().min(1).max(64)).optional()
+```
+
+No validation of values — strings are intentional opaqueness.
+
+### 3.4 Observability
+
+Two additions, neither blocking:
+
+1. WAL events `lock_acquired` / `lock_released` with `{ skill_id, run_id, group, wait_ms }`. Lets `nexaas doctor` surface contention: *"hr/stripe-billing-sync waited 47s on sqlite:data/onboarding.db (held by hr/engagement-sync)"*.
+2. `nexaas register-skill` warning when registering a skill into a group that already has another active member with an overlapping cron schedule. Pure ergonomics — no enforcement.
+
+## 4. Why not other approaches
+
+- **Per-skill BullMQ queue with `concurrency: 1`.** One queue per group works (BullMQ does support this via separate `Queue` instances), but doubles the operational surface (Bull Board, schedulers, repeat keys) and breaks the workspace-level rate limiter. In-process semaphore reuses the existing single queue.
+- **BullMQ `groupKey` (Pro feature).** Closed-source, license cost. Not available in OSS BullMQ.
+- **Job priority.** Solves "preempt", not "serialize." Long writers still block short ones.
+- **External advisory locks (Postgres `pg_advisory_lock`).** Adds a Postgres dependency for shell skills that have no other reason to touch Postgres. Redis is already required.
+
+## 5. Migration
+
+Backward-compatible, opt-in. Skills without `concurrency_groups` behave identically.
+
+Phoenix migration target (illustrative — workspace, not framework):
+
+```yaml
+# Every HR skill that opens data/onboarding.db
+concurrency_groups: [sqlite:data/onboarding.db]
+```
+
+Once landed, Phoenix removes its hand-staggered cron offsets (e.g. `23 */4` → `15 */4`) and lets the lock serialize.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Long-held locks starve short jobs | Same as today (busy_timeout). Group lock is FIFO, so starvation is bounded by queue depth, not unbounded. |
+| Deadlock on multi-group skills | Sorted acquisition order (3.1). |
+| Memory leak on the locks Map | GC on release when entry is the tail (3.1). |
+| Worker crash mid-lock | In-process locks die with the worker — no recovery needed. Redis backend uses TTL + heartbeat. |
+| Misuse: skill author over-declares groups, kills throughput | `nexaas doctor` surfaces high-wait groups. Cultural, not technical. |
+
+## 7. Out of scope
+
+- Cross-workspace locks (skills in workspace A serializing with skills in workspace B). YAGNI; workspaces are isolation units by design.
+- Priority within a group ("stripe-billing-sync goes before failure-monitor"). Add later if needed; FIFO covers 95%.
+- Distributed fairness across workers. Redis backend is naive SET-NX; if multi-worker fairness becomes a real ask, swap to Redlock or the BullMQ Pro group feature.
+
+## 8. Rollout
+
+1. Land `withGroups()` + manifest field behind no flag (it's opt-in by absence).
+2. Phoenix declares `sqlite:data/onboarding.db` on the eight HR skills that touch it.
+3. Watch one week of WAL `lock_acquired` events — confirm wait_ms p99 < 60s.
+4. Document the convention in `skill-authoring.md` §X.
+5. Phoenix removes the hand-staggered cron offsets.
+
+## 9. Open questions
+
+1. Should `nexaas register-skill` warn or **fail** on cron-overlap with same group? (Lean: warn — false positives are easy.)
+2. Default lock acquire timeout? (Lean: 5 min, matches the pillar pipeline ceiling.)
+3. Should an AI-skill's child agent calls inherit the parent's locks? (Lean: yes — implicit, same JS execution context.)

--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -96,6 +96,12 @@ export interface AiSkillManifest {
     max_consecutive_identical_tool_calls?: number;
     max_consecutive_errors?: number;
   };
+  /**
+   * Optional mutex groups. Skills declaring overlapping group names
+   * serialize within the worker; non-overlapping skills parallelize.
+   * See docs/rfcs/0001-skill-concurrency-groups.md.
+   */
+  concurrency_groups?: string[];
 }
 
 const DEFAULT_LIMITS: Required<Pick<AiSkillManifest, "limits">>["limits"] = {

--- a/packages/runtime/src/bullmq/worker.ts
+++ b/packages/runtime/src/bullmq/worker.ts
@@ -17,6 +17,7 @@ import type { SkillJobData } from "./queues.js";
 import { isRateLimitError, extractCooldownMs, pauseQueueFor } from "./rate-limit.js";
 import { startHeartbeatLoop, stopHeartbeatLoop } from "../fleet/heartbeat.js";
 import { shutdownMcpPool } from "../mcp/pool.js";
+import { withGroups } from "../concurrency-groups.js";
 import { readFileSync } from "fs";
 import { load as yamlLoad } from "js-yaml";
 import { randomUUID } from "crypto";
@@ -66,22 +67,46 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
           triggerPayload: data.triggerPayload,
         };
 
+        // RFC #95 — skill-declared concurrency groups serialize across
+        // shared resources (e.g. sqlite:data/onboarding.db). Skills
+        // without `concurrency_groups` bypass the semaphore entirely.
+        const groups = (manifest as { concurrency_groups?: string[] })
+          .concurrency_groups;
+        const lockMeta = {
+          workspace: data.workspace,
+          skillId: data.skillId,
+          runId: data.runId,
+        };
+
         if (execType === "shell") {
-          await runShellSkill(
-            data.workspace,
-            manifest as unknown as ShellSkillManifest,
-            executionContext,
+          await withGroups(
+            groups,
+            () =>
+              runShellSkill(
+                data.workspace,
+                manifest as unknown as ShellSkillManifest,
+                executionContext,
+              ),
+            lockMeta,
           );
           return;
         }
 
         if (execType === "ai-skill") {
+          // Hoist out of `jobData` so the closure passed to withGroups()
+          // doesn't lose TS narrowing across the function boundary.
+          const manifestPath = jobData.manifestPath;
           try {
-            await runAiSkill(
-              data.workspace,
-              manifest as unknown as AiSkillManifest,
-              jobData.manifestPath,
-              executionContext,
+            await withGroups(
+              groups,
+              () =>
+                runAiSkill(
+                  data.workspace,
+                  manifest as unknown as AiSkillManifest,
+                  manifestPath,
+                  executionContext,
+                ),
+              lockMeta,
             );
           } catch (err) {
             if (isRateLimitError(err)) {

--- a/packages/runtime/src/concurrency-groups.ts
+++ b/packages/runtime/src/concurrency-groups.ts
@@ -1,0 +1,97 @@
+/**
+ * Skill concurrency groups — declarative mutex on shared resources.
+ *
+ * Skills that touch the same backing resource (a SQLite DB, a vendor rate
+ * limit, a single-writer file) declare `concurrency_groups: [name]` in
+ * their manifest. The worker acquires every declared group lock before
+ * executing and releases all of them on completion or failure.
+ *
+ * Single-worker (default): in-process semaphore keyed on group name.
+ * Multi-worker: replace with Redis SET-NX + heartbeat (see RFC #95).
+ *
+ * See docs/rfcs/0001-skill-concurrency-groups.md for design.
+ */
+import { appendWal } from "@nexaas/palace";
+
+const locks = new Map<string, Promise<void>>();
+
+export interface LockMeta {
+  workspace?: string;
+  skillId?: string;
+  runId?: string;
+}
+
+/**
+ * Run `fn` with the named groups held as a serial lock. Multi-group
+ * acquisition uses sorted order to prevent deadlock between two skills
+ * that declare overlapping groups in different orders.
+ *
+ * Skills with no groups bypass the semaphore entirely (no overhead).
+ */
+export async function withGroups<T>(
+  groups: string[] | undefined,
+  fn: () => Promise<T>,
+  meta?: LockMeta,
+): Promise<T> {
+  if (!groups || groups.length === 0) return fn();
+
+  const sorted = [...new Set(groups)].sort();
+  const releases: Array<() => void> = [];
+
+  for (const group of sorted) {
+    const prev = locks.get(group) ?? Promise.resolve();
+    let releaseThis!: () => void;
+    const next = new Promise<void>((resolve) => {
+      releaseThis = resolve;
+    });
+    // Store `next` itself (not a chain) so the GC check on release can
+    // identify whether we're still the tail.
+    locks.set(group, next);
+
+    const waitStart = Date.now();
+    await prev;
+    const waitMs = Date.now() - waitStart;
+
+    if (meta?.workspace) {
+      void appendWal({
+        workspace: meta.workspace,
+        op: "lock_acquired",
+        actor: meta.skillId ? `skill:${meta.skillId}` : "concurrency-groups",
+        payload: {
+          group,
+          run_id: meta.runId,
+          skill_id: meta.skillId,
+          wait_ms: waitMs,
+        },
+      }).catch(() => {
+        /* WAL is best-effort — never block skill execution on observability */
+      });
+    }
+
+    releases.push(() => {
+      releaseThis();
+      // GC: if we're the tail (no one queued behind us), drop the entry.
+      if (locks.get(group) === next) locks.delete(group);
+      if (meta?.workspace) {
+        void appendWal({
+          workspace: meta.workspace,
+          op: "lock_released",
+          actor: meta.skillId ? `skill:${meta.skillId}` : "concurrency-groups",
+          payload: { group, run_id: meta.runId, skill_id: meta.skillId },
+        }).catch(() => {});
+      }
+    });
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Release in reverse order — symmetry with sorted acquire.
+    for (const release of releases.reverse()) release();
+  }
+}
+
+/** Test/diagnostic helper — exposes current lock holders. */
+export function _activeGroups(): string[] {
+  return Array.from(locks.keys());
+}

--- a/packages/runtime/src/concurrency-groups.ts
+++ b/packages/runtime/src/concurrency-groups.ts
@@ -9,6 +9,16 @@
  * Single-worker (default): in-process semaphore keyed on group name.
  * Multi-worker: replace with Redis SET-NX + heartbeat (see RFC #95).
  *
+ * **Lock lifetime is bounded by the worker process.** Locks live in-memory
+ * for the duration of the running worker — a clean shutdown or a crash
+ * releases every held lock implicitly via process exit, so a stuck lock
+ * cannot survive a restart. This is the right behavior for the single-
+ * worker case but means lock state is not durable across restarts:
+ * a skill mid-execution at shutdown does not "resume" holding the lock
+ * when the worker comes back, and the next caller acquires fresh.
+ * The phase-2 Redis backend (#97) will need explicit TTL + heartbeat
+ * cleanup to provide the same guarantee in a multi-worker deployment.
+ *
  * See docs/rfcs/0001-skill-concurrency-groups.md for design.
  */
 import { appendWal } from "@nexaas/palace";

--- a/packages/runtime/src/shell-skill.ts
+++ b/packages/runtime/src/shell-skill.ts
@@ -35,6 +35,12 @@ export interface ShellSkillManifest {
   rooms?: {
     primary?: { wing: string; hall: string; room: string };
   };
+  /**
+   * Optional mutex groups. Skills declaring overlapping group names
+   * serialize within the worker; non-overlapping skills parallelize.
+   * See docs/rfcs/0001-skill-concurrency-groups.md.
+   */
+  concurrency_groups?: string[];
 }
 
 export interface SkillExecutionContext {

--- a/scripts/test-concurrency-groups.mjs
+++ b/scripts/test-concurrency-groups.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env -S npx tsx
+// Smoke test for RFC #95 skill concurrency groups.
+// Run: npx tsx scripts/test-concurrency-groups.mjs
+//
+// Verifies:
+//  1. Empty groups → bypass (no serialization, no overhead)
+//  2. Single shared group → two callers serialize FIFO
+//  3. Two groups, opposite declaration order → no deadlock
+//  4. Lock released when the wrapped fn throws
+
+import { withGroups, _activeGroups } from "../packages/runtime/src/concurrency-groups.ts";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const log = [];
+const tag = (s) => log.push(`${(Date.now() - t0).toString().padStart(4)}ms ${s}`);
+const t0 = Date.now();
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`FAIL: ${msg}`);
+    console.error(log.join("\n"));
+    process.exit(1);
+  }
+}
+
+// 1. Empty groups bypass
+{
+  let ran = false;
+  await withGroups([], async () => {
+    ran = true;
+  });
+  assert(ran, "empty groups should still execute fn");
+  assert(_activeGroups().length === 0, "no locks held after empty-groups call");
+}
+
+// 2. Single shared group serializes
+{
+  const A = withGroups(["g1"], async () => {
+    tag("A start");
+    await sleep(50);
+    tag("A end");
+  });
+  const B = withGroups(["g1"], async () => {
+    tag("B start");
+    await sleep(50);
+    tag("B end");
+  });
+  await Promise.all([A, B]);
+  // A must fully complete before B starts
+  const aEnd = log.findIndex((l) => l.includes("A end"));
+  const bStart = log.findIndex((l) => l.includes("B start"));
+  assert(aEnd < bStart, "B started before A ended — group did not serialize");
+  assert(_activeGroups().length === 0, "locks leaked after single-group test");
+}
+
+// 3. Multi-group, opposite declaration order — no deadlock
+{
+  log.length = 0;
+  const X = withGroups(["alpha", "beta"], async () => {
+    tag("X work");
+    await sleep(40);
+  });
+  const Y = withGroups(["beta", "alpha"], async () => {
+    tag("Y work");
+    await sleep(40);
+  });
+  // Race ends if both complete; deadlock would hang past 5s.
+  const winner = await Promise.race([
+    Promise.all([X, Y]).then(() => "ok"),
+    sleep(5000).then(() => "deadlock"),
+  ]);
+  assert(winner === "ok", "two skills with opposite group declaration order deadlocked");
+  assert(_activeGroups().length === 0, "locks leaked after multi-group test");
+}
+
+// 4. Release on throw
+{
+  try {
+    await withGroups(["throwy"], async () => {
+      throw new Error("intentional");
+    });
+  } catch {
+    /* expected */
+  }
+  let ranAfter = false;
+  await withGroups(["throwy"], async () => {
+    ranAfter = true;
+  });
+  assert(ranAfter, "lock not released after fn threw — next caller starved");
+  assert(_activeGroups().length === 0, "locks leaked after throw");
+}
+
+console.log("OK — all 4 cases passed");
+console.log(log.join("\n"));


### PR DESCRIPTION
Closes phase 1 of #95.

## What this lands

- New manifest field `concurrency_groups?: string[]` on both shell- and ai-skill types. Optional — skills without the field bypass the semaphore entirely.
- `withGroups()` in `packages/runtime/src/concurrency-groups.ts` — single-worker in-process FIFO semaphore. ~95 LOC.
- Single integration point in `packages/runtime/src/bullmq/worker.ts` — wraps both `runShellSkill()` and `runAiSkill()` calls.
- WAL emits `lock_acquired` / `lock_released` events with `{ group, run_id, skill_id, wait_ms }` for `nexaas doctor` contention surfacing.
- Smoke test `scripts/test-concurrency-groups.mjs` (matches the repo's `stress-test-*.mjs` style — there's no test runner in this package).

## Why

Phoenix has hit `database is locked` on `data/onboarding.db` three times in the last month. Most recent: `hr/stripe-billing-sync` died on 2026-05-06 12:15 UTC, second consecutive run, blocked behind `engagement-sync`'s per-row HTTP+commit loop. Workaround today is hand-staggering crons by minute, which doesn't scale as the skill catalogue grows. Full motivation in #95 and `docs/rfcs/0001-skill-concurrency-groups.md`.

## Design highlights

- **Sorted multi-group acquire** prevents deadlock when two skills declare the same groups in opposite orders.
- **Tail-only GC** of the lock map: a release deletes the map entry only if it's still the tail, so concurrent acquirers don't lose their wait chain.
- **WAL is best-effort** — never blocks skill execution on observability writes.
- **Single integration site** keeps the executors themselves untouched. Easier to reason about, easier to revert.

## Verification

```
$ npx tsx scripts/test-concurrency-groups.mjs
OK — all 4 cases passed
 114ms X work
 160ms Y work

$ npx tsc --noEmit
(clean)
```

Smoke test cases:
1. Empty groups → bypass (no serialization)
2. Single shared group → two callers serialize FIFO
3. Two groups, opposite declaration order → no deadlock (both complete in ~80ms, not 5s timeout)
4. Lock released when the wrapped fn throws — next caller proceeds

## Out of scope (deferred)

- Redis SET-NX backend for multi-worker deployments. The `LockMeta` parameter on `withGroups()` and the WAL event shape are designed to make this a drop-in replacement. Tracked as phase 2 of #95.
- `nexaas register-skill` warning on cron-overlap with same group — pure ergonomics, can land separately.
- Zod schema for skill manifests — the repo doesn't have one yet (only `WorkspaceManifest`). When it lands, `concurrency_groups: z.array(z.string().min(1).max(64)).optional()`.

## Migration

Backward-compatible, opt-in. Phoenix migration plan (workspace-side, separate PR): declare `sqlite:data/onboarding.db` on the eight HR skills that touch it, then drop the hand-staggered cron offsets.

## Open questions for review

1. Should I also add a `nexaas doctor` reader for `lock_acquired` events in this PR, or land it separately? Leaning separately — easier to review.
2. The `_activeGroups()` export is a test-only diagnostic. Underscore-prefix is enough, or should it move behind a `NODE_ENV !== 'production'` gate?
3. Behavior on worker shutdown: in-process locks die with the process. Acceptable? (Redis backend will need TTL cleanup either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now declare concurrency groups to enforce mutual exclusion and prevent overlapping execution on shared resources.
  * Multiple concurrency groups per skill with automatic deadlock prevention.
  * Added observability for lock acquisition and release tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->