### PR TITLE
feat(runtime): scheduler-watchdog for overdue crons (#86 Gap 2)

### DIFF
--- a/packages/runtime/src/tasks/scheduler-watchdog.ts
+++ b/packages/runtime/src/tasks/scheduler-watchdog.ts
@@ -1,0 +1,264 @@
+/**
+ * Scheduler watchdog (#86 Gap 2).
+ *
+ * Detects cron triggers that should have fired but didn't — the failure
+ * mode that lost `marketing-health-pipeline` for ~2 weeks on Phoenix
+ * after the 2026-04-30 worker SIGTERM. The job vanished from BullMQ's
+ * delayed set and never appeared in `completed` / `failed` / `stalled`,
+ * so silent-failure-watchdog (#69) had nothing to count. Without this
+ * watchdog, the only way to find a missed firing is to manually
+ * `ZRANGE` BullMQ's keys.
+ *
+ * How it works:
+ *
+ * 1. Every N minutes, read every job scheduler in the workspace's
+ *    BullMQ queue.
+ * 2. For each scheduler, compare its `next` (millis-since-epoch) against
+ *    `now`. If `now - next` exceeds `2 * period` (where `period` is
+ *    inferred from the cron pattern), the cron is overdue.
+ * 3. Emit one drawer per overdue cron to
+ *    `notifications.pending.ops-alerts.scheduler-overdue`. The
+ *    notification-dispatcher routes via the configured channel role;
+ *    no separate transport.
+ *
+ * De-dupe: idempotency_key is `scheduler-overdue:<workspace>:<skillId>:<scheduledFor>`,
+ * so the same missed firing alerts exactly once across watchdog ticks.
+ * A subsequent missed firing for the same skill at a different time
+ * gets its own alert.
+ *
+ * Configuration (env-var, no manifest dependency):
+ *   NEXAAS_SCHEDULER_WATCHDOG_INTERVAL_MS  default 300000 (5 min); minimum 60000
+ *   NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE no default — unset = disabled
+ *   NEXAAS_SCHEDULER_WATCHDOG_GRACE_MULT   default 2 (× period); use 1 for tighter
+ *
+ * Disabled-by-default for compatibility with existing adopters; opt-in
+ * by setting CHANNEL_ROLE.
+ */
+
+import { Queue } from "bullmq";
+import parser from "cron-parser";
+import { palace, appendWal } from "@nexaas/palace";
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+const MIN_INTERVAL_MS = 60 * 1000;
+const DEFAULT_GRACE_MULT = 2;
+
+const CHANNEL_ROLE = process.env.NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE;
+const GRACE_MULT = (() => {
+  const raw = process.env.NEXAAS_SCHEDULER_WATCHDOG_GRACE_MULT;
+  if (!raw) return DEFAULT_GRACE_MULT;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_GRACE_MULT;
+  return parsed;
+})();
+
+let _interval: NodeJS.Timeout | null = null;
+let _polling = false;
+
+export interface OverdueCron {
+  skillId: string;
+  pattern: string;
+  tz: string;
+  scheduledForMs: number;
+  scheduledForIso: string;
+  lateByMs: number;
+  periodMs: number;
+}
+
+/**
+ * Compute approximate period of a cron pattern by taking the delta between
+ * the next two fires. Returns 0 for unparseable patterns; callers treat 0
+ * as "skip" so a malformed pattern doesn't fire false alerts.
+ */
+function inferPeriodMs(pattern: string, tz: string): number {
+  try {
+    const it = parser.parseExpression(pattern, { tz, currentDate: new Date() });
+    const a = it.next().toDate().getTime();
+    const b = it.next().toDate().getTime();
+    return Math.max(0, b - a);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Inspect every job scheduler on the queue, return overdue ones.
+ *
+ * Exported for the regression test (#86 Gap 2 test); not part of the
+ * runtime's public surface — the periodic loop in `startSchedulerWatchdog`
+ * is what skill authors and operators see.
+ */
+export async function findOverdueCrons(
+  queue: Queue,
+  graceMult: number = GRACE_MULT,
+  now: number = Date.now(),
+): Promise<OverdueCron[]> {
+  let schedulers: Array<{
+    name?: string;
+    pattern?: string;
+    tz?: string;
+    next?: number | null;
+    template?: { data?: unknown };
+  }>;
+  try {
+    schedulers = await queue.getJobSchedulers();
+  } catch {
+    return [];
+  }
+
+  const overdue: OverdueCron[] = [];
+  for (const sched of schedulers) {
+    if (!sched.pattern || !sched.name) continue;
+    const data = sched.template?.data as { skillId?: string } | undefined;
+    if (!data?.skillId) continue;
+
+    const tz = sched.tz ?? "UTC";
+    const period = inferPeriodMs(sched.pattern, tz);
+    if (period === 0) continue;
+
+    // Missing `next` is itself a signal — BullMQ should always have one
+    // for a scheduler that's still active. Treat as overdue at expected
+    // next-fire age (1 period beyond the previous fire).
+    const next = sched.next ?? null;
+    if (next === null) {
+      overdue.push({
+        skillId: data.skillId,
+        pattern: sched.pattern,
+        tz,
+        scheduledForMs: now - period,
+        scheduledForIso: new Date(now - period).toISOString(),
+        lateByMs: period,
+        periodMs: period,
+      });
+      continue;
+    }
+
+    const lateBy = now - next;
+    if (lateBy > graceMult * period) {
+      overdue.push({
+        skillId: data.skillId,
+        pattern: sched.pattern,
+        tz,
+        scheduledForMs: next,
+        scheduledForIso: new Date(next).toISOString(),
+        lateByMs: lateBy,
+        periodMs: period,
+      });
+    }
+  }
+
+  return overdue;
+}
+
+/**
+ * Emit one drawer per overdue cron, keyed for once-per-missed-firing
+ * de-dupe. Returns the count actually emitted (caller can WAL it).
+ */
+async function emitOverdueAlerts(
+  workspace: string,
+  overdue: OverdueCron[],
+): Promise<number> {
+  if (!CHANNEL_ROLE || overdue.length === 0) return 0;
+
+  const session = palace.enter({ workspace });
+  let emitted = 0;
+  for (const o of overdue) {
+    const lateMin = Math.round(o.lateByMs / 60000);
+    const periodMin = Math.round(o.periodMs / 60000);
+    try {
+      await session.writeDrawer(
+        { wing: "notifications", hall: "pending", room: "ops-alerts.scheduler-overdue" },
+        JSON.stringify({
+          idempotency_key: `scheduler-overdue:${workspace}:${o.skillId}:${o.scheduledForIso}`,
+          channel_role: CHANNEL_ROLE,
+          content:
+            `⚠️ Cron overdue: ${o.skillId}\n` +
+            `Pattern: ${o.pattern} (${o.tz})\n` +
+            `Expected fire: ${o.scheduledForIso}\n` +
+            `Late by: ${lateMin} min (period ${periodMin} min)`,
+        }),
+      );
+      emitted++;
+    } catch (err) {
+      console.error(
+        `[nexaas] scheduler-watchdog: emit failed for ${o.skillId} @ ${o.scheduledForIso}:`,
+        err,
+      );
+    }
+  }
+  return emitted;
+}
+
+export async function checkSchedulerHealth(
+  workspace: string,
+  queue: Queue,
+): Promise<{ overdue: number; alerted: number }> {
+  const overdue = await findOverdueCrons(queue);
+  if (overdue.length === 0) return { overdue: 0, alerted: 0 };
+
+  const alerted = await emitOverdueAlerts(workspace, overdue);
+
+  await appendWal({
+    workspace,
+    op: "scheduler_watchdog_overdue",
+    actor: "scheduler-watchdog",
+    payload: {
+      overdue_count: overdue.length,
+      alerted_count: alerted,
+      sample: overdue.slice(0, 5).map((o) => ({
+        skill_id: o.skillId,
+        pattern: o.pattern,
+        late_min: Math.round(o.lateByMs / 60000),
+      })),
+    },
+  });
+
+  return { overdue: overdue.length, alerted };
+}
+
+export function startSchedulerWatchdog(
+  workspace: string,
+  queue: Queue,
+  opts: { intervalMs?: number } = {},
+): void {
+  if (_interval) return;
+  if (!CHANNEL_ROLE) {
+    console.log(
+      `[nexaas] scheduler-watchdog: NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE unset; disabled`,
+    );
+    return;
+  }
+
+  const raw = opts.intervalMs ?? Number.parseInt(
+    process.env.NEXAAS_SCHEDULER_WATCHDOG_INTERVAL_MS ?? `${DEFAULT_INTERVAL_MS}`,
+    10,
+  );
+  const interval = Number.isFinite(raw) && raw >= MIN_INTERVAL_MS ? raw : DEFAULT_INTERVAL_MS;
+
+  _interval = setInterval(async () => {
+    if (_polling) return;
+    _polling = true;
+    try {
+      const result = await checkSchedulerHealth(workspace, queue);
+      if (result.overdue > 0) {
+        console.log(
+          `[nexaas] Scheduler watchdog: ${result.overdue} overdue cron(s), ${result.alerted} alert(s) emitted`,
+        );
+      }
+    } catch (err) {
+      console.error("[nexaas] scheduler-watchdog tick error:", err);
+    } finally {
+      _polling = false;
+    }
+  }, interval);
+  _interval.unref?.();
+
+  console.log(`[nexaas] Scheduler watchdog started (every ${Math.round(interval / 1000)}s, channel=${CHANNEL_ROLE})`);
+}
+
+export function stopSchedulerWatchdog(): void {
+  if (_interval) {
+    clearInterval(_interval);
+    _interval = null;
+  }
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -45,6 +45,7 @@ import { startNotificationDispatcher } from "./tasks/notification-dispatcher.js"
 import { startInboundDispatcher } from "./tasks/inbound-dispatcher.js";
 import { startApprovalResolver } from "./tasks/approval-resolver.js";
 import { startOutputStalenessWatchdog } from "./tasks/output-staleness-watchdog.js";
+import { startSchedulerWatchdog } from "./tasks/scheduler-watchdog.js";
 import {
   registerWaitpoint as registerInboundMatch,
   getWaitpointStatus as getInboundMatchStatus,
@@ -924,6 +925,14 @@ Generate the COMPLETE modified HTML file with the requested changes applied. Out
     // routes via the existing notification-dispatcher.
     const skillsRoot = join(process.env.NEXAAS_WORKSPACE_ROOT ?? "/opt/nexaas", "nexaas-skills");
     startOutputStalenessWatchdog(WORKSPACE!, skillsRoot);
+
+    // Scheduler watchdog (#86 Gap 2) — alerts on cron triggers that should
+    // have fired but didn't. Disabled when NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE
+    // is unset; opt-in for adopters who want overdue-cron visibility.
+    const schedulerQueue = new Queue(`nexaas-skills-${WORKSPACE}`, {
+      connection: getRedisConnectionOpts().connection,
+    });
+    startSchedulerWatchdog(WORKSPACE!, schedulerQueue);
 
     serverState = "ready";
     console.log("[nexaas] Worker ready.");

--- a/scripts/test-scheduler-watchdog-86.mjs
+++ b/scripts/test-scheduler-watchdog-86.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #86 Gap 2 — scheduler watchdog flags overdue
+ * crons. Mocks BullMQ's `getJobSchedulers()` so no Redis is required.
+ *
+ * Run from repo root: `node --import tsx scripts/test-scheduler-watchdog-86.mjs`
+ */
+
+import { findOverdueCrons } from "../packages/runtime/src/tasks/scheduler-watchdog.ts";
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+function fakeQueue(schedulers) {
+  return { getJobSchedulers: async () => schedulers };
+}
+
+const NOW = new Date("2026-05-08T15:00:00Z").getTime();
+const MIN = 60 * 1000;
+
+// 1. Healthy schedulers (next in the future) → no overdue.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-fresh", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW + 5 * MIN,
+      template: { data: { skillId: "ops/fresh" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 0, "healthy scheduler (next in future) → not overdue");
+}
+
+// 2. Slightly past expected next-fire (within grace) → not overdue.
+{
+  const q = fakeQueue([
+    // next was 10 min ago; period is 15 min; 10 min < 2*15 = 30 min grace
+    { name: "cron-ops-late", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW - 10 * MIN,
+      template: { data: { skillId: "ops/within-grace" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 0, "10 min late on a 15-min cron (within 2× grace) → not overdue");
+}
+
+// 3. More than 2× period overdue → flagged.
+{
+  const q = fakeQueue([
+    // next was 90 min ago; period is 15 min; 90 > 2*15 → overdue
+    { name: "cron-ops-stale", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW - 90 * MIN,
+      template: { data: { skillId: "ops/stale" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 1, "90 min late on a 15-min cron → overdue");
+  assert(out[0].skillId === "ops/stale", "overdue includes correct skillId");
+  assert(out[0].pattern === "*/15 * * * *", "overdue includes pattern");
+  assert(out[0].lateByMs === 90 * MIN, `lateByMs = 90 min (got ${out[0].lateByMs / MIN} min)`);
+}
+
+// 4. Daily schedule overdue by ~50h → flagged (2× period for daily = 48h).
+{
+  const q = fakeQueue([
+    { name: "cron-marketing", pattern: "0 13 * * *", tz: "America/New_York",
+      next: NOW - 50 * 60 * MIN,
+      template: { data: { skillId: "marketing/health-pipeline" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 1, "daily cron 50h overdue → flagged");
+  assert(out[0].skillId === "marketing/health-pipeline",
+    "Phoenix's missed marketing-health-pipeline scenario detected");
+}
+
+// 4b. Daily 25h overdue → NOT flagged (within 2× period grace for daily).
+{
+  const q = fakeQueue([
+    { name: "cron-daily", pattern: "0 13 * * *", tz: "America/New_York",
+      next: NOW - 25 * 60 * MIN,
+      template: { data: { skillId: "ops/daily" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 0, "daily cron 25h late (within 48h grace) → not yet overdue");
+}
+
+// 5. Missing `next` → flagged immediately (active scheduler should always have it).
+{
+  const q = fakeQueue([
+    { name: "cron-ops-broken", pattern: "*/15 * * * *", tz: "UTC",
+      next: null,
+      template: { data: { skillId: "ops/broken" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 1, "scheduler with null `next` → flagged");
+}
+
+// 6. Malformed pattern → silently skipped (no false alarm).
+{
+  const q = fakeQueue([
+    { name: "cron-bad", pattern: "this is not cron", tz: "UTC",
+      next: NOW - 100 * 24 * 60 * MIN,
+      template: { data: { skillId: "ops/bad-pattern" } } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 0, "malformed pattern → silently skipped");
+}
+
+// 7. Scheduler missing skillId in data → silently skipped.
+{
+  const q = fakeQueue([
+    { name: "cron-orphan", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW - 100 * MIN,
+      template: { data: {} } },
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 0, "scheduler without skillId in data → skipped");
+}
+
+// 8. Stricter grace (graceMult=1) catches earlier.
+{
+  const q = fakeQueue([
+    { name: "cron-ops", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW - 20 * MIN,
+      template: { data: { skillId: "ops/x" } } },
+  ]);
+  const tight = await findOverdueCrons(q, 1, NOW);
+  const loose = await findOverdueCrons(q, 2, NOW);
+  assert(tight.length === 1, "graceMult=1 + 20 min late on 15 min cron → overdue");
+  assert(loose.length === 0, "graceMult=2 + same → not yet overdue");
+}
+
+// 9. Mixed batch: only the overdue ones are returned.
+{
+  const q = fakeQueue([
+    { name: "cron-ops-fresh", pattern: "*/5 * * * *", tz: "UTC",
+      next: NOW + 2 * MIN,
+      template: { data: { skillId: "ops/fresh" } } },
+    { name: "cron-ops-stale", pattern: "*/15 * * * *", tz: "UTC",
+      next: NOW - 90 * MIN,
+      template: { data: { skillId: "ops/stale" } } },
+    { name: "cron-ops-borderline", pattern: "0 * * * *", tz: "UTC",
+      next: NOW - 30 * MIN,
+      template: { data: { skillId: "ops/borderline-hourly" } } },  // 30 min late on hourly = within grace
+  ]);
+  const out = await findOverdueCrons(q, 2, NOW);
+  assert(out.length === 1, "mixed batch → only the truly overdue one returned");
+  assert(out[0].skillId === "ops/stale", "correct overdue skill identified");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Second of three #86 follow-ups. Closes the **scheduling-visibility** gap that hid the 2026-04-30 missed firing of `marketing-health-pipeline` on Phoenix. Without this, a cron that should have fired but didn't is invisible — the only way to find a missed firing was to manually ZRANGE BullMQ's keys.

## How

Periodic task (default 5 min) reads `queue.getJobSchedulers()`, compares each scheduler's `next` timestamp against `now`, and flags schedulers where `now - next > graceMult × period`. Period is inferred via `cron-parser` (parse twice, subtract — already a transitive dep via BullMQ).

A null `next` is itself a signal: an active scheduler should always have one. Treated as overdue at expected-next-fire age.

## Alert dispatch

Per-overdue drawer follows silent-failure-watchdog (#69)'s pattern:

- Drawer at `notifications.pending.ops-alerts.scheduler-overdue`
- `idempotency_key = scheduler-overdue:<workspace>:<skillId>:<scheduledForIso>` → exactly-once de-dupe per missed firing across watchdog ticks
- `channel_role` from `NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE` env
- The existing notification-dispatcher routes it; no separate transport

WAL emit `scheduler_watchdog_overdue` carries `overdue_count`, `alerted_count`, and a 5-sample summary for ops dashboards.

## Configuration

```
NEXAAS_SCHEDULER_WATCHDOG_INTERVAL_MS    default 300000 (5 min); minimum 60000
NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE   no default — unset = disabled
NEXAAS_SCHEDULER_WATCHDOG_GRACE_MULT     default 2.0; use 1 for tighter alerting
```

**Disabled by default** for backwards compatibility; opt-in by setting `CHANNEL_ROLE`. On startup, logs `"NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE unset; disabled"` so operators know explicitly that it's a no-op.

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-scheduler-watchdog-86.mjs`** — 16/16 pass:
  - Healthy (next in future) → not overdue
  - Within grace (10 min late on 15-min cron) → not overdue
  - Overdue (90 min late on 15-min cron) → flagged with correct skillId, pattern, lateByMs
  - Daily 50h overdue → flagged (Phoenix's missed `marketing-health-pipeline` scenario)
  - Daily 25h overdue → not flagged (within 48h grace for daily)
  - Null `next` → flagged immediately
  - Malformed cron pattern → silently skipped
  - Scheduler without skillId in data → silently skipped
  - graceMult=1 catches earlier than graceMult=2
  - Mixed batch → only the overdue ones returned

Test stubs `queue.getJobSchedulers()`; no Redis required.

## Tie-in with Gap 3 (#106)

Once both ship the framework can distinguish:

- A cron that was **scheduled but never woke up** → this watchdog flags it
- A run that was **active but died at exit** → Gap 3's shutdown sweep marks it `failed` so silent-failure-watchdog (#69) can count it

Together they close the observability hole that made the marketing canary 14d/6d blackout invisible.

## Test plan

- [ ] On Phoenix: set `NEXAAS_SCHEDULER_WATCHDOG_CHANNEL_ROLE=ops_escalations` in `.env`, restart worker, verify the startup log line and that no false positives appear within the first hour
- [ ] Force the failure mode: pause the BullMQ queue (`PAUSE` Redis cmd) for 30+ min on a `*/15` cron, then unpause; verify the watchdog emits an `ops-alerts.scheduler-overdue` drawer within the next tick
- [ ] Verify the WAL `scheduler_watchdog_overdue` event shape on ops dashboards

## Next in this campaign

- **#86 Gap 1** — output-cadence staleness alert (would have caught the 14d social blackout / 6d email gap directly)
- **#82** — `email-outbound` `unsubscribe: "auto"`
- **#67** — Approval button + free-text follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)