### PR TITLE
feat(cli): nexaas doctor locks — concurrency-group contention report (#98)

### DIFF
--- a/docs/adoption-patterns/README.md
+++ b/docs/adoption-patterns/README.md
@@ -38,6 +38,7 @@ speculative until live validation are marked *(pending canary validation)*.
 | [`2fa-code-intercept.md`](./2fa-code-intercept.md) | v0.1 — shipped 2026-04-20 | Channel-agnostic one-time-code capture via the inbound-match waitpoint primitive (OAuth, TD MFA, 2FA flows) |
 | [`multi-vps-channel-relay.md`](./multi-vps-channel-relay.md) | v0.1 — shipped 2026-04-20, Nexmatic validation pending (#64) | Operator-managed multi-VPS inbound: ops-relay → `/api/drawers/inbound` → client VPS |
 | [`debugging-playbook.md`](./debugging-playbook.md) | v0.1 — shipped 2026-04-20 | Common symptoms → diagnostics → fixes, indexed by WAL op and SQL query |
+| [`approval-with-followup.md`](./approval-with-followup.md) | v0.1 — shipped 2026-05-08, Phoenix HR onboarding canary pending (#67) | Button click + free-text follow-up: capture rejection reason / amendment / follow-up info using approval-resolver + `framework__request_match` |
 | `approval-gated-output.md` | *pending* | TAG `approval_required` routing for ai-skill outputs — skill author → TAG → channel → human → resume |
 | `daily-automation-skill.md` | *pending* | Shell skill with cron trigger + preflight gate + output verification |
 | `ai-skill-migration.md` | *pending* | Converting Trigger.dev / n8n / `claude --print` automations into proper Nexaas ai-skills via `/nexaasify` |

--- a/docs/adoption-patterns/approval-with-followup.md
+++ b/docs/adoption-patterns/approval-with-followup.md
@@ -1,0 +1,184 @@
+# Approval with free-text follow-up
+
+*v0.1 — framework-side primitives shipped (#45 Stage 1a, framework__request_match), pattern documented from issue triage. Awaiting first canary validation (Phoenix HR onboarding — Mireille's [Reject]/[Need Info] reason capture); will be promoted to v0.2 once landed.*
+
+Pattern for skills that present an approval prompt with action buttons and need to capture **free-text follow-up** when the human picks a button that requires more context. Channel-agnostic — works for any channel the workspace has bound that supports inline buttons + reply capture (Telegram, Nexmatic dashboard, Slack, future SMS).
+
+The canonical example is rejection-with-reason: a skill writes a draft, the operator clicks `[Reject]`, the skill needs to know **why** before closing the row. The same shape covers any "button click + 1 free-text reply" follow-up.
+
+Unblocks flows like:
+
+- HR onboarding rejection: `[Reject]` → "Why are you rejecting this application?"
+- Sales-call confirmation: `[Need Info]` → "What information do they need first?"
+- Ops escalation: `[Defer]` → "What's the unblock?"
+- Marketing approval: `[Edit]` → "What would you like changed?"
+
+## When to use this pattern
+
+- The skill produces an output that needs human approval
+- One or more of the available decisions cannot stand alone — the operator's *reason* or *amendment* is part of the decision
+- The follow-up is **one** free-text reply, not a multi-turn conversation (multi-turn is its own pattern, not yet documented)
+
+## When **not** to use
+
+- Approval is binary and the framework's `decisions[{id, label}]` plus the routing engine's `auto_execute` / `approval_required` / `escalate` is enough — don't bolt on an unnecessary text capture
+- The "follow-up" is structured enough to be its own button — model it as additional decisions instead (`[Reject — wrong region]`, `[Reject — missing info]`, …)
+- The skill needs an open-ended back-and-forth — that's the conversation pattern, which uses repeated `framework__request_match` calls in a loop
+
+## Two surfaces — pick the right one
+
+### Surface 1: AI skill with `framework__request_match`
+
+The common case. The skill's agentic loop produces an output via `framework__produce_output`, the routing engine routes via `approval_required`, and on resume the skill detects the chosen decision and calls `framework__request_match` to capture the follow-up reply.
+
+```ts
+// Inside the skill prompt's instructions to Claude:
+
+// Step 1: produce the output that needs approval
+framework__produce_output({
+  output_id: "draft_decision",
+  payload: { ...whatever the skill produced... },
+})
+// Returns: { ok: true, status: "pending_approval", ... }
+// Skill is now suspended on a TAG-emitted approval-request waitpoint.
+// Telegram/dashboard/etc. shows the prompt with [Approve][Reject][Need Info].
+
+// === Operator clicks a button ===
+// approval-resolver (#45 Stage 1a) writes resolved_with: { button_id: "reject", … }
+// Skill resumes here.
+
+// Step 2: branch on the chosen decision
+const decision = ctx.resolved_with.button_id   // "approve" | "reject" | "need_info"
+
+if (decision === "approve") {
+  // Done — the routing engine already executed the original output.
+  // No follow-up needed.
+  return
+}
+
+if (decision === "reject" || decision === "need_info") {
+  // Send a follow-up prompt over the SAME channel binding so the
+  // operator sees the question in the same conversation thread.
+  framework__produce_output({
+    output_id: "followup_question",
+    payload: {
+      content:
+        decision === "reject"
+          ? "Why are you rejecting this? Reply with the reason in one message."
+          : "What information do they need first? Reply with details in one message.",
+    },
+  })
+
+  // Wait for the operator's next message in the same room.
+  const reply = framework__request_match({
+    channel_role: "<the role bound to this operator>",
+    content_pattern: "any",
+    sender_id: ctx.resolved_with.from_id,        // restrict to this operator
+    timeout_seconds: 3600,
+    extract: "full_content",
+  })
+
+  // reply.content is the operator's free-text answer.
+  // Use it for the appropriate downstream action — write a rejection
+  // record, schedule a discovery call, etc.
+}
+```
+
+The `sender_id` restriction is critical. Without it, *any* message landing in the room (a different operator's reply, an unrelated notification echo) would resolve the waitpoint. Pin it to the same `from.id` that resolved the button click — the skill can read it from `ctx.resolved_with`.
+
+### Surface 2: shell skill with the HTTP API
+
+Same shape, but the shell skill drives both waitpoints itself via `POST /api/waitpoints/inbound-match`. Useful for non-AI skills (cron-driven shell scripts) that need the same approval-then-follow-up primitive. See `2fa-code-intercept.md` § "Surface 1: HTTP API" for the canonical request/response shape — the only difference here is you'd register two consecutive waitpoints (button match, then any-content match) in the same script.
+
+## Manifest declaration
+
+In the skill's `skill.yaml`:
+
+```yaml
+outputs:
+  - id: draft_decision
+    routing_default: approval_required
+    approval:
+      channel_role: hr_lead              # who sees the prompt
+    decisions:
+      - id: approve
+        label: Approve
+      - id: reject
+        label: Reject
+      - id: need_info
+        label: Need Info
+
+  - id: followup_question
+    routing_default: auto_execute        # plain notification, no approval
+    notify:
+      channel_role: hr_lead              # same channel as the approval
+```
+
+The `decisions` field is what TAG (#45 Stage 1a) renders into channel-shaped `inline_buttons`. The `followup_question` output is just a notification — its only job is to ask the question; the answer comes back through `framework__request_match`, not through another approval.
+
+## Channel-binding hint
+
+Both the original approval and the follow-up question route through the same `channel_role`. Verify in the workspace manifest that the binding's MCP supports both inline buttons (for the approval) **and** reply capture (for the follow-up):
+
+| Channel | Inline buttons | Reply capture | Notes |
+|---|---|---|---|
+| Telegram | yes — `inline_buttons[{text, button_id}]` | yes — bot receives the next message in the same chat | Requires the bot to be in the chat; for DMs, the operator must have started a chat with the bot at least once |
+| Nexmatic dashboard | yes — `inline_buttons` rendered in the inbox UI | yes — the dashboard's reply box writes to the same room | The `pa_reply_<role>` convention applies; Mireille's `pa_reply_mireille` is the analogue |
+| Slack | yes — `block_actions` | yes via `event_callback` | Adapter must be configured for both event types |
+
+## Gotchas
+
+### Race: button click resolves before the skill registers the follow-up waitpoint
+
+The approval-resolver writes `resolved_with` and re-enqueues the skill *immediately* on button click. The skill then runs Step 2, which produces the follow-up question and registers the second waitpoint. Between the two registrations, the operator could (if they're fast) send a reply that doesn't match anything yet.
+
+The framework handles this correctly: `framework__request_match` is registered before the skill prints the follow-up question's content (the message hasn't gone out yet — production happens via the routing engine which fires on next tick), so the operator has nothing to reply to until after registration. But shell-skill drivers using the HTTP API directly should be careful to register the second waitpoint *before* sending the follow-up message themselves.
+
+### Wrong-operator reply resolves the waitpoint
+
+Always set `sender_id` on the follow-up `request_match`. Without it, any drawer in `inbox.messaging.<role>` resolves — including stale messages, other operators' chatter, or a reply meant for a different prompt. Pin to the operator who clicked the button (`ctx.resolved_with.from_id`).
+
+### Multi-line replies
+
+`content_pattern: "any"` matches any non-empty content, including multi-line. The extracted `content` preserves newlines. Skills that want only the first line should slice after extraction; the framework doesn't impose structure on free-text follow-ups.
+
+### Timeout handling
+
+If the operator never replies, `request_match` resolves with `status: "timeout"` after `timeout_seconds`. Skills should branch on the status:
+
+```ts
+const reply = framework__request_match({ ... timeout_seconds: 3600 })
+
+if (reply.status === "timeout") {
+  // Decide: re-prompt, escalate, or close as "rejected without reason"
+} else if (reply.status === "cancelled") {
+  // The waitpoint was cancelled out-of-band (operator killed the run, etc.)
+} else {
+  // reply.content has the answer
+}
+```
+
+Don't loop indefinitely without a timeout — that ties up a skill_run forever.
+
+## WAL signature
+
+| Op | When |
+|---|---|
+| `approval_requested` | Skill produces the approval-shaped output (TAG Stage 1a) |
+| `approval_resolved` | Operator clicks a button — approval-resolver records the decision + from.id |
+| `framework_request_match_registered` | Skill resumes and registers the follow-up waitpoint |
+| `framework_request_match_resolved` | Operator's reply lands — payload includes the extracted content |
+| `output_produced` × 2 | One for `draft_decision` (the original output), one for `followup_question` (#86 Gap 1) |
+
+`nexaas verify-wal` will see all five in sequence for a complete approval-with-followup interaction. Useful for post-mortems when an operator says "I clicked Reject and never got asked why" — the absence of the second `output_produced` or `framework_request_match_registered` row tells you exactly which step broke.
+
+## Why not a single compound waitpoint primitive?
+
+Issue #67 considered a "compound" waitpoint that resolves on `button_id OR (button_id + followup)` as a single registered primitive. The framework hasn't shipped this — the 2-waitpoint stitch covers the cases seen so far, and a compound primitive would force every adopter to learn a new abstraction. If 3+ adopters file requests for the same shape, the primitive becomes worth the cost.
+
+## Related
+
+- `2fa-code-intercept.md` — the channel-agnostic inbound-match waitpoint primitive that backs `framework__request_match`
+- `telegram-channel.md` — channel-specific inbound + outbound for Telegram
+- `manifest-hygiene.md` — chat_id types, `channel_role` naming, `channel_bindings` structure
+- Framework: `packages/runtime/src/tasks/inbound-match-waitpoint.ts`, `packages/runtime/src/tasks/approval-resolver.ts`, `packages/runtime/src/ai-skill-framework-tools.ts`

--- a/packages/cli/src/doctor-locks.ts
+++ b/packages/cli/src/doctor-locks.ts
@@ -1,0 +1,286 @@
+/**
+ * `nexaas doctor locks` — concurrency-group lock-contention report (#98).
+ *
+ * Reads the `lock_acquired` / `lock_released` WAL events emitted by
+ * `withGroups()` (#95 / #96) and computes per-group contention stats:
+ * acquire count, p50/p99 wait_ms, top blocked-on skill, top blocking
+ * skill (held the lock longest on average), and a one-line suggestion
+ * when a group looks pathological.
+ *
+ * Read-only. The whole purpose of the WAL events is contention surfacing;
+ * this command is the consumer. Phase-2 surfaces (Bull Board widget,
+ * dashboard panel) can layer on the same data without changing this CLI.
+ */
+
+import { sql, createPool } from "@nexaas/palace";
+
+interface LockAcquiredRow {
+  group: string;
+  skill_id: string | null;
+  run_id: string | null;
+  wait_ms: number;
+  acquired_at: string;
+}
+
+interface LockReleasedRow {
+  group: string;
+  skill_id: string | null;
+  run_id: string | null;
+  released_at: string;
+}
+
+interface GroupStats {
+  group: string;
+  acquires: number;
+  uniqueSkills: Set<string>;
+  waitMs: number[];
+  topBlocked: { skillId: string; maxWaitMs: number };
+  holdMsBySkill: Map<string, number[]>;
+}
+
+const USAGE = `\
+Usage: nexaas doctor locks [--since <duration>] [--group <name>] [--limit <n>]
+
+Concurrency-group lock contention report. Reads lock_acquired /
+lock_released WAL events emitted by skills that declare
+concurrency_groups (#95 / #96).
+
+Options:
+  --since <duration>    Window to analyze. Accepts e.g. 24h, 1h, 7d, 30m.
+                        Default: 24h.
+  --group <name>        Filter to a single group (substring match).
+  --limit <n>           Show at most N groups (most contended first).
+                        Default: 10.
+
+Required env: NEXAAS_WORKSPACE
+`;
+
+function parseSince(s: string): number | null {
+  const m = s.trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*(m|h|d)$/);
+  if (!m) return null;
+  const n = Number.parseFloat(m[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  switch (m[2]) {
+    case "m": return n * 60 * 1000;
+    case "h": return n * 60 * 60 * 1000;
+    case "d": return n * 24 * 60 * 60 * 1000;
+    default:  return null;
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function fmtMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}min`;
+}
+
+/**
+ * Build per-group stats from acquired + released event streams.
+ *
+ * Acquires carry the wait_ms directly. Hold-time is paired by
+ * (workspace, skill_id, run_id, group) — `withGroups()`'s lockMeta
+ * always supplies these three when the workspace is set, so the pair
+ * is deterministic when both events landed. Acquires without a
+ * matching release (worker died mid-skill, lost its release event)
+ * are still counted toward the wait stats but contribute no hold
+ * time — graceful degradation for the failure mode #86 Gap 3 fixes.
+ *
+ * Exported for the regression test (#98 test); not part of the
+ * runtime's public surface.
+ */
+export function buildStats(
+  acquired: LockAcquiredRow[],
+  released: LockReleasedRow[],
+): Map<string, GroupStats> {
+  const byGroup = new Map<string, GroupStats>();
+
+  for (const r of acquired) {
+    let stats = byGroup.get(r.group);
+    if (!stats) {
+      stats = {
+        group: r.group,
+        acquires: 0,
+        uniqueSkills: new Set(),
+        waitMs: [],
+        topBlocked: { skillId: r.skill_id ?? "(unknown)", maxWaitMs: 0 },
+        holdMsBySkill: new Map(),
+      };
+      byGroup.set(r.group, stats);
+    }
+    stats.acquires++;
+    if (r.skill_id) stats.uniqueSkills.add(r.skill_id);
+    stats.waitMs.push(r.wait_ms);
+    if (r.wait_ms > stats.topBlocked.maxWaitMs) {
+      stats.topBlocked = { skillId: r.skill_id ?? "(unknown)", maxWaitMs: r.wait_ms };
+    }
+  }
+
+  // Pair acquired ↔ released by (group, skill_id, run_id) for hold time.
+  // Use a multi-map keyed on the same triple so duplicates handle correctly.
+  const acquiredByKey = new Map<string, number>();   // key → acquired_at ms
+  for (const r of acquired) {
+    if (!r.skill_id || !r.run_id) continue;
+    acquiredByKey.set(`${r.group}|${r.skill_id}|${r.run_id}`, Date.parse(r.acquired_at));
+  }
+  for (const r of released) {
+    if (!r.skill_id || !r.run_id) continue;
+    const key = `${r.group}|${r.skill_id}|${r.run_id}`;
+    const acquiredAt = acquiredByKey.get(key);
+    if (acquiredAt === undefined) continue;
+    const holdMs = Date.parse(r.released_at) - acquiredAt;
+    if (!Number.isFinite(holdMs) || holdMs < 0) continue;
+
+    const stats = byGroup.get(r.group);
+    if (!stats) continue;
+    const list = stats.holdMsBySkill.get(r.skill_id) ?? [];
+    list.push(holdMs);
+    stats.holdMsBySkill.set(r.skill_id, list);
+  }
+
+  return byGroup;
+}
+
+function suggestion(stats: GroupStats): string | null {
+  const sorted = [...stats.waitMs].sort((a, b) => a - b);
+  const p99 = percentile(sorted, 99);
+  if (p99 < 5_000) return null;
+
+  // Find top blocker (skill that held the lock longest on average).
+  let topBlockerId: string | null = null;
+  let topBlockerAvg = 0;
+  for (const [skillId, holds] of stats.holdMsBySkill) {
+    if (holds.length === 0) continue;
+    const avg = holds.reduce((a, b) => a + b, 0) / holds.length;
+    if (avg > topBlockerAvg) { topBlockerAvg = avg; topBlockerId = skillId; }
+  }
+  if (!topBlockerId) return null;
+
+  return (
+    `${stats.topBlocked.skillId} waited ${fmtMs(stats.topBlocked.maxWaitMs)} ` +
+    `on '${stats.group}' (held by ${topBlockerId}, ` +
+    `avg hold ${fmtMs(topBlockerAvg)}) — consider splitting ${topBlockerId} ` +
+    `or moving ${stats.topBlocked.skillId} off the same minute.`
+  );
+}
+
+export async function runLocks(args: string[]): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const workspace = process.env.NEXAAS_WORKSPACE;
+  if (!workspace) {
+    console.error("NEXAAS_WORKSPACE is required");
+    process.exit(1);
+  }
+
+  let sinceMs = 24 * 60 * 60 * 1000;
+  let groupFilter: string | null = null;
+  let limit = 10;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--since" && args[i + 1]) {
+      const parsed = parseSince(args[++i]);
+      if (parsed === null) {
+        console.error(`Invalid --since: ${args[i]}. Examples: 24h, 1h, 7d, 30m`);
+        process.exit(1);
+      }
+      sinceMs = parsed;
+    } else if (args[i] === "--group" && args[i + 1]) {
+      groupFilter = args[++i];
+    } else if (args[i] === "--limit" && args[i + 1]) {
+      limit = Number.parseInt(args[++i], 10);
+      if (!Number.isFinite(limit) || limit <= 0) limit = 10;
+    }
+  }
+
+  createPool();
+  const sinceIso = new Date(Date.now() - sinceMs).toISOString();
+
+  const [acquired, released] = await Promise.all([
+    sql<LockAcquiredRow>(
+      `SELECT
+         payload->>'group' AS "group",
+         payload->>'skill_id' AS skill_id,
+         payload->>'run_id' AS run_id,
+         COALESCE((payload->>'wait_ms')::int, 0) AS wait_ms,
+         created_at::text AS acquired_at
+       FROM nexaas_memory.wal
+       WHERE workspace = $1
+         AND op = 'lock_acquired'
+         AND created_at >= $2::timestamptz`,
+      [workspace, sinceIso],
+    ),
+    sql<LockReleasedRow>(
+      `SELECT
+         payload->>'group' AS "group",
+         payload->>'skill_id' AS skill_id,
+         payload->>'run_id' AS run_id,
+         created_at::text AS released_at
+       FROM nexaas_memory.wal
+       WHERE workspace = $1
+         AND op = 'lock_released'
+         AND created_at >= $2::timestamptz`,
+      [workspace, sinceIso],
+    ),
+  ]);
+
+  const byGroup = buildStats(acquired, released);
+  if (byGroup.size === 0) {
+    console.log(
+      `No lock_acquired events for workspace=${workspace} in the last ${fmtMs(sinceMs)}.`,
+    );
+    if (acquired.length === 0) {
+      console.log("Either no skills declare concurrency_groups, or none have run in this window.");
+    }
+    return;
+  }
+
+  // Sort by p99 wait_ms descending (most pathological first).
+  const ranked = [...byGroup.values()]
+    .filter((g) => groupFilter === null || g.group.includes(groupFilter))
+    .map((g) => {
+      const sorted = [...g.waitMs].sort((a, b) => a - b);
+      return {
+        ...g,
+        sorted,
+        p50: percentile(sorted, 50),
+        p99: percentile(sorted, 99),
+      };
+    })
+    .sort((a, b) => b.p99 - a.p99)
+    .slice(0, limit);
+
+  console.log(
+    `\nLock contention for workspace=${workspace} over the last ${fmtMs(sinceMs)} ` +
+    `(${ranked.length} group${ranked.length === 1 ? "" : "s"} shown):\n`,
+  );
+  for (const g of ranked) {
+    console.log(`Group: ${g.group}`);
+    console.log(`  Acquires: ${g.acquires} (${g.uniqueSkills.size} skill${g.uniqueSkills.size === 1 ? "" : "s"})`);
+    console.log(`  Wait p50: ${fmtMs(g.p50)} | p99: ${fmtMs(g.p99)}`);
+    console.log(`  Top blocked-on: ${g.topBlocked.skillId} (${fmtMs(g.topBlocked.maxWaitMs)} wait)`);
+
+    let topBlockerLine = "Top blocker:    (no released events paired)";
+    let maxAvg = 0;
+    let topId: string | null = null;
+    for (const [skillId, holds] of g.holdMsBySkill) {
+      const avg = holds.reduce((a, b) => a + b, 0) / holds.length;
+      if (avg > maxAvg) { maxAvg = avg; topId = skillId; }
+    }
+    if (topId) {
+      topBlockerLine = `Top blocker:    ${topId} (held lock ${fmtMs(maxAvg)} avg)`;
+    }
+    console.log(`  ${topBlockerLine}`);
+
+    const hint = suggestion(g);
+    if (hint) console.log(`  Suggestion: ${hint}`);
+    console.log();
+  }
+}

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,0 +1,44 @@
+/**
+ * `nexaas doctor` — runtime diagnostics.
+ *
+ * Subcommand router for read-only operational health checks. Today:
+ *
+ *   doctor locks      Concurrency-group lock contention (#98 / #95)
+ *
+ * Future subcommands will live here too — keep them read-only and pure
+ * observability. Anything that mutates state (clears stuck rows, restarts
+ * tasks, etc.) belongs under a separate command surface.
+ */
+
+import { runLocks } from "./doctor-locks.js";
+
+const USAGE = `\
+Usage: nexaas doctor <subcommand> [options]
+
+Subcommands:
+  locks [--since <duration>] [--group <name>] [--limit <n>]
+        Concurrency-group lock contention report. Reads lock_acquired
+        / lock_released WAL events emitted by skills declaring
+        concurrency_groups. See #95 / #96 / #98.
+
+Required env: NEXAAS_WORKSPACE
+Optional env: DATABASE_URL
+`;
+
+export async function run(args: string[]): Promise<void> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    process.stdout.write(USAGE);
+    return;
+  }
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "locks":
+      await runLocks(rest);
+      return;
+    default:
+      console.error(`Unknown doctor subcommand: ${sub}`);
+      console.error(USAGE);
+      process.exit(1);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,9 @@ switch (command) {
   case "gdpr":
     import("./gdpr.js").then((m) => m.run(process.argv.slice(3)));
     break;
+  case "doctor":
+    import("./doctor.js").then((m) => m.run(process.argv.slice(3)));
+    break;
   default:
     console.log(`
 Nexaas CLI — framework for context-aware AI execution
@@ -83,6 +86,7 @@ Commands:
   upgrade                              Pull latest framework + apply migrations
   create-mcp <name>                    Scaffold a new MCP server
   gdpr export|delete|redact|subjects   PII management (GDPR compliance)
+  doctor locks [--since 24h]           Concurrency-group lock contention report
   status                                Check runtime health
   verify-wal [--full]                   Verify WAL chain integrity
 

--- a/scripts/test-doctor-locks-98.mjs
+++ b/scripts/test-doctor-locks-98.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #98 — `nexaas doctor locks` stats builder.
+ *
+ * Exercises buildStats() with synthetic acquired+released event streams.
+ * Pure function, no DB required.
+ *
+ * Run from repo root: `node --import tsx scripts/test-doctor-locks-98.mjs`
+ */
+
+import { buildStats } from "../packages/cli/src/doctor-locks.ts";
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+// Helper: build matched acquired+released pair.
+function pair(group, skillId, runId, acquiredAt, waitMs, holdMs) {
+  return {
+    acquired: { group, skill_id: skillId, run_id: runId, wait_ms: waitMs, acquired_at: acquiredAt },
+    released: { group, skill_id: skillId, run_id: runId, released_at: new Date(Date.parse(acquiredAt) + holdMs).toISOString() },
+  };
+}
+
+// 1. Empty input → empty map.
+{
+  const stats = buildStats([], []);
+  assert(stats.size === 0, "empty input → empty map");
+}
+
+// 2. Single group with two acquires → stats correct.
+{
+  const acq = [
+    { group: "g1", skill_id: "ops/a", run_id: "r1", wait_ms: 100, acquired_at: "2026-05-08T15:00:00.000Z" },
+    { group: "g1", skill_id: "ops/b", run_id: "r2", wait_ms: 5000, acquired_at: "2026-05-08T15:00:01.000Z" },
+  ];
+  const rel = [
+    { group: "g1", skill_id: "ops/a", run_id: "r1", released_at: "2026-05-08T15:00:00.500Z" },
+    { group: "g1", skill_id: "ops/b", run_id: "r2", released_at: "2026-05-08T15:00:11.000Z" },
+  ];
+  const stats = buildStats(acq, rel);
+  const g1 = stats.get("g1");
+  assert(g1?.acquires === 2, "acquires count = 2");
+  assert(g1?.uniqueSkills.size === 2, "unique skill count = 2");
+  assert(g1?.waitMs.length === 2, "waitMs collected for both acquires");
+  assert(g1?.topBlocked.skillId === "ops/b", "top blocked = the longest wait skill");
+  assert(g1?.topBlocked.maxWaitMs === 5000, "top blocked wait_ms recorded");
+  assert(g1?.holdMsBySkill.get("ops/a")?.[0] === 500, "ops/a hold = 500ms");
+  assert(g1?.holdMsBySkill.get("ops/b")?.[0] === 10000, "ops/b hold = 10000ms");
+}
+
+// 3. Acquired without matching released (worker died mid-skill) → wait counted, no hold.
+{
+  const acq = [
+    { group: "g2", skill_id: "ops/dead", run_id: "r3", wait_ms: 200, acquired_at: "2026-05-08T15:00:00.000Z" },
+  ];
+  const rel = [];   // worker exited before release fired
+  const stats = buildStats(acq, rel);
+  const g2 = stats.get("g2");
+  assert(g2?.acquires === 1, "orphan acquire still counted toward acquires");
+  assert(g2?.waitMs[0] === 200, "wait_ms still collected");
+  assert(g2?.holdMsBySkill.size === 0, "no hold recorded for orphan");
+}
+
+// 4. Released without matching acquired (cross-worker race or stale event) → ignored.
+{
+  const acq = [];
+  const rel = [
+    { group: "g3", skill_id: "ops/x", run_id: "r4", released_at: "2026-05-08T15:00:00.000Z" },
+  ];
+  const stats = buildStats(acq, rel);
+  assert(stats.size === 0, "released-only event → no group stats created");
+}
+
+// 5. Multiple acquires for same skill on the same group.
+{
+  const p1 = pair("g4", "ops/repeat", "r-1", "2026-05-08T15:00:00.000Z", 100, 1000);
+  const p2 = pair("g4", "ops/repeat", "r-2", "2026-05-08T15:01:00.000Z", 250, 2000);
+  const stats = buildStats([p1.acquired, p2.acquired], [p1.released, p2.released]);
+  const g4 = stats.get("g4");
+  assert(g4?.acquires === 2, "same skill 2 acquires");
+  assert(g4?.uniqueSkills.size === 1, "but only 1 unique skill");
+  const holds = g4?.holdMsBySkill.get("ops/repeat") ?? [];
+  assert(holds.length === 2, "both holds recorded");
+  assert(holds.includes(1000) && holds.includes(2000), "both hold values present");
+}
+
+// 6. Multiple groups in one input → independently aggregated.
+{
+  const a = pair("g5", "skill/a", "ra", "2026-05-08T15:00:00.000Z", 100, 500);
+  const b = pair("g6", "skill/b", "rb", "2026-05-08T15:00:00.000Z", 200, 1000);
+  const stats = buildStats([a.acquired, b.acquired], [a.released, b.released]);
+  assert(stats.size === 2, "two groups");
+  assert(stats.get("g5")?.uniqueSkills.has("skill/a"), "g5 has skill/a");
+  assert(stats.get("g6")?.uniqueSkills.has("skill/b"), "g6 has skill/b");
+  assert(!stats.get("g5")?.uniqueSkills.has("skill/b"), "g5 doesn't have skill/b");
+}
+
+// 7. Skill-id null on event → skipped from pairing but counted as acquire.
+{
+  const acq = [
+    { group: "g7", skill_id: null, run_id: null, wait_ms: 50, acquired_at: "2026-05-08T15:00:00.000Z" },
+    { group: "g7", skill_id: "ops/known", run_id: "r1", wait_ms: 100, acquired_at: "2026-05-08T15:00:00.000Z" },
+  ];
+  const rel = [
+    { group: "g7", skill_id: "ops/known", run_id: "r1", released_at: "2026-05-08T15:00:01.000Z" },
+  ];
+  const stats = buildStats(acq, rel);
+  const g7 = stats.get("g7");
+  assert(g7?.acquires === 2, "both acquires counted (including the null-skill one)");
+  assert(g7?.uniqueSkills.size === 1, "unique skills only counts non-null skill_ids");
+  assert(g7?.holdMsBySkill.size === 1, "only the paired one has hold time");
+}
+
+// 8. Released with mismatched run_id → not paired.
+{
+  const acq = [
+    { group: "g8", skill_id: "ops/x", run_id: "r-orig", wait_ms: 0, acquired_at: "2026-05-08T15:00:00.000Z" },
+  ];
+  const rel = [
+    { group: "g8", skill_id: "ops/x", run_id: "r-different", released_at: "2026-05-08T15:00:01.000Z" },
+  ];
+  const stats = buildStats(acq, rel);
+  const g8 = stats.get("g8");
+  assert(g8?.holdMsBySkill.size === 0, "mismatched run_id → no hold recorded");
+}
+
+// 9. Released BEFORE acquired (clock skew, retroactive event) → discarded as negative hold.
+{
+  const acq = [
+    { group: "g9", skill_id: "ops/x", run_id: "r1", wait_ms: 10, acquired_at: "2026-05-08T15:00:01.000Z" },
+  ];
+  const rel = [
+    { group: "g9", skill_id: "ops/x", run_id: "r1", released_at: "2026-05-08T15:00:00.000Z" },  // -1000ms
+  ];
+  const stats = buildStats(acq, rel);
+  const g9 = stats.get("g9");
+  assert(g9?.holdMsBySkill.size === 0, "negative hold (clock-skew) → discarded");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #98. Closes the loop on the concurrency-groups feature (#95 / #96) — Phase 1 emits the WAL events; this PR is the operator-facing reader.

## Why

Without this, an operator has no signal that their \`concurrency_groups\` declarations are correctly serializing or that a long-running skill is starving short ones — they find out only when something downstream fails.

## Sample output (matches the issue body)

\`\`\`
$ nexaas doctor locks --since 24h
Lock contention for workspace=phoenix-voyages over the last 24h (3 groups shown):

Group: sqlite:data/onboarding.db
  Acquires: 487 (8 skills)
  Wait p50: 1.2s | p99: 47s
  Top blocked-on: hr/stripe-billing-sync (47s wait)
  Top blocker:    hr/engagement-sync (held lock 38s avg)
  Suggestion: hr/stripe-billing-sync waited 47s on 'sqlite:data/onboarding.db' (held by hr/engagement-sync, avg hold 38s) — consider splitting hr/engagement-sync or moving hr/stripe-billing-sync off the same minute.
\`\`\`

## What lands

- **New `nexaas doctor` command surface** for read-only operational diagnostics. Future subcommands live alongside (`heartbeat`, `queues`, etc.); anything that mutates state belongs elsewhere.
- **`nexaas doctor locks [--since 24h] [--group <substr>] [--limit 10]`** — reads `lock_acquired` / `lock_released` events from `nexaas_memory.wal`, builds per-group stats, sorts by p99 wait_ms descending.
- **Per-group stats:** acquire count, unique skill count, p50 / p99 wait_ms, top-blocked-on skill (longest wait), top blocker (held lock longest on average), one-line suggestion when p99 > 5s.
- **Pairing strategy:** matched on `(group, skill_id, run_id)` — `withGroups()` always supplies these three when workspace is set, so pairing is deterministic when both events landed.
- **Graceful degradation:** acquires without a matching release (worker died mid-skill — exactly the failure mode #86 Gap 3 fixes) are still counted toward wait stats but contribute no hold time. No false signal from worker-killed runs.
- **Negative-hold guard:** released-before-acquired (clock skew, retroactive event) is discarded so a misbehaving event source doesn't pollute averages.

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-doctor-locks-98.mjs`** — 25 cases all pass:
  - Empty input → empty map
  - Single group, multiple acquires → correct counts, top-blocked skill, hold times
  - Orphan acquire (worker died) → wait counted, no hold
  - Released without acquired → ignored
  - Multiple groups → independently aggregated
  - Same skill multi-acquire → both holds recorded
  - Null `skill_id` → counted as acquire but excluded from pairing
  - `run_id` mismatch → not paired (no false hold)
  - Clock-skew negative hold → discarded

## Test plan

- [ ] On Phoenix: run `nexaas doctor locks --since 24h` and confirm output matches the actual SQLite contention pattern Mireille's HR pipeline exhibits
- [ ] `nexaas doctor locks --group sqlite:` filters as expected
- [ ] `nexaas doctor locks --since 1h --limit 3` narrows the report
- [ ] `nexaas doctor locks` on a workspace with no concurrency_groups declared shows the friendly \"no events\" message

## Out of scope

Real-time dashboards / Bull Board widgets (per the issue's explicit deferral). CLI consumes the same WAL events; phase-2 surfaces can layer on without changing this command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `nexaas doctor locks` CLI diagnostic command to monitor and report on concurrency lock contention, wait-time metrics, and bottleneck identification.

* **Documentation**
  * Added comprehensive guide for the "Approval with free-text follow-up" pattern, covering use cases, implementation approaches, channel binding requirements, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->