### PR TITLE
fix(cli): register-skill polish — --help, bulk command, path hint (#87)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,9 @@ switch (command) {
   case "register-skill":
     import("./register-skill.js").then((m) => m.run(process.argv.slice(3)));
     break;
+  case "register-skills":
+    import("./register-skills.js").then((m) => m.run(process.argv.slice(3)));
+    break;
   case "trigger-skill":
     import("./trigger-skill.js").then((m) => m.run(process.argv.slice(3)));
     break;
@@ -75,6 +78,7 @@ Commands:
   init --workspace <id>                 Set up Nexaas on this VPS
   onboard --workspace <path> --id <id>  Discover and register a workspace
   register-skill <path-to-skill.yaml>  Register a skill with the scheduler
+  register-skills [<dir>]              Bulk-register every skill.yaml under <dir>
   library list|contribute|install|diff|promote  Skill library management
   propagate check|push|accept|reject   Skill update propagation
   alerts [test|config]                 View and manage notifications

--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -2,18 +2,24 @@
  * nexaas register-skill — register a skill manifest with the BullMQ scheduler.
  *
  * Usage:
- *   nexaas register-skill /path/to/skill.yaml
+ *   nexaas register-skill <path-to-skill.yaml>
  *
  * Reads the manifest, registers cron triggers with BullMQ, and confirms.
+ *
+ * The core registration logic lives in `registerOneSkill()` and is reused
+ * by `register-skills.ts` for bulk operation. Everything that's expensive
+ * to set up — the Redis/BullMQ connection, the workspace timezone lookup —
+ * is passed in by the caller so a bulk run does it once for N manifests.
  */
 
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
 import { execSync } from "child_process";
 import { load as yamlLoad } from "js-yaml";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 
-interface SkillManifest {
+export interface SkillManifest {
   id: string;
   version: string;
   description?: string;
@@ -31,10 +37,182 @@ interface SkillManifest {
   };
 }
 
+export interface RegisterContext {
+  queue: Queue;
+  workspace: string;
+  workspaceTz: string;
+}
+
+export interface RegisterResult {
+  skillId: string;
+  version: string;
+  registered: number;
+  cleaned: number;
+  status: "registered" | "no-triggers" | "error";
+  error?: string;
+}
+
+const USAGE = `\
+Usage: nexaas register-skill <path-to-skill.yaml>
+
+Registers a skill manifest with the BullMQ scheduler. Reads the manifest,
+upserts every cron trigger as a repeatable BullMQ job, and prints a
+confirmation. Existing repeatables for the same skill ID are cleaned up
+before the new one is upserted.
+
+Bulk equivalent:
+  nexaas register-skills <dir>           Register every skill.yaml under <dir>
+
+Required env: NEXAAS_WORKSPACE
+Optional env: REDIS_URL (default redis://localhost:6379), DATABASE_URL
+              (for workspace-scoped timezone lookup)
+`;
+
+function printUsage(): void {
+  process.stdout.write(USAGE);
+}
+
+/**
+ * Resolve the workspace's preferred timezone from `nexaas_memory.workspace_config`.
+ * Used as the default for cron triggers that don't pin their own. Hoisted out
+ * of the per-skill loop so the bulk command pays the psql cost exactly once.
+ */
+export function resolveWorkspaceTimezone(workspace: string): string {
+  try {
+    const dbUrl = process.env.DATABASE_URL ?? "";
+    if (!dbUrl) return "UTC";
+    const result = execSync(
+      `psql "${dbUrl}" -c "SELECT timezone FROM nexaas_memory.workspace_config WHERE workspace = '${workspace}'" -t -A 2>/dev/null`,
+      { encoding: "utf-8", stdio: "pipe" },
+    ).trim();
+    return result || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Register a single skill manifest. Pass a shared `RegisterContext` so a
+ * bulk caller can reuse the Redis connection and workspace timezone lookup.
+ *
+ * Returns a structured result; never throws for normal manifest issues
+ * (missing file, bad YAML, no triggers) — those land in `result.error`
+ * so a bulk run can summarize the outcome instead of aborting on the
+ * first bad manifest.
+ */
+export async function registerOneSkill(
+  manifestPath: string,
+  ctx: RegisterContext,
+): Promise<RegisterResult> {
+  if (!existsSync(manifestPath)) {
+    return {
+      skillId: manifestPath,
+      version: "?",
+      registered: 0,
+      cleaned: 0,
+      status: "error",
+      error: `manifest not found at '${manifestPath}' — pass an absolute path or run from $NEXAAS_WORKSPACE_ROOT`,
+    };
+  }
+
+  let manifest: SkillManifest;
+  try {
+    const content = readFileSync(manifestPath, "utf-8");
+    manifest = yamlLoad(content) as SkillManifest;
+    if (!manifest?.id || !manifest?.version) {
+      return {
+        skillId: manifestPath,
+        version: "?",
+        registered: 0,
+        cleaned: 0,
+        status: "error",
+        error: "manifest missing required `id` or `version`",
+      };
+    }
+  } catch (err) {
+    return {
+      skillId: manifestPath,
+      version: "?",
+      registered: 0,
+      cleaned: 0,
+      status: "error",
+      error: `parse error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let registered = 0;
+  let cleaned = 0;
+
+  if (!manifest.triggers || manifest.triggers.length === 0) {
+    return {
+      skillId: manifest.id,
+      version: manifest.version,
+      registered: 0,
+      cleaned: 0,
+      status: "no-triggers",
+    };
+  }
+
+  for (const trigger of manifest.triggers) {
+    if (trigger.type !== "cron" || !trigger.schedule) continue;
+
+    const jobName = `cron-${manifest.id.replace(/\//g, "-")}`;
+    const tz =
+      trigger.timezone ??
+      manifest.timezone ??
+      ctx.workspaceTz ??
+      process.env.NEXAAS_TIMEZONE ??
+      "UTC";
+
+    // Remove any legacy repeatable entries for this skill (#22).
+    try {
+      const existing = await ctx.queue.getRepeatableJobs();
+      const stale = existing.filter((j) => j.name === jobName);
+      for (const j of stale) {
+        await ctx.queue.removeRepeatableByKey(j.key);
+      }
+      cleaned += stale.length;
+    } catch { /* non-fatal */ }
+
+    await ctx.queue.upsertJobScheduler(
+      jobName,
+      { pattern: trigger.schedule, tz },
+      {
+        name: "skill-step",
+        data: {
+          workspace: ctx.workspace,
+          skillId: manifest.id,
+          skillVersion: manifest.version,
+          stepId: manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec",
+          triggerType: "cron",
+          manifestPath,
+        },
+      },
+    );
+
+    registered++;
+  }
+
+  return {
+    skillId: manifest.id,
+    version: manifest.version,
+    registered,
+    cleaned,
+    status: registered > 0 ? "registered" : "no-triggers",
+  };
+}
+
 export async function run(args: string[]) {
+  // Help flag — pre-#87 this crashed because args[0] was passed straight
+  // to readFileSync as a manifest path.
+  if (args[0] === "--help" || args[0] === "-h") {
+    printUsage();
+    return;
+  }
+
   const manifestPath = args[0];
   if (!manifestPath) {
-    console.error("Usage: nexaas register-skill <path-to-skill.yaml>");
+    console.error(USAGE);
     process.exit(1);
   }
 
@@ -44,78 +222,40 @@ export async function run(args: string[]) {
     process.exit(1);
   }
 
-  const content = readFileSync(manifestPath, "utf-8");
-  const manifest = yamlLoad(content) as SkillManifest;
-
-  console.log(`\n  Registering skill: ${manifest.id} v${manifest.version}`);
-  if (manifest.description) console.log(`  Description: ${manifest.description}`);
+  // Resolve relative paths against $NEXAAS_WORKSPACE_ROOT when set, so
+  // `nexaas register-skill nexaas-skills/foo/skill.yaml` works regardless
+  // of the caller's cwd. Adopters were hitting this from automation scripts.
+  const resolved =
+    manifestPath.startsWith("/") || !process.env.NEXAAS_WORKSPACE_ROOT
+      ? manifestPath
+      : resolve(process.env.NEXAAS_WORKSPACE_ROOT, manifestPath);
 
   const connection = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
     maxRetriesPerRequest: null,
     enableReadyCheck: false,
   });
+  const queue = new Queue(`nexaas-skills-${workspace}`, { connection });
+  const workspaceTz = resolveWorkspaceTimezone(workspace);
 
-  const queueName = `nexaas-skills-${workspace}`;
-  const queue = new Queue(queueName, { connection });
+  try {
+    const result = await registerOneSkill(resolved, { queue, workspace, workspaceTz });
 
-  let registered = 0;
-
-  if (manifest.triggers) {
-    for (const trigger of manifest.triggers) {
-      if (trigger.type === "cron" && trigger.schedule) {
-        const jobName = `cron-${manifest.id.replace(/\//g, "-")}`;
-
-        // Timezone resolution: trigger → manifest → workspace config → env var → UTC
-        let workspaceTz = "UTC";
-        try {
-          const dbUrl = process.env.DATABASE_URL ?? "";
-          const result = execSync(
-            `psql "${dbUrl}" -c "SELECT timezone FROM nexaas_memory.workspace_config WHERE workspace = '${workspace}'" -t -A 2>/dev/null`,
-            { encoding: "utf-8", stdio: "pipe" },
-          ).trim();
-          if (result) workspaceTz = result;
-        } catch { /* use default */ }
-
-        const tz = trigger.timezone ?? manifest.timezone ?? workspaceTz ?? process.env.NEXAAS_TIMEZONE ?? "UTC";
-
-        // Remove any legacy repeatable entries for this skill (#22)
-        try {
-          const existing = await queue.getRepeatableJobs();
-          const stale = existing.filter(j => j.name === jobName);
-          for (const j of stale) {
-            await queue.removeRepeatableByKey(j.key);
-          }
-          if (stale.length > 0) {
-            console.log(`  Cleaned ${stale.length} legacy repeatable(s) for ${jobName}`);
-          }
-        } catch { /* non-fatal */ }
-
-        await queue.upsertJobScheduler(
-          jobName,
-          { pattern: trigger.schedule, tz },
-          {
-            name: "skill-step",
-            data: {
-              workspace,
-              skillId: manifest.id,
-              skillVersion: manifest.version,
-              stepId: manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec",
-              triggerType: "cron",
-              manifestPath,
-            },
-          },
-        );
-
-        console.log(`  ✓ Cron registered: ${trigger.schedule} (${tz}) → ${jobName}`);
-        registered++;
-      }
+    if (result.status === "error") {
+      console.error(`  ✗ ${result.error}`);
+      process.exit(1);
     }
-  }
 
-  if (registered === 0) {
-    console.log("  ⚠ No cron triggers found in this manifest");
+    console.log(`\n  Registering skill: ${result.skillId} v${result.version}`);
+    if (result.cleaned > 0) {
+      console.log(`  Cleaned ${result.cleaned} legacy repeatable(s)`);
+    }
+    if (result.status === "no-triggers") {
+      console.log("  ⚠ No cron triggers found in this manifest");
+    } else {
+      console.log(`  ✓ ${result.registered} cron trigger(s) registered`);
+    }
+    console.log(`\n  Skill registered. Next fire will appear in Bull Board at /queues\n`);
+  } finally {
+    await connection.quit();
   }
-
-  await connection.quit();
-  console.log(`\n  Skill registered. Next fire will appear in Bull Board at /queues\n`);
 }

--- a/packages/cli/src/register-skills.ts
+++ b/packages/cli/src/register-skills.ts
@@ -1,0 +1,185 @@
+/**
+ * nexaas register-skills — bulk register every skill manifest under a directory.
+ *
+ * Usage:
+ *   nexaas register-skills [<dir>]                  default: $NEXAAS_WORKSPACE_ROOT/nexaas-skills
+ *   nexaas register-skills <dir> --dry-run          show what would change
+ *   nexaas register-skills <dir> --only <substr>    only manifests whose path
+ *                                                   contains <substr>
+ *
+ * Why: re-registering N manifests via N invocations of `nexaas register-skill`
+ * spawns N tsx + Node + ioredis + psql lookups (Phoenix observed ~7 min
+ * for 138 skills). This command opens one Redis connection, does the
+ * workspace-timezone lookup once, walks the dir, and registers each
+ * manifest in-process. Wall time drops to seconds.
+ *
+ * Returns a summary line: `registered / updated / no-triggers / errors`.
+ */
+
+import { readdirSync, statSync } from "fs";
+import { join, resolve, basename } from "path";
+import { Queue } from "bullmq";
+import { Redis } from "ioredis";
+import {
+  registerOneSkill,
+  resolveWorkspaceTimezone,
+  type RegisterResult,
+} from "./register-skill.js";
+
+const USAGE = `\
+Usage: nexaas register-skills [<dir>] [--dry-run] [--only <substr>]
+
+Bulk-register every skill.yaml under <dir>. Defaults to
+$NEXAAS_WORKSPACE_ROOT/nexaas-skills if omitted.
+
+Options:
+  --dry-run         List manifests that would be registered, exit 0.
+  --only <substr>   Only register manifests whose path contains <substr>
+                    (e.g. --only marketing/ to limit by category).
+
+Required env: NEXAAS_WORKSPACE
+Optional env: NEXAAS_WORKSPACE_ROOT (default location for the skills tree),
+              REDIS_URL, DATABASE_URL.
+`;
+
+function printUsage(): void {
+  process.stdout.write(USAGE);
+}
+
+/** Walk a directory tree, collect every `skill.yaml` we find. */
+function findManifests(dir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch { continue; }
+    for (const entry of entries) {
+      const path = join(cur, entry);
+      let st;
+      try { st = statSync(path); } catch { continue; }
+      if (st.isDirectory()) {
+        stack.push(path);
+      } else if (basename(path) === "skill.yaml") {
+        out.push(path);
+      }
+    }
+  }
+  // Stable order so successive runs print the same sequence.
+  return out.sort();
+}
+
+interface Options {
+  dir: string;
+  dryRun: boolean;
+  only: string | null;
+}
+
+function parseArgs(args: string[]): Options | "help" {
+  if (args.includes("--help") || args.includes("-h")) return "help";
+
+  let dir: string | null = null;
+  let dryRun = false;
+  let only: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--dry-run") dryRun = true;
+    else if (a === "--only") { only = args[++i] ?? null; }
+    else if (!a.startsWith("--")) { dir = a; }
+  }
+
+  if (!dir) {
+    if (!process.env.NEXAAS_WORKSPACE_ROOT) {
+      console.error("No directory given and NEXAAS_WORKSPACE_ROOT is unset.");
+      console.error(USAGE);
+      process.exit(1);
+    }
+    dir = join(process.env.NEXAAS_WORKSPACE_ROOT, "nexaas-skills");
+  }
+
+  return { dir: resolve(dir), dryRun, only };
+}
+
+export async function run(args: string[]) {
+  const parsed = parseArgs(args);
+  if (parsed === "help") {
+    printUsage();
+    return;
+  }
+  const { dir, dryRun, only } = parsed;
+
+  const workspace = process.env.NEXAAS_WORKSPACE;
+  if (!workspace) {
+    console.error("NEXAAS_WORKSPACE is required");
+    process.exit(1);
+  }
+
+  let manifests = findManifests(dir);
+  if (only) {
+    manifests = manifests.filter((p) => p.includes(only));
+  }
+  if (manifests.length === 0) {
+    console.log(`  No skill.yaml files found under ${dir}${only ? ` matching --only '${only}'` : ""}`);
+    return;
+  }
+
+  console.log(`\n  Found ${manifests.length} manifest(s) under ${dir}${only ? ` (filtered by '${only}')` : ""}`);
+
+  if (dryRun) {
+    for (const p of manifests) console.log(`  [dry-run] would register ${p}`);
+    console.log(`\n  Dry-run complete: ${manifests.length} manifest(s)\n`);
+    return;
+  }
+
+  const connection = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+    maxRetriesPerRequest: null,
+    enableReadyCheck: false,
+  });
+  const queue = new Queue(`nexaas-skills-${workspace}`, { connection });
+  const workspaceTz = resolveWorkspaceTimezone(workspace);
+
+  let registered = 0;
+  let noTriggers = 0;
+  let errors = 0;
+  let totalCronTriggers = 0;
+  let totalCleaned = 0;
+  const errorDetails: Array<{ path: string; error: string }> = [];
+
+  try {
+    const start = Date.now();
+    for (const path of manifests) {
+      const result: RegisterResult = await registerOneSkill(path, { queue, workspace, workspaceTz });
+      totalCronTriggers += result.registered;
+      totalCleaned += result.cleaned;
+
+      if (result.status === "error") {
+        errors++;
+        errorDetails.push({ path, error: result.error ?? "unknown error" });
+        console.log(`  ✗ ${path}: ${result.error}`);
+      } else if (result.status === "no-triggers") {
+        noTriggers++;
+        // Quiet by default — common for sub-skills with no cron triggers.
+      } else {
+        registered++;
+        console.log(`  ✓ ${result.skillId} v${result.version} (${result.registered} cron trigger${result.registered === 1 ? "" : "s"})`);
+      }
+    }
+    const elapsedMs = Date.now() - start;
+
+    console.log(
+      `\n  Summary: ${registered} registered, ${noTriggers} no-triggers, ${errors} error(s) ` +
+      `— ${totalCronTriggers} cron trigger(s) upserted, ${totalCleaned} legacy repeatable(s) cleaned ` +
+      `in ${(elapsedMs / 1000).toFixed(1)}s\n`,
+    );
+
+    if (errors > 0) {
+      console.log("  Errors:");
+      for (const e of errorDetails) console.log(`    ${e.path}: ${e.error}`);
+      process.exit(1);
+    }
+  } finally {
+    await connection.quit();
+  }
+}


### PR DESCRIPTION
Closes #87.

## Summary

Three operator UX fixes surfaced during the Phoenix marketing canary recovery (#86). Independent of that incident; easy wins.

## What lands

### 1. `nexaas register-skill --help` no longer crashes

**Before:**
\`\`\`
$ nexaas register-skill --help
node:fs:448
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^
Error: ENOENT: no such file or directory, open '--help'
\`\`\`

**After:**
\`\`\`
$ nexaas register-skill --help
Usage: nexaas register-skill <path-to-skill.yaml>

Registers a skill manifest with the BullMQ scheduler. ...
\`\`\`

### 2. New `nexaas register-skills <dir>` for bulk register

Re-registering 138 Phoenix manifests via the per-invocation pattern took ~7 min — most of the wall time was the per-skill spawn (tsx + Node + ioredis + psql tz lookup). The bulk command opens one Redis connection and does one psql tz lookup, then iterates in-process.

\`\`\`
nexaas register-skills [<dir>] [--dry-run] [--only <substr>]
\`\`\`

- Defaults to `$NEXAAS_WORKSPACE_ROOT/nexaas-skills` if no dir given
- `--dry-run` lists what would be registered without touching BullMQ
- `--only <substr>` filters by path substring (e.g. `--only marketing/`)
- Returns a structured summary: `registered / no-triggers / errors` with elapsed time and per-error context for triage

### 3. Better missing-path handling

- Before: raw \`Error: ENOENT: no such file or directory\` stack trace from \`readFileSync\` with no hint
- After: typed error message ("manifest not found at &lt;path&gt; — pass an absolute path or run from \$NEXAAS_WORKSPACE_ROOT")
- Bonus: single-skill mode now resolves relative paths against \$NEXAAS_WORKSPACE_ROOT when set, so \`nexaas register-skill nexaas-skills/foo/skill.yaml\` works regardless of cwd

## Refactor note

Extracted `registerOneSkill(path, ctx)` and `resolveWorkspaceTimezone(workspace)` as exported helpers from `register-skill.ts` so the bulk command reuses the exact registration path. `RegisterContext` carries the shared queue + workspace + tz so neither helper sets up infra of its own. `registerOneSkill` returns a structured `RegisterResult` instead of throwing — bulk callers can summarize without aborting on the first bad manifest.

## Verification

- `tsc --noEmit` clean
- `register-skill --help` prints the usage block (smoke-tested)
- `register-skills --help` prints the usage block (smoke-tested)
- Missing-path returns the typed error message instead of a stack trace (smoke-tested with `/tmp/nonexistent.yaml`)
- Live verification on Phoenix's 138-skill re-register: should drop from ~7 min to single-digit seconds. Not an emergency; worth confirming on the next planned re-register.

## Test plan

- [ ] `nexaas register-skill --help` exits 0 with the usage block
- [ ] `nexaas register-skill /tmp/missing.yaml` exits 1 with the typed hint
- [ ] `nexaas register-skill nexaas-skills/foo/skill.yaml` works with `\$NEXAAS_WORKSPACE_ROOT` set even from a different cwd
- [ ] `nexaas register-skills --dry-run` lists every skill.yaml
- [ ] `nexaas register-skills --only marketing/` registers only marketing/* skills
- [ ] On Phoenix: `nexaas register-skills` re-registers all 138 skills in single-digit seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)