### PR TITLE
feat(cli): warn on cron-overlap within concurrency_groups (#99)

### DIFF
--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -18,12 +18,19 @@ import { execSync } from "child_process";
 import { load as yamlLoad } from "js-yaml";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
+import parser from "cron-parser";
 
 export interface SkillManifest {
   id: string;
   version: string;
   description?: string;
   timezone?: string;
+  /**
+   * Mutex groups (#95 / #96). Skills sharing a group serialize at the
+   * worker. The CLI also uses the list at registration time to flag
+   * cron-overlap with already-registered skills (#99).
+   */
+  concurrency_groups?: string[];
   triggers?: Array<{
     type: string;
     schedule?: string;
@@ -43,6 +50,17 @@ export interface RegisterContext {
   workspaceTz: string;
 }
 
+/**
+ * One overlap detected between the skill being registered and an
+ * already-registered one — both share at least one concurrency_group
+ * and their next-1h cron fires intersect (#99).
+ */
+export interface CronOverlapWarning {
+  group: string;
+  newPattern: string;
+  conflicts: Array<{ skillId: string; pattern: string }>;
+}
+
 export interface RegisterResult {
   skillId: string;
   version: string;
@@ -50,6 +68,7 @@ export interface RegisterResult {
   cleaned: number;
   status: "registered" | "no-triggers" | "error";
   error?: string;
+  warnings?: CronOverlapWarning[];
 }
 
 const USAGE = `\
@@ -89,6 +108,114 @@ export function resolveWorkspaceTimezone(workspace: string): string {
   } catch {
     return "UTC";
   }
+}
+
+/**
+ * Compute the set of next-N cron fires for a pattern, truncated to the
+ * minute (HH:MM ISO prefix). Used by the cron-overlap detector — two
+ * patterns overlap when their next-fire sets intersect.
+ *
+ * 12 fires is the bar: covers ~1h of `*\/5` cadence, ~3h of `*\/15`,
+ * a full day of hourly. Cheap to compute, good enough to catch the
+ * cases the issue's mock output shows. cron-parser is a transitive
+ * dep via BullMQ.
+ */
+function nextFireSet(pattern: string, tz: string, count = 12): Set<string> {
+  try {
+    const it = parser.parseExpression(pattern, { tz, currentDate: new Date() });
+    const out = new Set<string>();
+    for (let i = 0; i < count; i++) {
+      out.add(it.next().toDate().toISOString().slice(0, 16));
+    }
+    return out;
+  } catch {
+    return new Set();
+  }
+}
+
+function setsIntersect(a: Set<string>, b: Set<string>): boolean {
+  for (const x of a) if (b.has(x)) return true;
+  return false;
+}
+
+/**
+ * Inspect existing job schedulers for cron overlap with the new skill (#99).
+ *
+ * "Overlap" requires both:
+ *   1. ≥1 group name in common with the new skill, AND
+ *   2. Next-1h fires that intersect at any minute.
+ *
+ * Pure pre-flight nudge — never blocks registration. False negatives are
+ * fine (a `@hourly` skill on a heavily-used group is correct as designed
+ * and we don't try to flag it). False positives are the more annoying
+ * outcome, so we only warn when both conditions hold simultaneously.
+ *
+ * Existing schedulers must have been registered with `concurrencyGroups`
+ * in their job data — schedulers from before this code shipped will be
+ * silently skipped, which means warnings light up only after each skill
+ * has been re-registered once (acceptable for a pure ergonomics feature).
+ */
+export async function findCronOverlaps(
+  queue: Queue,
+  newSkill: {
+    id: string;
+    groups: string[];
+    triggers: Array<{ pattern: string; tz: string }>;
+  },
+): Promise<CronOverlapWarning[]> {
+  if (newSkill.groups.length === 0 || newSkill.triggers.length === 0) return [];
+
+  let existing: Array<{
+    name?: string;
+    pattern?: string;
+    tz?: string;
+    template?: { data?: unknown };
+  }>;
+  try {
+    existing = await queue.getJobSchedulers();
+  } catch {
+    return [];
+  }
+
+  const newGroups = new Set(newSkill.groups);
+  const sameJobName = `cron-${newSkill.id.replace(/\//g, "-")}`;
+  const warningsByGroup = new Map<string, CronOverlapWarning>();
+
+  for (const sched of existing) {
+    if (!sched.name || sched.name === sameJobName) continue;
+    if (!sched.pattern) continue;
+
+    const data = sched.template?.data as
+      | { skillId?: string; concurrencyGroups?: string[] }
+      | undefined;
+    if (!data?.skillId || !Array.isArray(data.concurrencyGroups)) continue;
+
+    const sharedGroups = data.concurrencyGroups.filter((g) => newGroups.has(g));
+    if (sharedGroups.length === 0) continue;
+
+    const existingFires = nextFireSet(sched.pattern, sched.tz ?? "UTC");
+    if (existingFires.size === 0) continue;
+
+    for (const trig of newSkill.triggers) {
+      const newFires = nextFireSet(trig.pattern, trig.tz);
+      if (newFires.size === 0) continue;
+      if (!setsIntersect(existingFires, newFires)) continue;
+
+      for (const group of sharedGroups) {
+        const w = warningsByGroup.get(group) ?? {
+          group,
+          newPattern: trig.pattern,
+          conflicts: [],
+        };
+        if (!w.conflicts.some((c) => c.skillId === data.skillId)) {
+          w.conflicts.push({ skillId: data.skillId, pattern: sched.pattern });
+        }
+        warningsByGroup.set(group, w);
+      }
+    }
+  }
+
+  return [...warningsByGroup.values()];
 }
 
 /**
@@ -153,6 +280,32 @@ export async function registerOneSkill(
     };
   }
 
+  // Resolve every cron trigger's effective timezone up-front so the
+  // overlap check sees the same tz the scheduler will use.
+  const cronTriggers: Array<{ pattern: string; tz: string }> = [];
+  for (const trigger of manifest.triggers) {
+    if (trigger.type === "cron" && trigger.schedule) {
+      cronTriggers.push({
+        pattern: trigger.schedule,
+        tz:
+          trigger.timezone ??
+          manifest.timezone ??
+          ctx.workspaceTz ??
+          process.env.NEXAAS_TIMEZONE ??
+          "UTC",
+      });
+    }
+  }
+
+  // Pre-flight cron-overlap warning (#99) — pure ergonomics, never blocks.
+  // Quietly empty if the skill has no concurrency_groups or no cron triggers.
+  const groups = manifest.concurrency_groups ?? [];
+  const warnings = await findCronOverlaps(ctx.queue, {
+    id: manifest.id,
+    groups,
+    triggers: cronTriggers,
+  });
+
   for (const trigger of manifest.triggers) {
     if (trigger.type !== "cron" || !trigger.schedule) continue;
 
@@ -186,6 +339,9 @@ export async function registerOneSkill(
           stepId: manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec",
           triggerType: "cron",
           manifestPath,
+          // Stored so the next register call's overlap check (#99) can
+          // see this skill's groups without re-reading manifests from disk.
+          concurrencyGroups: groups,
         },
       },
     );
@@ -199,7 +355,24 @@ export async function registerOneSkill(
     registered,
     cleaned,
     status: registered > 0 ? "registered" : "no-triggers",
+    warnings: warnings.length > 0 ? warnings : undefined,
   };
+}
+
+/** Print a CronOverlapWarning block (used by both single + bulk callers). */
+export function printOverlapWarnings(
+  warnings: CronOverlapWarning[],
+  newSkillId: string,
+): void {
+  for (const w of warnings) {
+    console.log(`  ⚠ Cron overlap on group '${w.group}':`);
+    for (const c of w.conflicts) {
+      console.log(`      ${c.skillId.padEnd(36)} (${c.pattern})`);
+    }
+    console.log(`      ${(newSkillId + " [NEW]").padEnd(36)} (${w.newPattern})`);
+    console.log(`    These will serialize via the group lock; expect added wait.`);
+    console.log(`    Consider offsetting one of them by a few minutes.`);
+  }
 }
 
 export async function run(args: string[]) {
@@ -248,6 +421,9 @@ export async function run(args: string[]) {
     console.log(`\n  Registering skill: ${result.skillId} v${result.version}`);
     if (result.cleaned > 0) {
       console.log(`  Cleaned ${result.cleaned} legacy repeatable(s)`);
+    }
+    if (result.warnings && result.warnings.length > 0) {
+      printOverlapWarnings(result.warnings, result.skillId);
     }
     if (result.status === "no-triggers") {
       console.log("  ⚠ No cron triggers found in this manifest");

--- a/packages/cli/src/register-skills.ts
+++ b/packages/cli/src/register-skills.ts
@@ -21,6 +21,7 @@ import { join, resolve, basename } from "path";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 import {
+  printOverlapWarnings,
   registerOneSkill,
   resolveWorkspaceTimezone,
   type RegisterResult,
@@ -164,6 +165,9 @@ export async function run(args: string[]) {
       } else {
         registered++;
         console.log(`  ✓ ${result.skillId} v${result.version} (${result.registered} cron trigger${result.registered === 1 ? "" : "s"})`);
+        if (result.warnings && result.warnings.length > 0) {
+          printOverlapWarnings(result.warnings, result.skillId);
+        }
       }
     }
     const elapsedMs = Date.now() - start;

--- a/scripts/test-cron-overlap-99.mjs
+++ b/scripts/test-cron-overlap-99.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #99 — register-skill warns on cron-overlap within
+ * a shared concurrency_group. Mocks BullMQ's `getJobSchedulers()` to
+ * inject controlled scenarios; no Redis or DB required.
+ *
+ * Run from repo root: `node --import tsx scripts/test-cron-overlap-99.mjs`
+ */
+
+import { findCronOverlaps } from "../packages/cli/src/register-skill.ts";
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+function fakeQueue(schedulers) {
+  return { getJobSchedulers: async () => schedulers };
+}
+
+// 1. New skill with no groups → no warnings, regardless of existing schedulers.
+{
+  const q = fakeQueue([
+    { name: "cron-other", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/other", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: [], triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 0, "no groups → no warnings");
+}
+
+// 2. New skill with no triggers → no warnings.
+{
+  const q = fakeQueue([
+    { name: "cron-other", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/other", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, { id: "ops/new", groups: ["g1"], triggers: [] });
+  assert(w.length === 0, "no triggers → no warnings");
+}
+
+// 3. Same group + overlapping cron → warning.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-engagement", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/engagement", concurrencyGroups: ["sqlite:onb"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["sqlite:onb"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 1, "same group + same cron → 1 warning");
+  assert(w[0].group === "sqlite:onb", "warning carries the group name");
+  assert(w[0].newPattern === "*/15 * * * *", "warning carries the new pattern");
+  assert(w[0].conflicts.length === 1, "warning lists 1 conflict");
+  assert(w[0].conflicts[0].skillId === "ops/engagement", "conflict identifies the existing skill");
+  assert(w[0].conflicts[0].pattern === "*/15 * * * *", "conflict carries the existing pattern");
+}
+
+// 4. Same group + non-overlapping cron → no warning.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-engagement", pattern: "0 9 * * *", tz: "UTC",  // daily 9am
+      template: { data: { skillId: "ops/engagement", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["g1"],
+    triggers: [{ pattern: "0 17 * * *", tz: "UTC" }],   // daily 5pm
+  });
+  assert(w.length === 0, "same group, non-overlapping cron → no warning");
+}
+
+// 5. Different group + same cron → no warning.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-engagement", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/engagement", concurrencyGroups: ["other"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["sqlite:onb"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 0, "different group → no warning even with same cron");
+}
+
+// 6. Existing scheduler without concurrencyGroups in data → silently skipped.
+{
+  const q = fakeQueue([
+    { name: "cron-legacy", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/legacy" /* no concurrencyGroups */ } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["g1"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 0, "scheduler missing concurrencyGroups → skipped (legacy)");
+}
+
+// 7. Re-registering the same skill (own job name) → not flagged against itself.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-new", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/new", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["g1"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 0, "re-registering same skill → no self-warning");
+}
+
+// 8. Multiple skills on same group with overlapping cron → all listed under one warning.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-engagement", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/engagement", concurrencyGroups: ["sqlite:onb"] } } },
+    { name: "cron-ops-failure-monitor", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/failure-monitor", concurrencyGroups: ["sqlite:onb"] } } },
+    { name: "cron-ops-unrelated", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/unrelated", concurrencyGroups: ["other-group"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["sqlite:onb"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 1, "multi-conflict → still 1 warning per group");
+  assert(w[0].conflicts.length === 2, "warning lists both conflicting skills");
+  const ids = new Set(w[0].conflicts.map((c) => c.skillId));
+  assert(ids.has("ops/engagement") && ids.has("ops/failure-monitor"),
+    "warning includes engagement + failure-monitor");
+  assert(!ids.has("ops/unrelated"), "warning does not include unrelated-group skill");
+}
+
+// 9. Skill with multiple groups, conflict on only one → only that group warns.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-engagement", pattern: "*/15 * * * *", tz: "UTC",
+      template: { data: { skillId: "ops/engagement", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["g1", "g2"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 1, "1 warning when only one of new skill's groups conflicts");
+  assert(w[0].group === "g1", "warning is for the conflicting group only");
+}
+
+// 10. Malformed cron pattern → silently skipped (no throw).
+{
+  const q = fakeQueue([
+    { name: "cron-bad", pattern: "this is not cron", tz: "UTC",
+      template: { data: { skillId: "ops/bad", concurrencyGroups: ["g1"] } } },
+  ]);
+  const w = await findCronOverlaps(q, {
+    id: "ops/new", groups: ["g1"],
+    triggers: [{ pattern: "*/15 * * * *", tz: "UTC" }],
+  });
+  assert(w.length === 0, "malformed existing cron → no throw, no warning");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #99. Stacks on #103 (fix #87). Closes the loop on the concurrency-groups operator-ergonomics track from #95 / #96.

## Summary

Pre-flight nudge during `register-skill`: when the new skill shares ≥1 `concurrency_group` with an already-registered skill **and** their next-1h cron fires intersect at any minute, print a warning. Pure ergonomics — never blocks registration.

**Why** — hand-staggered crons (the Phoenix workaround pre-#95) were fragile because every new skill author had to rediscover the existing minute-map. With `concurrency_groups` (#96) the lock serializes correctly, but a fresh author who picks `*/15` on a group already saturated by three `*/15` skills creates avoidable wait. Catching this at registration time saves the discovery-by-incident loop.

## Sample output

```
$ nexaas register-skill nexaas-skills/hr/new-thing/skill.yaml

  Registering skill: hr/new-thing v1.0.0
  ⚠ Cron overlap on group 'sqlite:data/onboarding.db':
      hr/engagement-sync                   (*/15 * * * *)
      hr/failure-monitor                   (*/15 * * * *)
      hr/new-thing [NEW]                   (*/15 * * * *)
    These will serialize via the group lock; expect added wait.
    Consider offsetting one of them by a few minutes.

  ✓ 1 cron trigger(s) registered

  Skill registered. Next fire will appear in Bull Board at /queues
```

## What changes

- **`SkillManifest` interface** gains `concurrency_groups?: string[]`. Matches #96's manifest semantics.
- **New `findCronOverlaps(queue, newSkill)` helper** walks `queue.getJobSchedulers()`, finds entries that share ≥1 group, computes next-12 fires (truncated to ISO minute) via `cron-parser`, and warns when the sets intersect. `cron-parser` is a transitive dep via BullMQ — no new direct dep.
- **`registerOneSkill` stores `concurrencyGroups`** in BullMQ job data so the next register call's overlap check can read it without re-parsing manifests from disk.
- **`RegisterResult.warnings`** field surfaces overlaps to both single + bulk callers.
- **`printOverlapWarnings(warnings, newSkillId)`** renders the block in a consistent format, used by both `register-skill` and `register-skills`.

## False-positive minimization

Warnings only fire when **both** group-overlap **and** fire-time-overlap hold simultaneously:

- `@hourly` skill on a heavily-used group (correct as designed) won't trigger noise
- Same group, non-overlapping cron (`0 9 * * *` vs `0 17 * * *`) → no warning
- Different group, same cron → no warning
- Schedulers without `concurrencyGroups` in their job data (skills registered before this code shipped) → silently skipped — warnings light up only after each gets re-registered once, which adopters do periodically

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-cron-overlap-99.mjs`** — 19 cases all pass:
  - No groups / no triggers → no warnings
  - Same group + overlapping cron → 1 warning with correct group, pattern, conflict list
  - Same group, non-overlapping cron → no warning
  - Different group + same cron → no warning
  - Legacy schedulers (no `concurrencyGroups` in data) → skipped
  - Re-registering same skill → no self-warning
  - Multi-conflict (two existing skills on same group) → both listed under one warning
  - Mixed groups (new skill has 2 groups, only one conflicts) → only that group warns
  - Malformed existing cron pattern → silently skipped, no throw

## Stack

\`main\` ← #103 (#87) ← **this**

Both PRs touch `register-skill.ts`. #99's overlap check lights up automatically in #87's bulk `register-skills` command since both call the same `registerOneSkill` path.

## Test plan

- [ ] `node --import tsx scripts/test-cron-overlap-99.mjs` → 19/19 pass
- [ ] On Phoenix: register a skill with `concurrency_groups: ["sqlite:data/onboarding.db"]` and `*/15` cron — expect the warning listing the existing skills on that group
- [ ] Register the same skill with `0 9 * * *` cron instead — expect no warning (different schedule)
- [ ] Re-register an already-registered skill — expect no self-warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)