### PR TITLE
fix(notifications): reap stuck-'claimed' rows after worker death (#94)

### DIFF
--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -31,6 +31,14 @@ const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const MAX_ATTEMPTS = 5;
 const POLL_BATCH_SIZE = 25;
 const MCP_CALL_TIMEOUT_MS = 15_000;
+/**
+ * How long a `claimed` row may sit before the reaper considers the
+ * original claimer dead and resets it to `failed` for retry. Must
+ * comfortably exceed `MCP_CALL_TIMEOUT_MS` plus typical worker-restart
+ * latency. See #94. Two minutes leaves headroom for slow MCP responses
+ * and orderly systemd restarts without false positives.
+ */
+const STALE_CLAIM_INTERVAL = "2 minutes";
 
 interface PendingDrawer {
   id: string;
@@ -146,6 +154,32 @@ function parseEnvelope(content: string): DispatchEnvelope | null {
     }
     return parsed as unknown as DispatchEnvelope;
   } catch { return null; }
+}
+
+/**
+ * Reset stuck-`claimed` rows back to `failed` so the normal retry path
+ * picks them up. See #94 — when the worker is restarted (or crashed)
+ * mid-dispatch, the row is left at `status='claimed'` indefinitely
+ * because the in-flight MCP `send` was killed before the dispatcher's
+ * try/finally reached `markDelivered` / `markFailed`. `selectPending`
+ * only considers `NULL` or `failed` rows, so stuck `claimed` rows are
+ * invisible to subsequent polls without this sweep.
+ *
+ * Returns the number of rows reaped (for the WAL emit). Best-effort —
+ * a single failed sweep doesn't halt the rest of the tick.
+ */
+async function reapStaleClaims(workspace: string): Promise<number> {
+  const reaped = await sql<{ idempotency_key: string }>(
+    `UPDATE nexaas_memory.notification_dispatches
+        SET status = 'failed',
+            last_error = COALESCE(last_error, $2)
+      WHERE workspace = $1
+        AND status = 'claimed'
+        AND claimed_at < now() - INTERVAL '${STALE_CLAIM_INTERVAL}'
+      RETURNING idempotency_key`,
+    [workspace, "reaped: claimed row exceeded stale threshold"],
+  );
+  return reaped.length;
 }
 
 async function selectPending(workspace: string): Promise<PendingDrawer[]> {
@@ -346,7 +380,27 @@ async function writeOutcomeDrawer(
 export async function dispatchPendingNotifications(
   workspace: string,
   workspaceManifest: WorkspaceManifest | null,
-): Promise<{ dispatched: number; failed: number; skipped: number }> {
+): Promise<{ dispatched: number; failed: number; skipped: number; reaped: number }> {
+  // Reap stuck-`claimed` rows from prior worker deaths (#94) before the
+  // poll, so they become eligible for `selectPending` on this same tick
+  // rather than waiting another interval.
+  let reaped = 0;
+  try {
+    reaped = await reapStaleClaims(workspace);
+    if (reaped > 0) {
+      await appendWal({
+        workspace,
+        op: "notification_reaped",
+        actor: "notification-dispatcher",
+        payload: { count: reaped, threshold: STALE_CLAIM_INTERVAL },
+      });
+    }
+  } catch (err) {
+    // Best-effort: log but don't halt the tick. A failed reap leaves
+    // stale rows for the next interval to clean up.
+    console.error("[nexaas] notification reaper error:", err);
+  }
+
   const pending = await selectPending(workspace);
   let dispatched = 0, failed = 0, skipped = 0;
 
@@ -443,7 +497,7 @@ export async function dispatchPendingNotifications(
     }
   }
 
-  return { dispatched, failed, skipped };
+  return { dispatched, failed, skipped, reaped };
 }
 
 export function startNotificationDispatcher(
@@ -460,9 +514,9 @@ export function startNotificationDispatcher(
       // Fresh manifest read each tick — framework fail-open per #41.
       const { manifest } = await loadWorkspaceManifest(workspace);
       const result = await dispatchPendingNotifications(workspace, manifest);
-      if (result.dispatched > 0 || result.failed > 0) {
+      if (result.dispatched > 0 || result.failed > 0 || result.reaped > 0) {
         console.log(
-          `[nexaas] Notification dispatcher: ${result.dispatched} delivered, ${result.failed} failed, ${result.skipped} skipped`,
+          `[nexaas] Notification dispatcher: ${result.dispatched} delivered, ${result.failed} failed, ${result.skipped} skipped, ${result.reaped} reaped`,
         );
       }
     } catch (err) {
@@ -482,6 +536,12 @@ export function startNotificationDispatcher(
  * on this. See `scripts/test-approval-render-93.mjs` for usage.
  */
 export const _renderApprovalRequest = renderApprovalRequest;
+
+/**
+ * Test-only export of the stale-claim reaper. Same convention as above.
+ * See `scripts/test-stale-claim-reaper-94.mjs` for usage.
+ */
+export const _reapStaleClaims = reapStaleClaims;
 
 export function stopNotificationDispatcher(): void {
   if (_interval) {

--- a/scripts/test-stale-claim-reaper-94.mjs
+++ b/scripts/test-stale-claim-reaper-94.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #94 — stuck-`claimed` rows after worker restart.
+ *
+ * Inserts representative rows into notification_dispatches, runs the
+ * reaper, and verifies only the stale-`claimed` row is reset to `failed`
+ * with the reaper message. Fresh claims, delivered rows, and already-
+ * failed rows must be untouched.
+ *
+ * Requires DATABASE_URL pointing at a Nexaas-bootstrapped Postgres.
+ * Run from repo root: `node scripts/test-stale-claim-reaper-94.mjs`
+ * Cleanup at end removes only this run's rows.
+ */
+
+import { sql } from "@nexaas/palace";
+import { _reapStaleClaims } from "@nexaas/runtime/tasks/notification-dispatcher";
+
+const WORKSPACE = `reaper-test-${Date.now()}-${process.pid}`;
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) {
+    console.log(`OK    ${label}`);
+    pass++;
+  } else {
+    console.log(`FAIL  ${label}`);
+    fail++;
+  }
+}
+
+async function fetchRow(idemKey) {
+  const rows = await sql(
+    `SELECT status, last_error
+       FROM nexaas_memory.notification_dispatches
+      WHERE workspace = $1 AND idempotency_key = $2`,
+    [WORKSPACE, idemKey],
+  );
+  return rows[0];
+}
+
+async function insertRow({ idemKey, status, claimedAtOffsetMin, lastError }) {
+  await sql(
+    `INSERT INTO nexaas_memory.notification_dispatches
+        (workspace, idempotency_key, channel_role, status, attempts,
+         claimed_at, last_error)
+     VALUES ($1, $2, 'test_role', $3, 1,
+             now() + ($4 || ' minutes')::interval, $5)`,
+    [WORKSPACE, idemKey, status, String(claimedAtOffsetMin), lastError ?? null],
+  );
+}
+
+try {
+  // Setup: four representative rows.
+  await insertRow({ idemKey: "stale-claim",   status: "claimed",   claimedAtOffsetMin: -5,  lastError: null });
+  await insertRow({ idemKey: "fresh-claim",   status: "claimed",   claimedAtOffsetMin: -1,  lastError: null });   // -1min < 2min threshold → not eligible
+  await insertRow({ idemKey: "borderline",    status: "claimed",   claimedAtOffsetMin: -3,  lastError: null });
+  await insertRow({ idemKey: "delivered-row", status: "delivered", claimedAtOffsetMin: -10, lastError: null });
+  await insertRow({ idemKey: "failed-row",    status: "failed",    claimedAtOffsetMin: -10, lastError: "earlier failure" });
+
+  // Run the reaper.
+  const reaped = await _reapStaleClaims(WORKSPACE);
+  assert(reaped === 2, `reaped count = 2 (stale-claim + borderline), got ${reaped}`);
+
+  // Assert each row's post-state.
+  const stale = await fetchRow("stale-claim");
+  assert(stale?.status === "failed", "stale-claim: status now 'failed'");
+  assert(
+    typeof stale?.last_error === "string" && stale.last_error.startsWith("reaped:"),
+    "stale-claim: last_error has reaper marker",
+  );
+
+  const borderline = await fetchRow("borderline");
+  assert(borderline?.status === "failed", "borderline (3min old): also reaped");
+
+  const fresh = await fetchRow("fresh-claim");
+  assert(fresh?.status === "claimed", "fresh-claim (1min old): still claimed (under threshold)");
+  assert(fresh?.last_error === null, "fresh-claim: last_error untouched");
+
+  const delivered = await fetchRow("delivered-row");
+  assert(delivered?.status === "delivered", "delivered-row: still delivered (wrong status for reaper)");
+
+  const previouslyFailed = await fetchRow("failed-row");
+  assert(previouslyFailed?.status === "failed", "failed-row: still failed");
+  assert(previouslyFailed?.last_error === "earlier failure", "failed-row: last_error preserved (reaper used COALESCE)");
+
+  // Idempotency: running again should reap nothing (no claimed rows left).
+  const secondRun = await _reapStaleClaims(WORKSPACE);
+  assert(secondRun === 0, "second sweep is a no-op");
+} finally {
+  // Cleanup — remove this run's rows regardless of pass/fail.
+  await sql(
+    `DELETE FROM nexaas_memory.notification_dispatches WHERE workspace = $1`,
+    [WORKSPACE],
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #94. Stacks on #100 (fix #93).

## Summary

When the nexaas-worker is restarted or crashes mid-dispatch, the `notification_dispatches` row is left at `status='claimed'` indefinitely. `selectPending` only considers `status IS NULL OR (status='failed' AND attempts < MAX)`, so a stuck claimed row is invisible to subsequent polls and the drawer is never delivered. Recovery required manual SQL `DELETE` — discovered live during #93 recovery on the Phoenix canary.

## What changes

**New `reapStaleClaims(workspace)`** runs at the top of each poll tick (before `selectPending`) and resets rows where `status='claimed' AND claimed_at < now() - INTERVAL '2 minutes'` to `status='failed'` with `last_error = 'reaped: claimed row exceeded stale threshold'`. The reaper uses `COALESCE(last_error, 'reaped: ...')` so it never overwrites a previously-recorded failure diagnostic — only stamps when `last_error` is currently NULL (the worker-died case, by definition).

**2-minute threshold** (`STALE_CLAIM_INTERVAL` constant) comfortably exceeds `MCP_CALL_TIMEOUT_MS` (15s) plus typical systemd restart latency. Tunable later if needed.

**Why explicit reaper, not broadening `selectPending`:**

- Leaves an explicit audit trail in `last_error`
- Emits a `notification_reaped` WAL event for oncall visibility
- Doesn't risk a race where the original worker comes back to life and double-dispatches against a row the new worker already re-claimed
- Reaped rows fall back into the normal `failed AND attempts < MAX` retry path → they don't bypass the attempts counter, so a chronically-failing drawer can't get unlimited retries from repeated reaps

**Best-effort error handling** — a failed reap call logs and moves on rather than aborting the tick. Next interval retries. Worst case is the row stays stuck one extra interval (5s).

**Dispatcher result type extended** with `reaped: number`. The periodic log line surfaces it alongside delivered/failed/skipped counts so oncall sees recovery activity without trawling WAL.

**Test-only `_reapStaleClaims` export** — underscore-prefixed, matching the convention from #93's `_renderApprovalRequest` and #96's `_activeGroups`.

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-stale-claim-reaper-94.mjs`** covers six cases:
  - Stale claim (5min old) → reaped
  - Borderline claim (3min old) → reaped (past threshold)
  - Fresh claim (1min old) → untouched
  - Delivered row → untouched (wrong status for reaper)
  - Already-failed row with prior `last_error` → status preserved, `last_error` preserved (COALESCE behavior)
  - Idempotency: second sweep is a no-op

  Test requires `DATABASE_URL` — runs the same way as `stress-test-71.mjs` (real DB, framework-bootstrapped workspace, cleanup in `finally`). I couldn't run it locally (this dev box has no DB); ready to verify against Phoenix or BSBC's DB on next run.

## Test plan

- [ ] On Phoenix (or BSBC), run `node --import tsx scripts/test-stale-claim-reaper-94.mjs` against the workspace DB → 8/8 pass
- [ ] Force a stuck-`claimed` row by `kill -9` on the worker mid-dispatch (or `systemctl restart nexaas-worker` while a `send` is in flight to a slow MCP), verify the row stays `claimed` on `main`, then apply this patch and verify the row is reaped to `failed` after ~2 min and re-attempted
- [ ] Verify the periodic log line surfaces `N reaped` after a reaper run

## Stack

\`main\` ← #100 (#93) ← **this**

Will retarget to `main` automatically as #100 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)