### PR TITLE
feat(runtime): output-cadence staleness watchdog (#86 Gap 1)

### DIFF
--- a/packages/runtime/src/ai-skill-framework-tools.ts
+++ b/packages/runtime/src/ai-skill-framework-tools.ts
@@ -30,6 +30,7 @@
  */
 
 import type { PalaceSession, Drawer } from "@nexaas/palace";
+import { appendWal } from "@nexaas/palace";
 import type { McpTool } from "./models/agentic-loop.js";
 import type { AiSkillManifest } from "./ai-skill.js";
 import type { RoutingDecision } from "./tag/route.js";
@@ -241,6 +242,30 @@ async function produceOutput(
   }
 
   ctx.state.producedOutputs.push(output.id);
+
+  // Single source of truth for output-cadence tracking (#86 Gap 1). The
+  // staleness watchdog reads MAX(created_at) on this op per (skill_id,
+  // output_id) to decide whether a declared output has gone silent
+  // longer than the manifest's staleness_alert.max_silence permits.
+  // Best-effort; observability never blocks the produce-output path.
+  try {
+    await appendWal({
+      workspace: ctx.workspace,
+      op: "output_produced",
+      actor: `skill:${ctx.manifest.id}`,
+      payload: {
+        skill_id: ctx.manifest.id,
+        skill_version: ctx.manifest.version,
+        output_id: output.id,
+        output_kind: output.kind ?? null,
+        routing,
+        run_id: ctx.runId,
+        step_id: ctx.stepId,
+      },
+    });
+  } catch (err) {
+    console.error("[nexaas] output_produced WAL emit failed:", err);
+  }
 
   // Compact receipt — enough for the AI to decide next steps without
   // leaking internal framework state.

--- a/packages/runtime/src/tasks/output-staleness-watchdog.ts
+++ b/packages/runtime/src/tasks/output-staleness-watchdog.ts
@@ -1,0 +1,284 @@
+/**
+ * Output-cadence staleness watchdog (#86 Gap 1).
+ *
+ * Catches the failure mode where a skill runs to status='completed' but
+ * its declared `outputs[]` never land downstream (no broadcast scheduled,
+ * no email sent, no asset uploaded). The cron fires, Claude returns,
+ * skill_runs records `completed` — and from the framework's perspective
+ * everything is green. Phoenix's marketing canary sat in this state for
+ * 14 days (social) / 6 days (email) before a human noticed.
+ *
+ * The framework already knows what outputs exist (manifest.outputs[]) and
+ * already records when each one is produced (the `output_produced` WAL
+ * op emitted by ai-skill-framework-tools). This watchdog is the missing
+ * loop: per (skill_id, output_id) declared with `staleness_alert`, check
+ * whether `MAX(created_at) WHERE op='output_produced' AND ...` is older
+ * than `max_silence`. If so, alert.
+ *
+ * Manifest schema:
+ *
+ *   outputs:
+ *     - id: broadcast_scheduled
+ *       routing_default: auto_execute
+ *       staleness_alert:
+ *         max_silence: 9d                # 9d, 12h, 30m — duration string
+ *         channel_role: ops_escalations  # binds to workspace manifest
+ *
+ * Skills without `staleness_alert` are silently ignored — the field is
+ * additive and adopters opt-in per output.
+ *
+ * De-dupe: idempotency_key encodes the last-produced timestamp (or
+ * 'never'), so once an alert fires it doesn't repeat until the output
+ * either produces something new (changing the key) or stays silent for
+ * another full max_silence window.
+ *
+ * Configuration:
+ *   NEXAAS_OUTPUT_STALENESS_INTERVAL_MS  default 6h; minimum 60s
+ *   NEXAAS_OUTPUT_STALENESS_DEFAULT_ROLE optional fallback channel_role
+ *                                        for outputs that declared
+ *                                        staleness_alert.max_silence
+ *                                        without channel_role
+ *
+ * The watchdog reads skill manifests from
+ * $NEXAAS_WORKSPACE_ROOT/nexaas-skills on each tick — same path the worker
+ * already uses for cron self-heal. Manifests are small and parsed once
+ * per tick (default 6h), so the cost is sub-second on Phoenix's 138-skill
+ * tree.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from "fs";
+import { join } from "path";
+import { load as yamlLoad } from "js-yaml";
+import { sql, palace, appendWal } from "@nexaas/palace";
+
+const DEFAULT_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const MIN_INTERVAL_MS = 60 * 1000;
+const DEFAULT_ROLE = process.env.NEXAAS_OUTPUT_STALENESS_DEFAULT_ROLE;
+
+let _interval: NodeJS.Timeout | null = null;
+let _polling = false;
+
+interface StalenessConfig {
+  max_silence: string;
+  channel_role?: string;
+}
+
+interface OutputDecl {
+  id: string;
+  staleness_alert?: StalenessConfig;
+}
+
+interface ManifestForStaleness {
+  id: string;
+  outputs?: OutputDecl[];
+}
+
+export interface StaleOutput {
+  skillId: string;
+  outputId: string;
+  maxSilenceMs: number;
+  silentForMs: number;
+  lastProducedIso: string | null;
+  channelRole: string;
+}
+
+/**
+ * Parse a duration string like "9d", "12h", "30m". Returns 0 for
+ * unparseable input — caller treats 0 as "skip this output, don't alert
+ * on garbage manifest".
+ */
+export function parseDuration(s: string): number {
+  if (typeof s !== "string") return 0;
+  const m = s.trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/);
+  if (!m) return 0;
+  const n = Number.parseFloat(m[1]);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  switch (m[2]) {
+    case "ms": return n;
+    case "s":  return n * 1000;
+    case "m":  return n * 60 * 1000;
+    case "h":  return n * 60 * 60 * 1000;
+    case "d":  return n * 24 * 60 * 60 * 1000;
+    default:   return 0;
+  }
+}
+
+function loadManifest(path: string): ManifestForStaleness | null {
+  try {
+    const m = yamlLoad(readFileSync(path, "utf-8")) as ManifestForStaleness;
+    if (!m?.id || !Array.isArray(m.outputs)) return null;
+    return m;
+  } catch { return null; }
+}
+
+function findManifests(skillsRoot: string): string[] {
+  if (!existsSync(skillsRoot)) return [];
+  const out: string[] = [];
+  for (const category of readdirSync(skillsRoot)) {
+    const catPath = join(skillsRoot, category);
+    let catStat;
+    try { catStat = statSync(catPath); } catch { continue; }
+    if (!catStat.isDirectory()) continue;
+    for (const skillName of readdirSync(catPath)) {
+      const skillPath = join(catPath, skillName, "skill.yaml");
+      if (existsSync(skillPath)) out.push(skillPath);
+    }
+  }
+  return out;
+}
+
+/**
+ * Find outputs whose `MAX(output_produced.created_at)` is older than the
+ * declared max_silence. Exported for the regression test; not part of
+ * the runtime's public surface.
+ */
+export async function findStaleOutputs(
+  workspace: string,
+  manifestPaths: string[],
+  now: number = Date.now(),
+): Promise<StaleOutput[]> {
+  const stale: StaleOutput[] = [];
+  for (const path of manifestPaths) {
+    const manifest = loadManifest(path);
+    if (!manifest) continue;
+    for (const output of manifest.outputs ?? []) {
+      const cfg = output.staleness_alert;
+      if (!cfg?.max_silence) continue;
+      const channelRole = cfg.channel_role ?? DEFAULT_ROLE;
+      if (!channelRole) continue;
+
+      const maxSilenceMs = parseDuration(cfg.max_silence);
+      if (maxSilenceMs === 0) continue;
+
+      const rows = await sql<{ last_at: string | null }>(
+        `SELECT MAX(created_at)::text AS last_at
+           FROM nexaas_memory.wal
+          WHERE workspace = $1
+            AND op = 'output_produced'
+            AND payload->>'skill_id' = $2
+            AND payload->>'output_id' = $3`,
+        [workspace, manifest.id, output.id],
+      );
+
+      const lastAtIso = rows[0]?.last_at ?? null;
+      const lastAtMs = lastAtIso ? Date.parse(lastAtIso) : null;
+      const silentForMs = lastAtMs === null ? Number.POSITIVE_INFINITY : now - lastAtMs;
+
+      if (silentForMs > maxSilenceMs) {
+        stale.push({
+          skillId: manifest.id,
+          outputId: output.id,
+          maxSilenceMs,
+          silentForMs: Number.isFinite(silentForMs) ? silentForMs : maxSilenceMs * 2,
+          lastProducedIso: lastAtIso,
+          channelRole,
+        });
+      }
+    }
+  }
+  return stale;
+}
+
+async function emitStaleAlerts(
+  workspace: string,
+  stale: StaleOutput[],
+): Promise<number> {
+  if (stale.length === 0) return 0;
+  const session = palace.enter({ workspace });
+  let emitted = 0;
+  for (const s of stale) {
+    const lastTok = s.lastProducedIso ?? "never";
+    const silentMin = Math.round(s.silentForMs / 60000);
+    const maxMin = Math.round(s.maxSilenceMs / 60000);
+    try {
+      await session.writeDrawer(
+        { wing: "notifications", hall: "pending", room: "ops-alerts.output-stale" },
+        JSON.stringify({
+          idempotency_key: `output-stale:${workspace}:${s.skillId}:${s.outputId}:${lastTok}`,
+          channel_role: s.channelRole,
+          content:
+            `⚠️ Output silent: ${s.skillId} → ${s.outputId}\n` +
+            `Last produced: ${s.lastProducedIso ?? "never"}\n` +
+            `Silent for: ${silentMin} min (max ${maxMin} min)`,
+        }),
+      );
+      emitted++;
+    } catch (err) {
+      console.error(
+        `[nexaas] output-staleness: emit failed for ${s.skillId}/${s.outputId}:`,
+        err,
+      );
+    }
+  }
+  return emitted;
+}
+
+export async function checkOutputStaleness(
+  workspace: string,
+  skillsRoot: string,
+): Promise<{ stale: number; alerted: number }> {
+  const manifests = findManifests(skillsRoot);
+  const stale = await findStaleOutputs(workspace, manifests);
+  if (stale.length === 0) return { stale: 0, alerted: 0 };
+
+  const alerted = await emitStaleAlerts(workspace, stale);
+  await appendWal({
+    workspace,
+    op: "output_staleness_detected",
+    actor: "output-staleness-watchdog",
+    payload: {
+      stale_count: stale.length,
+      alerted_count: alerted,
+      sample: stale.slice(0, 5).map((s) => ({
+        skill_id: s.skillId,
+        output_id: s.outputId,
+        silent_min: Math.round(s.silentForMs / 60000),
+        max_silence_min: Math.round(s.maxSilenceMs / 60000),
+      })),
+    },
+  });
+  return { stale: stale.length, alerted };
+}
+
+export function startOutputStalenessWatchdog(
+  workspace: string,
+  skillsRoot: string,
+  opts: { intervalMs?: number } = {},
+): void {
+  if (_interval) return;
+
+  const raw = opts.intervalMs ?? Number.parseInt(
+    process.env.NEXAAS_OUTPUT_STALENESS_INTERVAL_MS ?? `${DEFAULT_INTERVAL_MS}`,
+    10,
+  );
+  const interval = Number.isFinite(raw) && raw >= MIN_INTERVAL_MS ? raw : DEFAULT_INTERVAL_MS;
+
+  _interval = setInterval(async () => {
+    if (_polling) return;
+    _polling = true;
+    try {
+      const result = await checkOutputStaleness(workspace, skillsRoot);
+      if (result.stale > 0) {
+        console.log(
+          `[nexaas] Output staleness watchdog: ${result.stale} stale output(s), ${result.alerted} alert(s) emitted`,
+        );
+      }
+    } catch (err) {
+      console.error("[nexaas] output-staleness-watchdog tick error:", err);
+    } finally {
+      _polling = false;
+    }
+  }, interval);
+  _interval.unref?.();
+
+  console.log(
+    `[nexaas] Output staleness watchdog started (every ${Math.round(interval / 60000)} min, scanning ${skillsRoot})`,
+  );
+}
+
+export function stopOutputStalenessWatchdog(): void {
+  if (_interval) {
+    clearInterval(_interval);
+    _interval = null;
+  }
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -44,6 +44,7 @@ import { loadWorkspaceManifest } from "./schemas/load-manifest.js";
 import { startNotificationDispatcher } from "./tasks/notification-dispatcher.js";
 import { startInboundDispatcher } from "./tasks/inbound-dispatcher.js";
 import { startApprovalResolver } from "./tasks/approval-resolver.js";
+import { startOutputStalenessWatchdog } from "./tasks/output-staleness-watchdog.js";
 import {
   registerWaitpoint as registerInboundMatch,
   getWaitpointStatus as getInboundMatchStatus,
@@ -916,6 +917,13 @@ Generate the COMPLETE modified HTML file with the requested changes applied. Out
     // dispatcher (skills can subscribe to the same drawer and also see
     // the button click).
     startApprovalResolver(WORKSPACE!);
+
+    // Output-cadence staleness watchdog (#86 Gap 1) — alerts when a
+    // declared output hasn't been produced within max_silence. No-op
+    // for skills without staleness_alert config; per-output channel_role
+    // routes via the existing notification-dispatcher.
+    const skillsRoot = join(process.env.NEXAAS_WORKSPACE_ROOT ?? "/opt/nexaas", "nexaas-skills");
+    startOutputStalenessWatchdog(WORKSPACE!, skillsRoot);
 
     serverState = "ready";
     console.log("[nexaas] Worker ready.");

--- a/scripts/test-output-staleness-86.mjs
+++ b/scripts/test-output-staleness-86.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #86 Gap 1 — output-cadence staleness watchdog.
+ *
+ * The parseDuration helper has no DB dependency and is exercised here.
+ * The findStaleOutputs / WAL-query path requires DATABASE_URL — runs
+ * against a real Nexaas-bootstrapped Postgres, same pattern as
+ * test-shutdown-sweep-86.mjs.
+ *
+ * Run from repo root: `node --import tsx scripts/test-output-staleness-86.mjs`
+ */
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { sql, appendWal } from "@nexaas/palace";
+import {
+  parseDuration,
+  findStaleOutputs,
+} from "../packages/runtime/src/tasks/output-staleness-watchdog.ts";
+
+const WORKSPACE = `staleness-test-${Date.now()}-${process.pid}`;
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// parseDuration — pure, no DB
+// ─────────────────────────────────────────────────────────────────────
+assert(parseDuration("9d") === 9 * 24 * 60 * 60 * 1000, "9d");
+assert(parseDuration("12h") === 12 * 60 * 60 * 1000, "12h");
+assert(parseDuration("30m") === 30 * 60 * 1000, "30m");
+assert(parseDuration("90s") === 90 * 1000, "90s");
+assert(parseDuration("500ms") === 500, "500ms");
+assert(parseDuration("1.5h") === 1.5 * 60 * 60 * 1000, "decimal: 1.5h");
+assert(parseDuration("9 d") === 9 * 24 * 60 * 60 * 1000, "whitespace tolerated");
+assert(parseDuration("9D") === 9 * 24 * 60 * 60 * 1000, "case-insensitive");
+assert(parseDuration("") === 0, "empty → 0");
+assert(parseDuration("9") === 0, "no unit → 0");
+assert(parseDuration("foo") === 0, "garbage → 0");
+assert(parseDuration("-5d") === 0, "negative → 0");
+assert(parseDuration("0d") === 0, "zero → 0");
+assert(parseDuration(null) === 0, "null → 0");
+
+// ─────────────────────────────────────────────────────────────────────
+// findStaleOutputs — exercises manifest reading + WAL query
+// ─────────────────────────────────────────────────────────────────────
+let skillsRoot = null;
+try {
+  // Build a tiny on-disk manifest tree.
+  const tmp = mkdtempSync(join(tmpdir(), "staleness-test-"));
+  skillsRoot = join(tmp, "nexaas-skills");
+  mkdirSync(join(skillsRoot, "marketing", "fresh-skill"), { recursive: true });
+  mkdirSync(join(skillsRoot, "marketing", "stale-skill"), { recursive: true });
+  mkdirSync(join(skillsRoot, "ops", "no-staleness"), { recursive: true });
+  mkdirSync(join(skillsRoot, "ops", "never-produced"), { recursive: true });
+
+  // Skill 1: produced recently → not stale.
+  writeFileSync(
+    join(skillsRoot, "marketing", "fresh-skill", "skill.yaml"),
+    `id: marketing/fresh-skill\nversion: "1.0.0"\noutputs:\n  - id: weekly_post\n    routing_default: auto_execute\n    staleness_alert:\n      max_silence: 9d\n      channel_role: ops_escalations\n`,
+  );
+
+  // Skill 2: produced 14 days ago → stale (max 9d).
+  writeFileSync(
+    join(skillsRoot, "marketing", "stale-skill", "skill.yaml"),
+    `id: marketing/stale-skill\nversion: "1.0.0"\noutputs:\n  - id: weekly_broadcast\n    routing_default: auto_execute\n    staleness_alert:\n      max_silence: 9d\n      channel_role: ops_escalations\n`,
+  );
+
+  // Skill 3: declares an output without staleness_alert → ignored.
+  writeFileSync(
+    join(skillsRoot, "ops", "no-staleness", "skill.yaml"),
+    `id: ops/no-staleness\nversion: "1.0.0"\noutputs:\n  - id: silent_output\n    routing_default: auto_execute\n`,
+  );
+
+  // Skill 4: declares staleness_alert but has never produced anything → stale.
+  writeFileSync(
+    join(skillsRoot, "ops", "never-produced", "skill.yaml"),
+    `id: ops/never-produced\nversion: "1.0.0"\noutputs:\n  - id: would_be_published\n    routing_default: auto_execute\n    staleness_alert:\n      max_silence: 1d\n      channel_role: ops_escalations\n`,
+  );
+
+  const NOW = Date.now();
+  // Insert a recent output_produced for fresh-skill.
+  await appendWal({
+    workspace: WORKSPACE,
+    op: "output_produced",
+    actor: "skill:marketing/fresh-skill",
+    payload: {
+      skill_id: "marketing/fresh-skill",
+      output_id: "weekly_post",
+      output_kind: "social",
+      routing: "auto_execute",
+    },
+  });
+  // Insert a 14-day-old output_produced for stale-skill.
+  await sql(
+    `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, created_at, prev_hash, hash)
+     VALUES ($1, 'output_produced', 'skill:marketing/stale-skill', $2::jsonb,
+             now() - interval '14 days', '0', 'test-hash-' || gen_random_uuid())`,
+    [WORKSPACE, JSON.stringify({
+      skill_id: "marketing/stale-skill",
+      output_id: "weekly_broadcast",
+      output_kind: "email",
+      routing: "auto_execute",
+    })],
+  );
+
+  const stale = await findStaleOutputs(WORKSPACE, [
+    join(skillsRoot, "marketing", "fresh-skill", "skill.yaml"),
+    join(skillsRoot, "marketing", "stale-skill", "skill.yaml"),
+    join(skillsRoot, "ops", "no-staleness", "skill.yaml"),
+    join(skillsRoot, "ops", "never-produced", "skill.yaml"),
+  ], NOW);
+
+  // fresh-skill: ~now < 9d → not stale, not in result
+  // stale-skill: 14d old > 9d max → stale
+  // no-staleness: no config → ignored
+  // never-produced: lastAt null → silent forever > 1d max → stale
+
+  assert(stale.length === 2, `2 stale outputs (got ${stale.length})`);
+
+  const ids = new Set(stale.map((s) => `${s.skillId}/${s.outputId}`));
+  assert(ids.has("marketing/stale-skill/weekly_broadcast"), "stale-skill flagged");
+  assert(ids.has("ops/never-produced/would_be_published"), "never-produced flagged");
+  assert(!ids.has("marketing/fresh-skill/weekly_post"), "fresh-skill NOT flagged");
+  assert(!ids.has("ops/no-staleness/silent_output"), "no-staleness config → not flagged");
+
+  const staleSkill = stale.find((s) => s.skillId === "marketing/stale-skill");
+  assert(staleSkill?.lastProducedIso != null, "stale-skill: lastProducedIso populated");
+  assert(staleSkill?.silentForMs > 13 * 24 * 60 * 60 * 1000, "stale-skill: silentForMs > 13 days");
+  assert(staleSkill?.channelRole === "ops_escalations", "stale-skill: channelRole from manifest");
+
+  const neverProduced = stale.find((s) => s.skillId === "ops/never-produced");
+  assert(neverProduced?.lastProducedIso === null, "never-produced: lastProducedIso null");
+  assert(neverProduced?.maxSilenceMs === 24 * 60 * 60 * 1000, "never-produced: max=1d (24h)");
+} finally {
+  // Cleanup WAL rows.
+  await sql(`DELETE FROM nexaas_memory.wal WHERE workspace = $1`, [WORKSPACE]);
+  if (skillsRoot) {
+    try { rmSync(join(skillsRoot, ".."), { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Final of three #86 follow-ups. Closes the **most adopter-felt gap** from the marketing canary post-mortem: a skill runs to \`status='completed'\` but its declared outputs never land downstream. Phoenix's marketing skills sat in this state for 14 days (social) / 6 days (email) before a human noticed.

## How

**New manifest field** `outputs[].staleness_alert`:

\`\`\`yaml
outputs:
  - id: broadcast_scheduled
    routing_default: auto_execute
    staleness_alert:
      max_silence: 9d
      channel_role: ops_escalations
\`\`\`

Optional and additive — skills without it bypass the check entirely.

**New WAL op `output_produced`** emitted from `ai-skill-framework-tools.ts` after `applyRoutedAction` succeeds. Carries `{skill_id, skill_version, output_id, output_kind, routing, run_id, step_id}`. Single source of truth — all staleness queries read this op.

**New `output-staleness-watchdog`** periodic task (default 6h):

1. Walks `$NEXAAS_WORKSPACE_ROOT/nexaas-skills`, parses every `skill.yaml`
2. For each output with `staleness_alert`, queries `MAX(created_at)` on `output_produced` for that `(skill_id, output_id)`
3. If older than `max_silence`, emits a drawer to `notifications.pending.ops-alerts.output-stale`
4. Idempotency key encodes the last-produced timestamp → alerts exactly once per silent window

**parseDuration** supports `9d`, `12h`, `30m`, `90s`, `500ms`, decimals, case-insensitive, whitespace-tolerant. Returns 0 (skip) for invalid input so manifest typos don't fire noisy alerts.

## Configuration

\`\`\`
NEXAAS_OUTPUT_STALENESS_INTERVAL_MS    default 21600000 (6h); minimum 60000
NEXAAS_OUTPUT_STALENESS_DEFAULT_ROLE   optional fallback channel_role
\`\`\`

The watchdog runs whenever the worker is up; per-output `staleness_alert.channel_role` opt-in is the gate.

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-output-staleness-86.mjs`**:
  - **`parseDuration`** — 14/14 pass locally (no DB)
  - **`findStaleOutputs`** — 7 cases requiring `DATABASE_URL`:
    - 14d-old output (max 9d) → flagged
    - Recently-produced output (max 9d) → NOT flagged
    - Never-produced output → flagged (lastProducedIso null)
    - Output without `staleness_alert` config → ignored
    - `lastProducedIso`, `silentForMs`, `channelRole` populated correctly

DB section runs on Phoenix or BSBC (same pattern as `test-shutdown-sweep-86.mjs`).

## Tie-in with Gaps 2 + 3

Together with #107 (Gap 2 — scheduler-watchdog) and #106 (Gap 3 — shutdown sweep), the framework now distinguishes three independent failure modes that combined to make the Phoenix blackout invisible:

| Failure mode | Detection |
|---|---|
| Cron scheduled but never woke up | #107 — scheduler-watchdog |
| Run was active but died at exit | #106 — shutdown sweep |
| Run completed cleanly but produced nothing | **this PR** |

The 14d/6d Phoenix blackout would have alerted within `9d max_silence + 6h watchdog tick` ≈ 9.25d, instead of \"a human notices the feeds are dead.\"

## Test plan

- [ ] On Phoenix or BSBC: run `node --import tsx scripts/test-output-staleness-86.mjs` against the workspace DB → 21/21 pass
- [ ] Add `staleness_alert: { max_silence: 9d, channel_role: ops_escalations }` to one of Phoenix's marketing outputs, restart worker, verify the startup log line and that no false positives appear within the first 6h tick
- [ ] Force the failure mode: manually `DELETE FROM wal WHERE op='output_produced' AND payload->>'skill_id' = '...'` to simulate a silent skill, wait one watchdog tick, verify the `ops-alerts.output-stale` drawer is written

## Next

- **#82** — `email-outbound` `unsubscribe: "auto"` + List-Unsubscribe header expansion
- **#67** — Approval button + free-text follow-up capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)