### PR TITLE
fix(notifications): render approval-request drawers into channel-shaped fields (#93)

### DIFF
--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -63,6 +63,81 @@ interface DispatchEnvelope {
 let _polling = false;
 let _interval: NodeJS.Timeout | null = null;
 
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Render an approval-request drawer into channel-shaped fields.
+ *
+ * TAG (#45 Stage 1a) writes approval drawers with structured fields
+ * (`summary`, `payload_full`, `payload_preview`, `decisions`) and no
+ * `content` — the dispatcher must translate them into something a
+ * channel adapter can render. Without this step the dispatcher forwards
+ * `content: ""` and Telegram (and presumably any adapter) rejects empty
+ * messages, retries 5×, and the approval prompt is never delivered (#93).
+ *
+ * Email-shape detection: when `payload_full` carries `{to, subject, body}`
+ * we render a proper email preview using `<blockquote>` for the body —
+ * not `<pre>`, because a code block makes prose unreadable and the
+ * JSON-stringified `payload_preview` shows literal `\n` and escaped
+ * quotes. Other payload shapes fall back to `<pre>{payload_preview}</pre>`.
+ *
+ * `decisions[{id, label}]` → `inline_buttons[{text: label, button_id: id}]`
+ * matches what `approval-resolver` validates against (`click.button_id`
+ * is checked against the recorded `decisionIds`).
+ */
+function renderApprovalRequest(envelope: DispatchEnvelope): {
+  content: string;
+  parse_mode: string;
+  inline_buttons?: Array<{ text: string; button_id: string }>;
+} {
+  const summary = typeof envelope.summary === "string" ? envelope.summary : "";
+  const payloadFull = envelope.payload_full as Record<string, unknown> | undefined;
+  const payloadPreview = typeof envelope.payload_preview === "string"
+    ? envelope.payload_preview
+    : "";
+
+  const isEmailPayload =
+    payloadFull != null &&
+    typeof payloadFull.to === "string" &&
+    typeof payloadFull.subject === "string" &&
+    typeof payloadFull.body === "string";
+
+  const lead = summary ? `${htmlEscape(summary)}\n\n` : "";
+  let content: string;
+  if (isEmailPayload && payloadFull != null) {
+    const to = htmlEscape(payloadFull.to as string);
+    const subject = htmlEscape(payloadFull.subject as string);
+    const body = htmlEscape(payloadFull.body as string);
+    content =
+      `${lead}` +
+      `<b>To:</b> ${to}\n` +
+      `<b>Subject:</b> ${subject}\n\n` +
+      `<blockquote>${body}</blockquote>`;
+  } else {
+    content = `${lead}<pre>${htmlEscape(payloadPreview)}</pre>`;
+  }
+
+  let buttons: Array<{ text: string; button_id: string }> | undefined;
+  const decisionsRaw = envelope.decisions;
+  if (Array.isArray(decisionsRaw)) {
+    buttons = decisionsRaw
+      .filter((d): d is { id?: unknown; label?: unknown } => d !== null && typeof d === "object")
+      .map((d) => ({
+        text: typeof d.label === "string" ? d.label : String(d.id ?? "?"),
+        button_id: typeof d.id === "string" ? d.id : String(d.id ?? ""),
+      }))
+      .filter((b) => b.button_id !== "");
+    if (buttons.length === 0) buttons = undefined;
+  }
+
+  return { content, parse_mode: "HTML", inline_buttons: buttons };
+}
+
 function parseEnvelope(content: string): DispatchEnvelope | null {
   try {
     const parsed = JSON.parse(content) as Record<string, unknown>;
@@ -179,10 +254,27 @@ async function dispatchViaMcp(
     // through as-is — channel adapters may use it (e.g., Telegram
     // disable_notification) but the framework doesn't touch it.
     // `to` is derived from binding.config if the envelope didn't supply one.
+    //
+    // Approval-request drawers (#45 Stage 1a) carry no `content` — TAG
+    // writes structured fields and expects the dispatcher to render them.
+    // Without this branch the adapter receives `content: ""` and rejects
+    // the send; see #93.
+    const renderedApproval =
+      envelope.kind === "approval_request" && !envelope.content
+        ? renderApprovalRequest(envelope)
+        : null;
+
     const sendInput: Record<string, unknown> = {
       to: envelope.to ?? binding.config?.to ?? binding.config?.chat_id ?? binding.config?.channel,
-      content: envelope.content ?? "",
+      content: renderedApproval ? renderedApproval.content : (envelope.content ?? ""),
     };
+    if (renderedApproval) {
+      sendInput.parse_mode = renderedApproval.parse_mode;
+      if (renderedApproval.inline_buttons) {
+        sendInput.inline_buttons = renderedApproval.inline_buttons;
+      }
+    }
+    // Envelope-supplied overrides win over rendered defaults.
     if (envelope.parse_mode != null) sendInput.parse_mode = envelope.parse_mode;
     if (envelope.inline_buttons) sendInput.inline_buttons = envelope.inline_buttons;
     if (envelope.reply_to != null) sendInput.reply_to = envelope.reply_to;
@@ -194,8 +286,9 @@ async function dispatchViaMcp(
       // TAG approval-request drawer fields (#45 Stage 1a) — don't forward
       // these to the MCP; they're for the subscriber's own context.
       "kind", "run_id", "step_id", "waitpoint_signal", "output_id",
-      "summary", "payload_preview", "decisions", "channel_kind",
-      "channel_mcp", "channel_config", "on_timeout",
+      "summary", "payload_preview", "payload_full", "decisions",
+      "handlers", "skill_id", "channel_kind", "channel_mcp",
+      "channel_config", "on_timeout",
     ]);
     for (const [k, v] of Object.entries(envelope)) {
       if (!reserved.has(k)) sendInput[k] = v;
@@ -382,6 +475,13 @@ export function startNotificationDispatcher(
 
   console.log(`[nexaas] Notification dispatcher started (polling every ${interval / 1000}s)`);
 }
+
+/**
+ * Test-only export of the approval-request renderer. Underscore prefix
+ * marks it as not part of the public surface; consumers should not rely
+ * on this. See `scripts/test-approval-render-93.mjs` for usage.
+ */
+export const _renderApprovalRequest = renderApprovalRequest;
 
 export function stopNotificationDispatcher(): void {
   if (_interval) {

--- a/scripts/test-approval-render-93.mjs
+++ b/scripts/test-approval-render-93.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #93 — notification-dispatcher must render
+ * approval-request drawers (kind: "approval_request") into channel-shaped
+ * fields. Under the pre-fix code the dispatcher forwarded `content: ""`
+ * and Telegram rejected the message with HTTP 400.
+ *
+ * Run from repo root: `node scripts/test-approval-render-93.mjs`
+ * No database, no network — pure unit-style assertions.
+ */
+
+import { _renderApprovalRequest } from "@nexaas/runtime/tasks/notification-dispatcher";
+
+let pass = 0, fail = 0;
+
+function assert(cond, label) {
+  if (cond) {
+    console.log(`OK    ${label}`);
+    pass++;
+  } else {
+    console.log(`FAIL  ${label}`);
+    fail++;
+  }
+}
+
+// 1. Email-shape payload renders with To/Subject labels and blockquote body.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k1",
+    channel_role: "pa_reply_mireille",
+    kind: "approval_request",
+    summary: "Mireille drafted a reply about Friday tasting",
+    payload_full: {
+      to: "joanne@example.com",
+      subject: "Re: Friday tasting",
+      body: "Hi Joanne, thanks for confirming. We have your spot held...",
+      in_reply_to: "<msg-id@example.com>",
+    },
+    payload_preview: "{\"to\":\"joanne@example.com\",\"subject\":\"Re: Friday tasting\",\"body\":\"Hi Joanne...\"}",
+    decisions: [
+      { id: "approve", label: "Approve" },
+      { id: "edit", label: "Edit" },
+      { id: "reject", label: "Reject" },
+    ],
+  });
+  assert(r.parse_mode === "HTML", "email-shape: parse_mode is HTML");
+  assert(r.content.includes("<b>To:</b> joanne@example.com"), "email-shape: To label");
+  assert(r.content.includes("<b>Subject:</b> Re: Friday tasting"), "email-shape: Subject label");
+  assert(r.content.includes("<blockquote>Hi Joanne"), "email-shape: body wrapped in blockquote");
+  assert(!r.content.includes("<pre>"), "email-shape: no <pre> block");
+  assert(r.content.startsWith("Mireille drafted a reply"), "email-shape: summary leads");
+  assert(r.inline_buttons?.length === 3, "email-shape: 3 inline_buttons");
+  assert(r.inline_buttons?.[0]?.button_id === "approve", "email-shape: button_id matches decision id");
+  assert(r.inline_buttons?.[0]?.text === "Approve", "email-shape: button text matches decision label");
+}
+
+// 2. Non-email payload falls back to <pre>{payload_preview}</pre>.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k2",
+    channel_role: "ops_review",
+    kind: "approval_request",
+    summary: "Onboarding step 3 awaiting review",
+    payload_preview: "{\"step\":\"verify_dba\",\"client\":\"acme\"}",
+    decisions: [{ id: "approve", label: "Approve" }],
+  });
+  assert(r.content.includes("<pre>"), "non-email: uses <pre>");
+  assert(!r.content.includes("<blockquote>"), "non-email: no blockquote");
+  assert(r.content.includes("verify_dba"), "non-email: payload_preview escaped & embedded");
+}
+
+// 3. HTML metacharacters in user input are escaped.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k3",
+    channel_role: "x",
+    kind: "approval_request",
+    summary: "<script>alert(1)</script>",
+    payload_full: {
+      to: "user@example.com",
+      subject: "<img onerror=alert(1)>",
+      body: "evil & dangerous <b>injected</b>",
+    },
+  });
+  assert(!r.content.includes("<script>"), "escape: <script> tag escaped");
+  assert(!r.content.includes("<img onerror"), "escape: <img onerror> escaped");
+  assert(r.content.includes("&lt;script&gt;"), "escape: < and > entitied");
+  assert(r.content.includes("evil &amp; dangerous"), "escape: ampersand entitied");
+  assert(r.content.includes("&lt;b&gt;injected&lt;/b&gt;"), "escape: nested tags entitied in body");
+}
+
+// 4. Missing summary → content has no lead-in but still renders payload.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k4",
+    channel_role: "x",
+    kind: "approval_request",
+    payload_full: { to: "a@b.c", subject: "S", body: "B" },
+  });
+  assert(!r.content.startsWith("\n"), "no-summary: no leading newline");
+  assert(r.content.startsWith("<b>To:</b>"), "no-summary: starts with To label");
+}
+
+// 5. Missing decisions → no inline_buttons in output.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k5",
+    channel_role: "x",
+    kind: "approval_request",
+    summary: "no buttons",
+    payload_preview: "{}",
+  });
+  assert(r.inline_buttons === undefined, "no-decisions: inline_buttons undefined");
+}
+
+// 6. Empty decisions array → no inline_buttons.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k6",
+    channel_role: "x",
+    kind: "approval_request",
+    summary: "empty array",
+    payload_preview: "{}",
+    decisions: [],
+  });
+  assert(r.inline_buttons === undefined, "empty-decisions: inline_buttons undefined");
+}
+
+// 7. Decisions missing label → falls back to id as button text.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k7",
+    channel_role: "x",
+    kind: "approval_request",
+    payload_preview: "{}",
+    decisions: [{ id: "go" }],
+  });
+  assert(r.inline_buttons?.[0]?.text === "go", "missing-label: text falls back to id");
+}
+
+// 8. Decisions with non-string id are coerced via String() and dropped if empty.
+{
+  const r = _renderApprovalRequest({
+    idempotency_key: "k8",
+    channel_role: "x",
+    kind: "approval_request",
+    payload_preview: "{}",
+    decisions: [{ id: 7, label: "Seven" }, { id: "", label: "Empty" }],
+  });
+  assert(r.inline_buttons?.length === 1, "coerce-id: keeps numeric id, drops empty");
+  assert(r.inline_buttons?.[0]?.button_id === "7", "coerce-id: numeric id stringified");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #93.

## Summary

Approval-request drawers (TAG #45 Stage 1a) carry structured fields (`summary`, `payload_full`, `payload_preview`, `decisions`) and no `content`. The pre-fix dispatcher forwarded `content: envelope.content ?? ""` and the channel adapter rejected the empty message — Telegram returns HTTP 400. Five retries, all fail identically, approval prompt never delivered. The PA appeared silent to the user even though the underlying skill ran successfully.

## What changes

**New `renderApprovalRequest(envelope)` helper** translates the structured drawer into `{content, parse_mode: "HTML", inline_buttons}`:

- **Email-shape detection** — `payload_full` has `{to, subject, body}` → render with `<b>To:</b>` / `<b>Subject:</b>` labels and `<blockquote>` for the body. Not `<pre>` — code blocks make prose unreadable, and the JSON-stringified `payload_preview` shows literal `\n` and escaped quotes.
- **Non-email fallback** — `<pre>{payload_preview}</pre>`.
- **`decisions[{id, label}]` → `inline_buttons[{text: label, button_id: id}]`** matching what `approval-resolver` checks (`click.button_id` against the recorded `decisionIds`).
- **HTML escaping** for all user-controlled fields (summary, body, subject, payload_preview) — prevents injection into the rendered Telegram HTML.

**`dispatchViaMcp` detection** — when `envelope.kind === "approval_request" && !envelope.content`, the renderer's defaults are used. Envelope-supplied `parse_mode` / `inline_buttons` / `content` still win over rendered defaults; caller knows best.

**Reserved-key set extended** with `payload_full`, `handlers`, `skill_id` so they don't leak through as freeform MCP arguments. The other TAG-internal fields (`summary`, `payload_preview`, `decisions`, etc.) were already reserved.

**Test-only export** — `_renderApprovalRequest` (underscore-prefixed, matching #96's `_activeGroups` convention) so the regression test can exercise the renderer without DB or network setup.

## Verification

- **`scripts/test-approval-render-93.mjs`** — 24 cases all pass:
  - Email-shape rendering (To/Subject labels, blockquote body, summary lead, button mapping)
  - Non-email fallback (`<pre>` block, no blockquote)
  - HTML escaping (`<script>`, `<img onerror>`, ampersand, nested tags in body)
  - Missing-summary, missing-decisions, empty-decisions, missing-label
  - Numeric-id coercion
- **`tsc --noEmit` clean**
- **Live-tested on Phoenix canary** (per the issue body) — Mireille's PA delivered the approval prompt with proper formatting and working Approve / Edit / Reject buttons.

## Test plan

- [ ] `node --import tsx scripts/test-approval-render-93.mjs` → 24/24 pass
- [ ] Trigger an `approval_required` output through any AI skill and verify the channel receives a properly-formatted message with working buttons
- [ ] Verify HTML metacharacters in skill output (someone tries to inject `<b>` in their email body) are rendered escaped, not interpreted

## Related

#94 — stuck-`claimed` rows after worker restart, sister bug from the same Phoenix incident — follows in a separate PR stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)