### PR TITLE
fix(worker): mark in-flight skill_runs as failed on shutdown (#86 Gap 3)

### DIFF
--- a/packages/runtime/src/bullmq/worker.ts
+++ b/packages/runtime/src/bullmq/worker.ts
@@ -12,7 +12,7 @@ import { runSkillStep } from "../pipeline.js";
 import { runShellSkill, type ShellSkillManifest } from "../shell-skill.js";
 import { runAiSkill, type AiSkillManifest } from "../ai-skill.js";
 import { runTracker } from "../run-tracker.js";
-import { appendWal } from "@nexaas/palace";
+import { appendWal, sql } from "@nexaas/palace";
 import type { SkillJobData } from "./queues.js";
 import { isRateLimitError, extractCooldownMs, pauseQueueFor } from "./rate-limit.js";
 import { startHeartbeatLoop, stopHeartbeatLoop } from "../fleet/heartbeat.js";
@@ -223,6 +223,19 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
         try { await worker.close(true); } catch { /* already forced */ }
       }
     }
+    // Sweep in-flight skill_runs that didn't finish during drain (#86 Gap 3).
+    // Worker SIGTERM (status=143, OOM-adjacent kills) used to lose jobs that
+    // were `active` at exit time — they vanished from every BullMQ queue
+    // without `markStepFailed` ever firing, so silent-failure-watchdog (#69)
+    // never saw the streak. This sweep closes the loop: any skill_run still
+    // at status='running' for this workspace gets stamped failed before
+    // process.exit. Idempotent — if BullMQ later recovers the job, the
+    // normal markCompleted path overwrites this stamp with status='completed'.
+    try {
+      await sweepInFlightRuns(workspaceId, signal);
+    } catch (err) {
+      console.warn(`[nexaas] in-flight sweep error: ${(err as Error).message}`);
+    }
     // Tear down any pooled MCP subprocesses (#63). No-op when pooling is
     // disabled. Best-effort so shutdown never hangs on a misbehaving child.
     try { await shutdownMcpPool(); } catch (err) {
@@ -239,4 +252,77 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
 
 export function getWorker(): Worker | null {
   return _worker;
+}
+
+/**
+ * On worker shutdown, mark every still-`running` skill_run for this workspace
+ * as failed with `error_summary='worker-exit-during-execution'` (#86 Gap 3).
+ *
+ * Why this is needed: a SIGTERM during BullMQ's drain window can force-close
+ * the worker before active jobs run their `markStepFailed` / `markCompleted`
+ * path. Those rows then sit at status='running' forever, invisible to
+ * `silent-failure-watchdog` (#69) which only counts `failed` runs toward
+ * its streak. Without this sweep, an OOM-adjacent SIGTERM during a marketing
+ * skill run can leave the skill silently broken — exactly the failure mode
+ * documented in #86.
+ *
+ * Idempotency: BullMQ's stalled-job recovery will re-process killed jobs
+ * when the worker comes back. The normal completion path calls
+ * `markCompleted` which overwrites the stamp with `status='completed'`,
+ * so a job that recovers cleanly leaves no trace of the temporary failure
+ * stamp. A job that fails on retry stays `failed` (correct outcome).
+ *
+ * Single-worker scope: this sweeps all `running` rows for the workspace
+ * unconditionally. The Phase-2 multi-worker world (#97) will need a
+ * worker-id filter so concurrent workers don't trample each other's
+ * in-flight runs.
+ *
+ * Exported for the regression test (#86 Gap 3 test); not part of the
+ * runtime's public surface.
+ */
+export async function sweepInFlightRuns(
+  workspace: string,
+  signal: string,
+): Promise<number> {
+  const rows = await sql<{ run_id: string; current_step: string | null; skill_id: string }>(
+    `SELECT run_id, current_step, skill_id
+       FROM nexaas_memory.skill_runs
+      WHERE workspace = $1 AND status = 'running'`,
+    [workspace],
+  );
+
+  if (rows.length === 0) return 0;
+
+  let marked = 0;
+  for (const row of rows) {
+    try {
+      // markStepFailed bumps the silent-failure streak counter (#69) — so
+      // a sudden burst of worker-exit-during-execution stamps will trip
+      // the watchdog if the threshold says it should. That's the desired
+      // tie-in with #86 Gap 1; without this we'd never count toward the
+      // streak when the worker died mid-execution.
+      await runTracker.markStepFailed(
+        row.run_id,
+        row.current_step ?? "unknown",
+        "worker-exit-during-execution",
+      );
+      marked++;
+    } catch (err) {
+      console.warn(
+        `[nexaas] sweep: failed to mark run ${row.run_id} (${row.skill_id}): ${(err as Error).message}`,
+      );
+    }
+  }
+
+  console.log(`[nexaas] Shutdown sweep (${signal}): marked ${marked}/${rows.length} in-flight run(s) as failed`);
+  try {
+    await appendWal({
+      workspace,
+      op: "worker_shutdown_sweep",
+      actor: "bullmq-worker",
+      payload: { signal, total: rows.length, marked, failures: rows.length - marked },
+    });
+  } catch { /* WAL is observability; never let it block shutdown */ }
+
+  return marked;
 }

--- a/scripts/test-shutdown-sweep-86.mjs
+++ b/scripts/test-shutdown-sweep-86.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #86 Gap 3 — shutdown sweep marks in-flight skill_runs
+ * as failed so silent-failure-watchdog (#69) can see them.
+ *
+ * Inserts skill_runs in every status, runs the sweep, asserts only `running`
+ * rows for the test workspace are reset to `failed` with the expected
+ * error_summary stamp. Other statuses, and other workspaces' running rows,
+ * are untouched.
+ *
+ * Requires DATABASE_URL. Run from repo root:
+ *   node --import tsx scripts/test-shutdown-sweep-86.mjs
+ */
+
+import { sql } from "@nexaas/palace";
+import { sweepInFlightRuns } from "../packages/runtime/src/bullmq/worker.ts";
+
+const WORKSPACE = `sweep-test-${Date.now()}-${process.pid}`;
+const OTHER_WORKSPACE = `${WORKSPACE}-other`;
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+async function fetchRow(workspace, runId) {
+  const rows = await sql(
+    `SELECT status, error_summary, completed_at, current_step
+       FROM nexaas_memory.skill_runs
+      WHERE workspace = $1 AND run_id = $2`,
+    [workspace, runId],
+  );
+  return rows[0];
+}
+
+async function insertRun({ workspace, runId, status, currentStep, errorSummary, skillId }) {
+  await sql(
+    `INSERT INTO nexaas_memory.skill_runs
+        (run_id, workspace, skill_id, trigger_type, status, current_step, error_summary)
+     VALUES ($1, $2, $3, 'manual', $4, $5, $6)`,
+    [runId, workspace, skillId ?? "test/sweep", status, currentStep ?? null, errorSummary ?? null],
+  );
+}
+
+try {
+  // Two `running` rows for the test workspace — both should be reset.
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000001", status: "running", currentStep: "step-A" });
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000002", status: "running", currentStep: null });
+  // Other-status rows for the test workspace — must be untouched.
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000003", status: "waiting" });
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000004", status: "completed" });
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000005", status: "failed", errorSummary: "earlier failure" });
+  await insertRun({ workspace: WORKSPACE, runId: "11111111-1111-1111-1111-000000000006", status: "escalated" });
+  // Other-workspace `running` row — must be untouched (single-worker scope).
+  await insertRun({ workspace: OTHER_WORKSPACE, runId: "11111111-1111-1111-1111-000000000007", status: "running", currentStep: "x" });
+
+  const marked = await sweepInFlightRuns(WORKSPACE, "SIGTERM");
+  assert(marked === 2, `marked count = 2 (got ${marked})`);
+
+  const r1 = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000001");
+  assert(r1?.status === "failed", "running row 1 → failed");
+  assert(r1?.error_summary === "worker-exit-during-execution", "running row 1: error_summary stamped");
+  assert(r1?.completed_at != null, "running row 1: completed_at set");
+
+  const r2 = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000002");
+  assert(r2?.status === "failed", "running row 2 (no current_step) → failed");
+
+  const waiting = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000003");
+  assert(waiting?.status === "waiting", "waiting row untouched");
+
+  const completed = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000004");
+  assert(completed?.status === "completed", "completed row untouched");
+
+  const previouslyFailed = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000005");
+  assert(previouslyFailed?.status === "failed", "previously-failed row stays failed");
+  assert(previouslyFailed?.error_summary === "earlier failure", "previously-failed: error_summary preserved (sweep doesn't overwrite)");
+
+  const escalated = await fetchRow(WORKSPACE, "11111111-1111-1111-1111-000000000006");
+  assert(escalated?.status === "escalated", "escalated row untouched");
+
+  const otherWs = await fetchRow(OTHER_WORKSPACE, "11111111-1111-1111-1111-000000000007");
+  assert(otherWs?.status === "running", "other workspace's running row untouched (workspace scoping)");
+
+  // Idempotency: second sweep should mark zero (all formerly-running rows
+  // now have status='failed').
+  const second = await sweepInFlightRuns(WORKSPACE, "SIGTERM");
+  assert(second === 0, `second sweep is a no-op (got ${second})`);
+} finally {
+  // Clean up only this run's rows (workspace prefix is unique).
+  await sql(
+    `DELETE FROM nexaas_memory.skill_runs WHERE workspace IN ($1, $2)`,
+    [WORKSPACE, OTHER_WORKSPACE],
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
First of three #86 follow-ups. Closes the data-integrity gap that made the marketing canary blackout invisible: worker SIGTERM during in-flight execution used to lose runs entirely — never `completed`, never `failed`, never seen by silent-failure-watchdog (#69).

## Why

Phoenix's 2026-04-30 worker exit (status 143, OOM-adjacent) killed `marketing-health-pipeline` mid-execution. The skill_run sat at \`status='running'\` indefinitely. silent-failure-watchdog only counts \`failed\` runs toward its streak, so the watchdog never fired — the failure was invisible at every layer.

## What changes

**New `sweepInFlightRuns(workspace, signal)`** runs inside the SIGTERM/SIGINT handler, AFTER `worker.close()` (clean drain or forced) and BEFORE `process.exit`. Selects every skill_run with `workspace=$1 AND status='running'` and calls \`runTracker.markStepFailed(runId, current_step, 'worker-exit-during-execution')\` on each.

**`markStepFailed` already bumps the silent-failure streak** via `checkFailureStreak`, so worker-killed runs finally count toward #69's threshold. That tie-in is the whole point of this gap.

**Idempotent on BullMQ recovery.** When the worker comes back, BullMQ's stalled-job recovery re-processes killed jobs. The normal `markCompleted` path overwrites the failure stamp with \`status='completed'\` (run-tracker doesn't restrict transitions). A job that fails on retry stays failed (correct outcome). No double-counting.

**Best-effort.** Per-row `markStepFailed` errors are caught and logged but don't halt the sweep. WAL emit (\`worker_shutdown_sweep\`) is wrapped in try/catch so observability never blocks shutdown.

**Scope guard.** The SELECT filters by workspace, so concurrent workers on different workspaces don't trample each other's runs. The Phase-2 multi-worker world (#97) — multiple workers per workspace — will need a worker-id filter; documented in the JSDoc as the single-worker scope.

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-shutdown-sweep-86.mjs`** covers nine cases:
  - Two `running` rows → both marked `failed`
  - `error_summary` stamped, `completed_at` set
  - `waiting` / `completed` / `escalated` rows untouched (status filter)
  - Previously-failed row's `error_summary` preserved (not in SELECT)
  - Other workspace's `running` row untouched (workspace scoping)
  - Idempotency: second sweep is a no-op

Test requires `DATABASE_URL` — runs the same way as `test-stale-claim-reaper-94.mjs` (real DB, framework-bootstrapped workspace, cleanup in `finally`). Couldn't run on this dev box; ready for verification against Phoenix or BSBC's DB.

## Test plan

- [ ] On Phoenix or BSBC, run `node --import tsx scripts/test-shutdown-sweep-86.mjs` against the workspace DB → all 9 cases pass
- [ ] Force the failure mode: `kill -TERM` on the worker while a long-running AI skill is in flight; verify the skill_run goes to `status='failed'` with `error_summary='worker-exit-during-execution'` instead of being stuck at `running`
- [ ] Verify the periodic log line on a real shutdown: `[nexaas] Shutdown sweep (SIGTERM): marked N/M in-flight run(s) as failed`

## Next in this campaign

- **#86 Gap 2** — `scheduler-watchdog` for overdue crons (would have caught the missed `marketing-health-pipeline` firing within ~2h)
- **#86 Gap 1** — output-cadence staleness alert (would have caught the 14d social blackout / 6d email gap directly)
- **#82** — `email-outbound` `unsubscribe: "auto"` 
- **#67** — Approval button + free-text follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)