### PR TITLE
feat(build): run compiled JS in production (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ State lives in rooms. Skills declare which rooms they read (retrieval) and write
 
 The `nexaas-worker.service` runs the BullMQ worker, outbox relay, and Bull Board dashboard.
 
+**Production runs compiled JS (#37):** the unit invokes `node --conditions=production /opt/nexaas/packages/runtime/dist/worker.js`. Each workspace package has its own `tsconfig.json` and emits to its own `dist/` via `npm run build`. Conditional `exports` in each `package.json` route cross-package imports (`@nexaas/palace`, `@nexaas/runtime`, `@nexaas/integration-sdk`) to `dist/index.js` when `--conditions=production` is set, and to `src/index.ts` otherwise. `nexaas init` and `nexaas upgrade` both run `npm run build` before (re)starting the service; `nexaas upgrade` also auto-migrates legacy tsx-based units in place.
+
+**Dev/test runs TS source via tsx:** scripts and ad-hoc invocations use `node --import tsx packages/runtime/src/worker.ts` (or `npx tsx ...`). Without `--conditions=production`, Node falls back to the `default` exports condition, which points at `src/index.ts` — tsx transforms on the fly. Test scripts under `scripts/` follow this pattern.
+
 **Critical deployment lessons (from Phoenix production):**
 - Use direct node invocation, NOT npm/npx wrappers — snap node through npm swallows stdout and escapes cgroup cleanup
 - Use `KillMode=mixed` + `ExecStopPost=fuser -k` to prevent orphan processes holding the port

--- a/integrations/email-provider-postmark/package.json
+++ b/integrations/email-provider-postmark/package.json
@@ -3,11 +3,21 @@
   "version": "0.1.0",
   "description": "Postmark implementation of the Nexaas email-outbound capability. Reference integration (#88).",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
+    "dist",
     "nexaas-integration.yaml"
   ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"
   },

--- a/integrations/email-provider-postmark/tsconfig.json
+++ b/integrations/email-provider-postmark/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/integrations/email-provider-resend/package.json
+++ b/integrations/email-provider-resend/package.json
@@ -3,11 +3,21 @@
   "version": "0.1.0",
   "description": "Resend implementation of the Nexaas email-outbound capability. Reference integration (#88).",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
+    "dist",
     "nexaas-integration.yaml"
   ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"
   },

--- a/integrations/email-provider-resend/tsconfig.json
+++ b/integrations/email-provider-resend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/integrations/email-provider-sendgrid/package.json
+++ b/integrations/email-provider-sendgrid/package.json
@@ -3,11 +3,21 @@
   "version": "0.1.0",
   "description": "SendGrid implementation of the Nexaas email-outbound capability. Reference integration (#88).",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
+    "dist",
     "nexaas-integration.yaml"
   ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"
   },

--- a/integrations/email-provider-sendgrid/tsconfig.json
+++ b/integrations/email-provider-sendgrid/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "description": "Outbound email MCP server — implements the email-outbound capability (#78). Provider-pluggable; ships with Resend, Postmark, and SendGrid.",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@nexaas/integration-sdk": "0.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,9 +3,18 @@
   "version": "0.1.0",
   "description": "Nexaas CLI tools — verify-wal, validate-skill, install-agent, rebuild-skill-runs, dry-run",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "nexaas": "src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "@nexaas/palace": "^0.1.0",

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -334,10 +334,16 @@ NEXAAS_WORKER_PORT=9090
 
   step(5, TOTAL_STEPS, "Installing services...");
 
-  // Resolve tsx path — bypass npm/npx wrapper to fix journald logging (#20)
-  // and orphan process cleanup (#18)
-  // Prefer global tsx, fall back to local
-  const tsxBin = exec("which tsx", { silent: true }) || `${NEXAAS_ROOT}/node_modules/.bin/tsx`;
+  // Build compiled JS for production (#37). The systemd unit runs
+  // `node --conditions=production dist/worker.js` so cross-package
+  // imports resolve to compiled JS rather than tsx-transpiled TS at
+  // runtime — quicker boots, lower memory, no tsx in the hot path.
+  exec(`cd ${NEXAAS_ROOT} && npm run build`);
+  if (!existsSync(join(NEXAAS_ROOT, "packages/runtime/dist/worker.js"))) {
+    fail("Build failed — packages/runtime/dist/worker.js missing. Check 'npm run build' output above.");
+  }
+  log("Production build complete");
+
   const nodeBin = exec("which node", { silent: true }) || "/usr/bin/node";
 
   const serviceContent = `[Unit]
@@ -349,7 +355,7 @@ Type=simple
 User=${dbUser}
 WorkingDirectory=${NEXAAS_ROOT}
 EnvironmentFile=${NEXAAS_ROOT}/.env
-ExecStart=${nodeBin} ${tsxBin} ${NEXAAS_ROOT}/packages/runtime/src/worker.ts
+ExecStart=${nodeBin} --conditions=production ${NEXAAS_ROOT}/packages/runtime/dist/worker.js
 ExecStopPost=/bin/sh -c 'fuser -k -TERM 9090/tcp 2>/dev/null; sleep 2; fuser -k -KILL 9090/tcp 2>/dev/null; exit 0'
 Restart=always
 RestartSec=5

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -101,6 +101,26 @@ export async function run(args: string[]) {
         exec(`cd ${nexaasRoot} && npm install --production 2>/dev/null`, { timeout: 300_000 });
         console.log("  Dependencies updated");
       }
+
+      // Step 4b: Compile TS → JS for production (#37). The systemd unit
+      // runs compiled JS via `node --conditions=production dist/worker.js`.
+      // Build is fast (<10s on a warm cache) and skipped only when no
+      // source files changed.
+      const sourceChanged = changedFiles.split("\n").some((f) => /^(packages|integrations|mcp\/servers)\/[^/]+\/(src|tsconfig)/.test(f));
+      if (sourceChanged || !existsSync(join(nexaasRoot, "packages/runtime/dist/worker.js"))) {
+        console.log("  Building production JS...");
+        exec(`cd ${nexaasRoot} && npm run build`, { timeout: 300_000 });
+        if (!existsSync(join(nexaasRoot, "packages/runtime/dist/worker.js"))) {
+          console.error("  Build failed — packages/runtime/dist/worker.js missing.");
+          process.exit(1);
+        }
+        console.log("  Build complete");
+      }
+
+      // Step 4c: Auto-migrate the systemd unit if it's still on the old
+      // tsx-based ExecStart. New installs (#37) write the compiled-JS
+      // form directly; existing installs flip on first upgrade.
+      maybeMigrateSystemdUnit(nexaasRoot);
     }
   }
 
@@ -199,6 +219,46 @@ export async function run(args: string[]) {
 
   console.log("");
   await pool.end();
+}
+
+/**
+ * Flip an existing nexaas-worker.service from the legacy tsx ExecStart
+ * to the compiled-JS form (#37). One-shot: detects the old `node tsx
+ * .../src/worker.ts` invocation and rewrites it to
+ * `node --conditions=production .../dist/worker.js`. No-op once
+ * migrated. The unit ships compiled-by-default for new installs.
+ */
+function maybeMigrateSystemdUnit(nexaasRoot: string): void {
+  const unitPath = "/etc/systemd/system/nexaas-worker.service";
+  if (!existsSync(unitPath)) return;
+
+  let unit: string;
+  try {
+    unit = readFileSync(unitPath, "utf-8");
+  } catch {
+    return; // No permission to read — leave alone.
+  }
+
+  // Already migrated.
+  if (unit.includes("--conditions=production") && unit.includes("dist/worker.js")) return;
+
+  // Match the legacy form: `ExecStart=<node> <tsx> .../packages/runtime/src/worker.ts`
+  const legacy = /^ExecStart=(\S+)\s+\S+tsx\S*\s+\S+\/packages\/runtime\/src\/worker\.ts.*$/m;
+  const m = unit.match(legacy);
+  if (!m) return; // Some other custom form — don't touch.
+
+  const nodeBin = m[1]!;
+  const newExecStart = `ExecStart=${nodeBin} --conditions=production ${nexaasRoot}/packages/runtime/dist/worker.js`;
+  const migrated = unit.replace(legacy, newExecStart);
+
+  console.log("\n  Migrating systemd unit to compiled-JS ExecStart (#37)...");
+  try {
+    exec(`sudo tee ${unitPath} > /dev/null <<'NEXAAS_UNIT_EOF'\n${migrated}\nNEXAAS_UNIT_EOF`);
+    exec("sudo systemctl daemon-reload");
+    console.log("  Systemd unit migrated");
+  } catch (e) {
+    console.error(`  Systemd unit migration failed (will retry next upgrade): ${(e as Error).message}`);
+  }
 }
 
 async function getPendingMigrations(pool: pg.Pool, nexaasRoot: string): Promise<string[]> {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/packages/integration-sdk/package.json
+++ b/packages/integration-sdk/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "description": "Authoring kit for Nexaas integrations — manifest schema, capability contracts, and shared helpers used by all integration packages (reference + adopter).",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "zod": "^3.23.0"
   },

--- a/packages/integration-sdk/tsconfig.json
+++ b/packages/integration-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/packages/palace/package.json
+++ b/packages/palace/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "description": "Palace substrate — data model, palace API, WAL, signing, verification, pgvector retrieval",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "pg": "^8.20.0",
     "zod": "^3.23.0"

--- a/packages/palace/tsconfig.json
+++ b/packages/palace/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -3,7 +3,16 @@
   "version": "0.1.0",
   "description": "Pillar pipeline runtime — CAG, RAG, TAG, model gateway, BullMQ execution, sub-agents, Bull Board dashboard",
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
     "@bull-board/api": "^6.0.0",

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false,
+    "removeComments": false
+  }
+}


### PR DESCRIPTION
Closes #37.

## Summary

Production worker now runs compiled JS instead of `node --import tsx ... src/worker.ts`, eliminating esbuild from the long-running hot path. This is the structural fix behind the #33 mitigation: handler authors no longer need to police dynamic imports to keep `/health` from stalling on transpile lag.

## How it works

- **Per-package builds.** Every workspace package has its own `tsconfig.json` extending `tsconfig.base.json` and emitting to its own `dist/`. `npm run build` at root fans out via `--workspaces --if-present`.
- **Conditional exports.** Each `package.json` declares:
  ```json
  "exports": {
    ".": {
      "production": "./dist/index.js",
      "default": "./src/index.ts"
    }
  }
  ```
  Node with `--conditions=production` resolves cross-package imports (`@nexaas/palace`, `@nexaas/runtime`, `@nexaas/integration-sdk`) to compiled JS. Without it (dev/test/scripts), Node falls back to `default` → `src/index.ts`, which `tsx` transforms on the fly.
- **`nexaas init`** runs `npm run build` before the service install and writes a unit with `ExecStart=node --conditions=production .../packages/runtime/dist/worker.js`.
- **`nexaas upgrade`** runs `npm run build` after pulling (when source/tsconfig changed) and includes a one-shot `maybeMigrateSystemdUnit()` that flips legacy tsx-based units in place — existing installs auto-migrate on first upgrade.

Buildable packages (8): `palace`, `runtime`, `integration-sdk`, `cli`, three email-provider integrations, `mcp/servers/email-outbound`. Empty shell packages (`factory`, `ops-console-core`) are not built.

## Test plan

- [x] `npm run build` from repo root — all 8 packages compile clean
- [x] `node --conditions=production packages/runtime/dist/worker.js` boots fully (Express up, BullMQ worker started, outbox + dispatchers polling, "Worker ready"), drains cleanly on SIGTERM. Stack traces during smoke-test confirm cross-package resolution lands at `packages/palace/dist/db.js` (production condition active)
- [x] `node --import tsx ... src/...` dev/test path still resolves to TS source via default condition
- [x] `node --check` passes on `worker.js`, `palace/dist/index.js`, `cli/dist/index.js`, `email-provider-resend/dist/index.js`, `mcp/servers/email-outbound/dist/index.js`
- [ ] Manually run `nexaas upgrade` on a Phoenix-style install and confirm the unit migration triggers (will verify post-merge on canary)
- [ ] Confirm worker boot time drops vs tsx baseline (anecdotal, post-merge)

## Files

20 files: 1 new root `tsconfig.base.json`, 8 per-package `tsconfig.json`, 8 `package.json` exports updates, 2 CLI sources (`init.ts`, `upgrade.ts`), 1 CLAUDE.md doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)