### PR TITLE
feat(runtime): POST /api/skills/trigger HTTP endpoint (#83)

### DIFF
--- a/packages/runtime/src/api/skills-trigger.ts
+++ b/packages/runtime/src/api/skills-trigger.ts
@@ -1,0 +1,222 @@
+/**
+ * Helpers for the `/api/skills/trigger` HTTP endpoint (#83).
+ *
+ * The peer of `nexaas trigger-skill` for non-CLI callers (Nexmatic
+ * dashboard "send now" buttons, external webhooks, dashboard manual
+ * re-runs). Same auth posture as `/api/waitpoints/inbound-match`:
+ * `bearerAuth()` if `NEXAAS_CROSS_VPS_BEARER_TOKEN` is set, otherwise
+ * pass-through (localhost-only deployments where the dashboard runs on
+ * the same VPS).
+ *
+ * The actual Express route lives in `packages/runtime/src/worker.ts`
+ * so it sits next to its peers (`/api/waitpoints/*`, `/api/drawers/*`).
+ * This module owns the bits that benefit from being testable without
+ * spinning up Express:
+ *
+ * - skill_id → manifest path resolution with path-traversal protection
+ * - manifest load + id-vs-id consistency check
+ * - request-body validation
+ *
+ * The `executeTrigger()` orchestrator wires those helpers together and
+ * the actual queue.add() so the route handler stays a thin shim.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { resolve, sep } from "path";
+import { load as yamlLoad } from "js-yaml";
+import { randomUUID } from "crypto";
+
+export interface TriggerInput {
+  skillId: string;
+  workspace?: string;
+  payload?: Record<string, unknown>;
+  actor?: string;
+  idempotencyKey?: string;
+}
+
+export type TriggerError =
+  | { status: 400; error: string }
+  | { status: 404; error: string };
+
+export interface TriggerSuccess {
+  status: 202;
+  body: {
+    ok: true;
+    data: {
+      runId: string;
+      queueJobId: string | undefined;
+    };
+  };
+}
+
+export type TriggerOutcome = TriggerError | TriggerSuccess;
+
+export interface ManifestSlim {
+  id: string;
+  version: string;
+  execution?: { type?: string };
+}
+
+/**
+ * Resolve a skill_id into an absolute manifest path under the workspace's
+ * skills root, rejecting any input that would escape the root.
+ *
+ * Matches the convention used by `nexaas register-skill` and the worker's
+ * scheduler self-heal: `<root>/nexaas-skills/<category>/<name>/skill.yaml`.
+ *
+ * Returns null for inputs that look like path-traversal attempts. The
+ * caller surfaces a 400; we don't try to be clever about partial matches.
+ */
+export function resolveSkillManifestPath(
+  skillId: string,
+  workspaceRoot: string,
+): string | null {
+  // Tighten input shape — alphanumeric segments separated by `/`, no `..`,
+  // no leading slash, no embedded NULs.
+  if (!/^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/.test(skillId)) return null;
+
+  const skillsRoot = resolve(workspaceRoot, "nexaas-skills");
+  const candidate = resolve(skillsRoot, skillId, "skill.yaml");
+
+  // Defense in depth — even though the regex above blocks `..`, verify
+  // the resolved path is genuinely under the skills root before touching
+  // the filesystem. Catches e.g. symlinked categories.
+  if (!candidate.startsWith(skillsRoot + sep)) return null;
+
+  return candidate;
+}
+
+export function loadSkillManifest(path: string): ManifestSlim | null {
+  if (!existsSync(path)) return null;
+  try {
+    const m = yamlLoad(readFileSync(path, "utf-8")) as ManifestSlim;
+    if (!m?.id || !m?.version) return null;
+    return m;
+  } catch {
+    return null;
+  }
+}
+
+export function validateTriggerInput(input: unknown): TriggerInput | TriggerError {
+  if (!input || typeof input !== "object") {
+    return { status: 400, error: "request body must be a JSON object" };
+  }
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.skillId !== "string" || obj.skillId.length === 0) {
+    return { status: 400, error: "skillId is required" };
+  }
+  if (obj.workspace !== undefined && typeof obj.workspace !== "string") {
+    return { status: 400, error: "workspace must be a string when provided" };
+  }
+  if (obj.actor !== undefined && typeof obj.actor !== "string") {
+    return { status: 400, error: "actor must be a string when provided" };
+  }
+  if (obj.idempotencyKey !== undefined && typeof obj.idempotencyKey !== "string") {
+    return { status: 400, error: "idempotencyKey must be a string when provided" };
+  }
+  if (obj.payload !== undefined && (obj.payload === null || typeof obj.payload !== "object" || Array.isArray(obj.payload))) {
+    return { status: 400, error: "payload must be a JSON object when provided" };
+  }
+  return {
+    skillId: obj.skillId,
+    workspace: obj.workspace as string | undefined,
+    payload: obj.payload as Record<string, unknown> | undefined,
+    actor: obj.actor as string | undefined,
+    idempotencyKey: obj.idempotencyKey as string | undefined,
+  };
+}
+
+export interface ExecuteDeps {
+  workspaceRoot: string;
+  defaultWorkspace: string | undefined;
+  enqueue: (queueName: string, jobName: string, data: unknown, opts: { jobId: string }) => Promise<{ id: string | undefined }>;
+  audit: (entry: {
+    workspace: string;
+    op: string;
+    actor: string;
+    payload: Record<string, unknown>;
+  }) => Promise<void>;
+}
+
+/**
+ * The end-to-end trigger flow: validate → resolve manifest → enqueue
+ * → audit. Handler in worker.ts is just `res.status(out.status).json(out.body)`.
+ */
+export async function executeTrigger(
+  input: TriggerInput,
+  deps: ExecuteDeps,
+): Promise<TriggerOutcome> {
+  const workspace = input.workspace ?? deps.defaultWorkspace;
+  if (!workspace) {
+    return { status: 400, error: "workspace is required (or set NEXAAS_WORKSPACE on the worker)" };
+  }
+
+  const manifestPath = resolveSkillManifestPath(input.skillId, deps.workspaceRoot);
+  if (!manifestPath) {
+    return { status: 400, error: `invalid skillId: must match [a-zA-Z0-9_-]+(\\/[a-zA-Z0-9_-]+)*` };
+  }
+
+  const manifest = loadSkillManifest(manifestPath);
+  if (!manifest) {
+    return { status: 404, error: `skill not found at ${manifestPath} — register it first via 'nexaas register-skill'` };
+  }
+  if (manifest.id !== input.skillId) {
+    return {
+      status: 400,
+      error: `manifest id mismatch — file declares '${manifest.id}', request asked for '${input.skillId}'`,
+    };
+  }
+
+  const runId = randomUUID();
+  const sanitizedSkillId = manifest.id.replace(/\//g, "-");
+  // BullMQ jobIds dedupe within retention. With idempotencyKey supplied,
+  // repeated POSTs collapse to the same job; without, each request gets
+  // a unique id (but the runId in the response identifies the run either
+  // way).
+  const jobId = input.idempotencyKey
+    ? `manual-${sanitizedSkillId}-${input.idempotencyKey}`
+    : `manual-${sanitizedSkillId}-${runId}`;
+
+  const enqueued = await deps.enqueue(
+    `nexaas-skills-${workspace}`,
+    "skill-step",
+    {
+      workspace,
+      runId,
+      skillId: manifest.id,
+      skillVersion: manifest.version,
+      stepId: manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec",
+      triggerType: "manual",
+      triggerPayload: input.payload ?? {},
+      manifestPath,
+    },
+    { jobId },
+  );
+
+  // Audit. Best-effort: if WAL append fails, the job is already enqueued
+  // and the caller should still get the runId — we surface the audit
+  // failure in the WAL layer's own logging, not as a request error.
+  try {
+    await deps.audit({
+      workspace,
+      op: "skill_trigger_http",
+      actor: input.actor ?? "http-trigger",
+      payload: {
+        skill_id: manifest.id,
+        run_id: runId,
+        job_id: enqueued.id ?? null,
+        idempotency_key: input.idempotencyKey ?? null,
+      },
+    });
+  } catch (err) {
+    console.error("[nexaas] skill_trigger_http audit emit failed:", err);
+  }
+
+  return {
+    status: 202,
+    body: {
+      ok: true,
+      data: { runId, queueJobId: enqueued.id },
+    },
+  };
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -50,6 +50,7 @@ import {
   cancelWaitpoint as cancelInboundMatch,
   listNamedPatterns,
 } from "./tasks/inbound-match-waitpoint.js";
+import { executeTrigger, validateTriggerInput } from "./api/skills-trigger.js";
 
 // Async exec for use inside HTTP handlers. Never use execSync in a route
 // handler — it blocks the Node event loop, which wedges /health, /queues,
@@ -409,6 +410,43 @@ async function main() {
   // Once the drawer lands, the inbound dispatcher's poll cycle picks
   // it up and routes to subscribed skills (inbound-match waitpoints
   // resolve within one dispatcher tick).
+
+  // ─── Manual skill trigger (#83) ─────────────────────────────────────
+  // HTTP peer of `nexaas trigger-skill` for the dashboard, external
+  // webhooks, and any add-on UX with a "do it now" button. Same auth
+  // posture as the waitpoint/inbound endpoints — bearer when
+  // NEXAAS_CROSS_VPS_BEARER_TOKEN is set, pass-through otherwise.
+
+  app.post("/api/skills/trigger", bearerAuth(), async (req, res) => {
+    try {
+      const validated = validateTriggerInput(req.body);
+      if ("error" in validated) {
+        res.status(validated.status).json({ error: validated.error });
+        return;
+      }
+      const outcome = await executeTrigger(validated, {
+        workspaceRoot: process.env.NEXAAS_WORKSPACE_ROOT ?? "/opt/nexaas",
+        defaultWorkspace: WORKSPACE,
+        enqueue: async (queueName, jobName, data, opts) => {
+          const queue = new Queue(queueName, getRedisConnectionOpts());
+          try {
+            const job = await queue.add(jobName, data, opts);
+            return { id: job.id };
+          } finally {
+            await queue.close();
+          }
+        },
+        audit: async (entry) => { await appendWal(entry); },
+      });
+      if ("error" in outcome) {
+        res.status(outcome.status).json({ error: outcome.error });
+        return;
+      }
+      res.status(outcome.status).json(outcome.body);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
 
   app.post("/api/drawers/inbound", bearerAuth(), async (req, res) => {
     try {

--- a/scripts/test-http-trigger-83.mjs
+++ b/scripts/test-http-trigger-83.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #83 — `/api/skills/trigger` HTTP endpoint helpers.
+ *
+ * Exercises the pure handler logic without an HTTP server: input
+ * validation, path-traversal protection, manifest resolution, the
+ * end-to-end trigger orchestrator with stubbed enqueue + audit deps.
+ *
+ * Run from repo root: `node --import tsx scripts/test-http-trigger-83.mjs`
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  validateTriggerInput,
+  resolveSkillManifestPath,
+  loadSkillManifest,
+  executeTrigger,
+} from "../packages/runtime/src/api/skills-trigger.ts";
+
+let pass = 0, fail = 0;
+function assert(cond, label) {
+  if (cond) { console.log(`OK    ${label}`); pass++; }
+  else      { console.log(`FAIL  ${label}`); fail++; }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. validateTriggerInput
+// ─────────────────────────────────────────────────────────────────────
+{
+  const r = validateTriggerInput(null);
+  assert("error" in r && r.status === 400, "null body → 400");
+}
+{
+  const r = validateTriggerInput({});
+  assert("error" in r && r.status === 400 && /skillId/.test(r.error), "missing skillId → 400 with name");
+}
+{
+  const r = validateTriggerInput({ skillId: "" });
+  assert("error" in r && r.status === 400, "empty skillId → 400");
+}
+{
+  const r = validateTriggerInput({ skillId: "marketing/email-broadcast" });
+  assert(!("error" in r) && r.skillId === "marketing/email-broadcast", "valid minimal → ok");
+}
+{
+  const r = validateTriggerInput({ skillId: "x/y", actor: 42 });
+  assert("error" in r && r.status === 400 && /actor/.test(r.error), "non-string actor → 400");
+}
+{
+  const r = validateTriggerInput({ skillId: "x/y", payload: "not an object" });
+  assert("error" in r && r.status === 400 && /payload/.test(r.error), "non-object payload → 400");
+}
+{
+  const r = validateTriggerInput({ skillId: "x/y", payload: ["array", "not", "object"] });
+  assert("error" in r && r.status === 400, "array payload → 400");
+}
+{
+  const r = validateTriggerInput({ skillId: "x/y", workspace: "phoenix-voyages", actor: "dashboard:user@example.com", payload: { id: 1 }, idempotencyKey: "abc" });
+  assert(!("error" in r) && r.workspace === "phoenix-voyages" && r.idempotencyKey === "abc", "full valid input → preserved");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. resolveSkillManifestPath — path traversal protection
+// ─────────────────────────────────────────────────────────────────────
+{
+  const root = "/opt/test-workspace";
+  const ok = resolveSkillManifestPath("marketing/email-broadcast", root);
+  assert(ok === "/opt/test-workspace/nexaas-skills/marketing/email-broadcast/skill.yaml",
+    "well-formed skillId resolves correctly");
+}
+{
+  const root = "/opt/test-workspace";
+  assert(resolveSkillManifestPath("../../../etc/passwd", root) === null, "../ traversal → null");
+  assert(resolveSkillManifestPath("/abs/path", root) === null, "absolute path → null");
+  assert(resolveSkillManifestPath("a/../b", root) === null, "embedded .. → null");
+  assert(resolveSkillManifestPath("a\0b", root) === null, "null byte → null");
+  assert(resolveSkillManifestPath("a$b", root) === null, "shell-meta char → null");
+  assert(resolveSkillManifestPath("a..b", root) === null, "embedded .. (no slash) → null");
+  assert(resolveSkillManifestPath("a..b/c", root) === null, "embedded .. with slash → null");
+  assert(resolveSkillManifestPath("a b/c", root) === null, "space → null");
+}
+{
+  const root = "/opt/test-workspace";
+  assert(resolveSkillManifestPath("a", root) === "/opt/test-workspace/nexaas-skills/a/skill.yaml",
+    "single segment ok");
+  assert(resolveSkillManifestPath("a/b/c", root) === "/opt/test-workspace/nexaas-skills/a/b/c/skill.yaml",
+    "three segments ok");
+  assert(resolveSkillManifestPath("under_score-and-dash", root)?.endsWith("/under_score-and-dash/skill.yaml"),
+    "underscore + dash ok");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. loadSkillManifest
+// ─────────────────────────────────────────────────────────────────────
+{
+  const tmp = mkdtempSync(join(tmpdir(), "trigger-test-"));
+  try {
+    const goodPath = join(tmp, "good.yaml");
+    writeFileSync(goodPath, `id: marketing/test\nversion: "1.0.0"\nexecution:\n  type: ai-skill\n`);
+    const m = loadSkillManifest(goodPath);
+    assert(m?.id === "marketing/test", "valid manifest loaded");
+    assert(m?.execution?.type === "ai-skill", "execution.type preserved");
+
+    const missingPath = join(tmp, "missing.yaml");
+    assert(loadSkillManifest(missingPath) === null, "missing file → null");
+
+    const badPath = join(tmp, "bad.yaml");
+    writeFileSync(badPath, "this is not yaml: : :");
+    assert(loadSkillManifest(badPath) === null, "malformed YAML → null");
+
+    const incompletePath = join(tmp, "incomplete.yaml");
+    writeFileSync(incompletePath, "description: only this\n");   // no id, no version
+    assert(loadSkillManifest(incompletePath) === null, "missing id/version → null");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. executeTrigger end-to-end with stubbed deps
+// ─────────────────────────────────────────────────────────────────────
+const tmp = mkdtempSync(join(tmpdir(), "trigger-e2e-"));
+try {
+  const skillsRoot = join(tmp, "nexaas-skills");
+  mkdirSync(join(skillsRoot, "marketing", "email-broadcast"), { recursive: true });
+  writeFileSync(
+    join(skillsRoot, "marketing", "email-broadcast", "skill.yaml"),
+    `id: marketing/email-broadcast\nversion: "1.0.0"\nexecution:\n  type: ai-skill\n`,
+  );
+  mkdirSync(join(skillsRoot, "ops", "shell-thing"), { recursive: true });
+  writeFileSync(
+    join(skillsRoot, "ops", "shell-thing", "skill.yaml"),
+    `id: ops/shell-thing\nversion: "0.5.0"\nexecution:\n  type: shell\n`,
+  );
+  // A manifest where id != path (misconfigured).
+  mkdirSync(join(skillsRoot, "broken", "wrong-id"), { recursive: true });
+  writeFileSync(
+    join(skillsRoot, "broken", "wrong-id", "skill.yaml"),
+    `id: actually/different\nversion: "1.0.0"\n`,
+  );
+
+  let enqueueCalls = [];
+  let auditCalls = [];
+  const deps = {
+    workspaceRoot: tmp,
+    defaultWorkspace: "phoenix-voyages",
+    enqueue: async (queueName, jobName, data, opts) => {
+      enqueueCalls.push({ queueName, jobName, data, opts });
+      return { id: `job-${enqueueCalls.length}` };
+    },
+    audit: async (entry) => { auditCalls.push(entry); },
+  };
+
+  // 4a. Happy path — AI skill.
+  {
+    const out = await executeTrigger(
+      { skillId: "marketing/email-broadcast", payload: { broadcast_id: "b-123" }, actor: "dashboard:al@nexmatic.ca" },
+      deps,
+    );
+    assert(out.status === 202, "AI skill happy path → 202");
+    assert(out.body.ok === true, "ok=true");
+    assert(typeof out.body.data.runId === "string" && out.body.data.runId.length === 36, "runId is a UUID");
+    assert(out.body.data.queueJobId === "job-1", "queueJobId returned");
+    assert(enqueueCalls.length === 1, "1 enqueue call");
+    assert(enqueueCalls[0].queueName === "nexaas-skills-phoenix-voyages", "queue name uses default workspace");
+    assert(enqueueCalls[0].data.skillId === "marketing/email-broadcast", "data has skillId");
+    assert(enqueueCalls[0].data.skillVersion === "1.0.0", "data has skillVersion");
+    assert(enqueueCalls[0].data.stepId === "ai-exec", "ai-skill → ai-exec stepId");
+    assert(enqueueCalls[0].data.triggerType === "manual", "triggerType is manual");
+    assert(enqueueCalls[0].data.triggerPayload.broadcast_id === "b-123", "payload forwarded");
+    assert(typeof enqueueCalls[0].data.manifestPath === "string", "manifestPath set");
+    assert(auditCalls.length === 1, "1 audit call");
+    assert(auditCalls[0].op === "skill_trigger_http", "audit op = skill_trigger_http");
+    assert(auditCalls[0].actor === "dashboard:al@nexmatic.ca", "audit actor preserved");
+  }
+
+  // 4b. Shell skill maps to shell-exec.
+  {
+    auditCalls = [];
+    enqueueCalls = [];
+    const out = await executeTrigger(
+      { skillId: "ops/shell-thing" },
+      deps,
+    );
+    assert(out.status === 202, "shell skill → 202");
+    assert(enqueueCalls[0].data.stepId === "shell-exec", "shell type → shell-exec stepId");
+    assert(auditCalls[0].actor === "http-trigger", "default actor = http-trigger");
+  }
+
+  // 4c. Missing skill → 404.
+  {
+    enqueueCalls = [];
+    const out = await executeTrigger({ skillId: "nope/missing" }, deps);
+    assert(out.status === 404, "missing skill → 404");
+    assert(/not found/.test(out.error), "error mentions 'not found'");
+    assert(enqueueCalls.length === 0, "no enqueue when not found");
+  }
+
+  // 4d. Path traversal → 400.
+  {
+    enqueueCalls = [];
+    const out = await executeTrigger({ skillId: "../../../etc/passwd" }, deps);
+    assert(out.status === 400, "traversal attempt → 400");
+    assert(enqueueCalls.length === 0, "no enqueue on traversal");
+  }
+
+  // 4e. Manifest id mismatch → 400.
+  {
+    enqueueCalls = [];
+    const out = await executeTrigger({ skillId: "broken/wrong-id" }, deps);
+    assert(out.status === 400, "manifest id mismatch → 400");
+    assert(/mismatch/.test(out.error), "error mentions 'mismatch'");
+  }
+
+  // 4f. Idempotency: same key → same jobId encoded.
+  {
+    enqueueCalls = [];
+    await executeTrigger({ skillId: "ops/shell-thing", idempotencyKey: "k1" }, deps);
+    await executeTrigger({ skillId: "ops/shell-thing", idempotencyKey: "k1" }, deps);
+    assert(enqueueCalls.length === 2, "two enqueue calls fired");
+    assert(enqueueCalls[0].opts.jobId === enqueueCalls[1].opts.jobId, "same idempotencyKey → same jobId");
+    assert(enqueueCalls[0].opts.jobId === "manual-ops-shell-thing-k1", "jobId encodes idempotencyKey");
+  }
+
+  // 4g. No idempotencyKey → unique jobId per call.
+  {
+    enqueueCalls = [];
+    await executeTrigger({ skillId: "ops/shell-thing" }, deps);
+    await executeTrigger({ skillId: "ops/shell-thing" }, deps);
+    assert(enqueueCalls[0].opts.jobId !== enqueueCalls[1].opts.jobId, "no idempotencyKey → different jobIds");
+  }
+
+  // 4h. Workspace override: explicit workspace beats default.
+  {
+    enqueueCalls = [];
+    await executeTrigger({ skillId: "ops/shell-thing", workspace: "other-workspace" }, deps);
+    assert(enqueueCalls[0].queueName === "nexaas-skills-other-workspace", "explicit workspace honored");
+    assert(enqueueCalls[0].data.workspace === "other-workspace", "data carries the explicit workspace");
+  }
+
+  // 4i. No workspace at all → 400.
+  {
+    enqueueCalls = [];
+    const out = await executeTrigger({ skillId: "ops/shell-thing" }, { ...deps, defaultWorkspace: undefined });
+    assert(out.status === 400, "no workspace + no default → 400");
+    assert(/workspace/.test(out.error), "error mentions workspace");
+  }
+
+  // 4j. Audit emit failure doesn't fail the request.
+  {
+    enqueueCalls = [];
+    const flakyDeps = {
+      ...deps,
+      audit: async () => { throw new Error("DB unreachable"); },
+    };
+    const out = await executeTrigger({ skillId: "ops/shell-thing" }, flakyDeps);
+    assert(out.status === 202, "audit failure → still 202 (best-effort)");
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #83. Adds the missing HTTP peer of \`nexaas trigger-skill\` so the Nexmatic dashboard, external webhooks, and any add-on UX with a \"do it now\" button can fire registered skills without SSHing in.

## Sample

\`\`\`
POST /api/skills/trigger
Authorization: Bearer <NEXAAS_CROSS_VPS_BEARER_TOKEN OR localhost-only>
Content-Type: application/json

{
  \"skillId\": \"marketing/email-broadcast\",
  \"payload\": { \"broadcast_id\": \"broadcast-...\" },
  \"actor\": \"dashboard:user@example.com\",
  \"idempotencyKey\": \"<optional>\"
}

→ 202 Accepted
{ \"ok\": true, \"data\": { \"runId\": \"<uuid>\", \"queueJobId\": \"manual-marketing-email-broadcast-<key-or-uuid>\" } }
\`\`\`

## What lands

- **`packages/runtime/src/api/skills-trigger.ts`** — pure handler logic factored out for testability:
  - \`validateTriggerInput()\` — body-shape validation
  - \`resolveSkillManifestPath()\` — skill_id → absolute path with **path-traversal protection** (tight regex + defense-in-depth \`resolve\`+\`startsWith\` check rejects anything outside the skills root)
  - \`loadSkillManifest()\` — slim YAML parse with id/version validation
  - \`executeTrigger()\` — orchestrator: validate → resolve → enqueue → audit
- **Express route in `packages/runtime/src/worker.ts`** mounted alongside the existing \`/api/waitpoints/*\` and \`/api/drawers/*\` peers. Same auth posture: \`bearerAuth()\` — bearer when \`NEXAAS_CROSS_VPS_BEARER_TOKEN\` is set, pass-through otherwise (dashboard on same VPS as the worker).
- **Idempotency** — \`idempotencyKey\` encodes into the BullMQ jobId, so duplicate POSTs collapse within retention. Without a key, each request gets a unique jobId but the response always identifies the run by \`runId\`.
- **Audit** — emits \`skill_trigger_http\` WAL op with \`{skill_id, run_id, job_id, idempotency_key}\`. Best-effort: audit emit failure is logged but doesn't fail the request (the job is already enqueued).
- **Response shape** per the issue: 202 + \`{ ok, data: { runId, queueJobId } }\`. Errors carry discriminating status codes (400 validation, 404 unknown skill).

## Path-traversal protection

The skill_id is part of a filesystem path, so it gets defended in depth:

| Input | Result |
|---|---|
| \`marketing/email-broadcast\` | resolves to \`<root>/nexaas-skills/marketing/email-broadcast/skill.yaml\` |
| \`../../../etc/passwd\` | 400 (regex reject) |
| \`/abs/path\` | 400 (leading slash reject) |
| \`a/../b\` | 400 (embedded ..) |
| \`a..b\` | 400 (\`..\` substring) |
| \`a\\0b\` | 400 (null byte) |
| \`a\\$b\` | 400 (shell meta) |
| \`a b/c\` | 400 (whitespace) |

## Verification

- **`tsc --noEmit` clean**
- **`scripts/test-http-trigger-83.mjs`** — 59/59 pass:
  - Body validation: 8 cases
  - Path-traversal: 14 cases (rejected patterns + well-formed paths)
  - Manifest loading: 4 cases (good / missing / malformed / incomplete)
  - End-to-end orchestrator with stubbed enqueue + audit deps: 33 cases including AI vs shell skill stepId routing, 404 missing skill, 400 traversal, 400 manifest-id mismatch, idempotency dedup, default vs explicit workspace, audit-failure-doesn't-fail-request

## Test plan

- [ ] On Phoenix (or BSBC): \`curl -X POST http://localhost:9090/api/skills/trigger -H \"Content-Type: application/json\" -d '{\"skillId\":\"<a-known-skill>\",\"payload\":{}}'\` → 202 with runId
- [ ] Same with traversal skillId → 400
- [ ] Same with unregistered skillId → 404
- [ ] Two POSTs with the same idempotencyKey → only one row in skill_runs
- [ ] Verify \`skill_trigger_http\` WAL row carries \`actor\` and \`idempotency_key\`
- [ ] When \`NEXAAS_CROSS_VPS_BEARER_TOKEN\` is set: requires bearer; when unset: localhost-only pass-through

## Out of scope (per issue)

- Cancellation endpoint (separate)
- Streaming run progress (existing \`skill_runs\` polling is fine for v1)
- Quota / rate limiting (will need it eventually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)