### PR TITLE
feat(pa-router): Wave 1 foundation — schema + persona profile (#122)

### DIFF
--- a/database/migrations/020_pa_threads.sql
+++ b/database/migrations/020_pa_threads.sql
@@ -1,0 +1,48 @@
+-- PA-as-Router Wave 1 (RFC-0002, #122).
+--
+-- Foundational schema for domain-scoped per-PA threads:
+--
+--   1. events.thread_id     — first-class column on the central events table
+--                             (justification in RFC §3.1: every PA inbound
+--                             classification, every inbox-by-thread query,
+--                             every per-thread digest reads WHERE thread_id=$1)
+--   2. pa_threads           — declared thread registry, per (workspace, user)
+--                             with channel_target opacity (jsonb)
+--
+-- Forward migration is purely additive — no behavior change until Wave 2
+-- wires the new endpoint and Wave 3 wires the resolver shadow drawer.
+--
+-- Reverse migration drops the column + table and is destructive of any
+-- PA-thread state. Production rollback requires operator-level coordination
+-- (see #122 acceptance).
+
+ALTER TABLE nexaas_memory.events
+  ADD COLUMN IF NOT EXISTS thread_id text;
+
+-- Partial index on the typical PA inbound-classification query:
+--   SELECT ... WHERE workspace=$1 AND hall=$2 AND thread_id=$3
+--   ORDER BY created_at DESC LIMIT N
+-- WHERE-clause skip rows where thread_id is null (the overwhelming majority
+-- of rows from non-PA skills) so the index stays compact.
+CREATE INDEX IF NOT EXISTS events_user_thread_idx
+  ON nexaas_memory.events (workspace, hall, thread_id, created_at DESC)
+  WHERE thread_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS nexaas_memory.pa_threads (
+  workspace          text NOT NULL,
+  user_hall          text NOT NULL,                -- e.g. "<user_handle>"
+  thread_id          text NOT NULL,                -- e.g. "hr"
+  display_name       text NOT NULL,                -- "👥 HR"
+  status             text NOT NULL DEFAULT 'active',  -- active | paused | closed
+  channel_target     jsonb,                        -- e.g. {"telegram":{"chat_id":"-100…","topic_id":3}}
+  domain_aliases     text[] DEFAULT '{}',          -- inference hints (RFC §3.4)
+  opened_at          timestamptz NOT NULL DEFAULT now(),
+  last_activity      timestamptz NOT NULL DEFAULT now(),
+  notification_count integer NOT NULL DEFAULT 0,
+  PRIMARY KEY (workspace, user_hall, thread_id),
+  CONSTRAINT pa_threads_status_chk CHECK (status IN ('active', 'paused', 'closed'))
+);
+
+CREATE INDEX IF NOT EXISTS pa_threads_user_active_idx
+  ON nexaas_memory.pa_threads (workspace, user_hall, status)
+  WHERE status = 'active';

--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -13,12 +13,18 @@
  */
 
 import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
+import { resolve, dirname, join } from "path";
 import { execSync } from "child_process";
 import { load as yamlLoad } from "js-yaml";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 import parser from "cron-parser";
+import {
+  loadPersonaProfile,
+  upsertPaThreads,
+  detectPaReplyUser,
+  type UpsertSummary,
+} from "@nexaas/runtime";
 
 export interface SkillManifest {
   id: string;
@@ -35,6 +41,7 @@ export interface SkillManifest {
     type: string;
     schedule?: string;
     timezone?: string;
+    channel_role?: string;            // for type=inbound-message; e.g. "pa_reply_<user>"
   }>;
   execution?: {
     type: string;
@@ -69,6 +76,12 @@ export interface RegisterResult {
   status: "registered" | "no-triggers" | "error";
   error?: string;
   warnings?: CronOverlapWarning[];
+  /** PA-as-Router (#122). Set when this skill is a PA conversation-turn skill. */
+  paProfile?: {
+    userHall: string;
+    profilePath: string;
+    summary: UpsertSummary;
+  };
 }
 
 const USAGE = `\
@@ -269,6 +282,7 @@ export async function registerOneSkill(
 
   let registered = 0;
   let cleaned = 0;
+  let paProfile: RegisterResult["paProfile"];
 
   if (!manifest.triggers || manifest.triggers.length === 0) {
     return {
@@ -278,6 +292,33 @@ export async function registerOneSkill(
       cleaned: 0,
       status: "no-triggers",
     };
+  }
+
+  // PA-as-Router (#122 Wave 1) — when a skill declares an inbound-message
+  // trigger with channel_role `pa_reply_<user>`, locate the persona profile
+  // at agents/pa/sub-agents/<user>/profile.yaml relative to the manifest's
+  // workspace root, validate it, and project its `threads:` block into
+  // pa_threads. Hard-fail registration on missing or malformed profile —
+  // a PA without a thread declaration would route nothing.
+  for (const trigger of manifest.triggers) {
+    if (trigger.type !== "inbound-message") continue;
+    const userHall = detectPaReplyUser(trigger.channel_role);
+    if (!userHall) continue;
+    const profilePath = locatePersonaProfile(manifestPath, userHall);
+    const loaded = loadPersonaProfile(profilePath);
+    if (!loaded.ok) {
+      return {
+        skillId: manifest.id,
+        version: manifest.version,
+        registered: 0,
+        cleaned: 0,
+        status: "error",
+        error: `${loaded.error} (expected at ${profilePath})`,
+      };
+    }
+    const summary = await upsertPaThreads(ctx.workspace, userHall, loaded.profile);
+    paProfile = { userHall, profilePath, summary };
+    break; // one PA profile per skill — first match wins
   }
 
   // Resolve every cron trigger's effective timezone up-front so the
@@ -354,9 +395,39 @@ export async function registerOneSkill(
     version: manifest.version,
     registered,
     cleaned,
-    status: registered > 0 ? "registered" : "no-triggers",
+    status: registered > 0 || paProfile ? "registered" : "no-triggers",
     warnings: warnings.length > 0 ? warnings : undefined,
+    paProfile,
   };
+}
+
+/**
+ * Resolve a PA persona profile path from a skill manifest path. Convention:
+ *   <workspace_root>/agents/pa/sub-agents/<user>/profile.yaml
+ *
+ * The skill manifest typically lives somewhere under
+ * `<workspace_root>/nexaas-skills/...`, so we walk up to find the workspace
+ * root (the nearest ancestor containing `agents/` and `nexaas-skills/`),
+ * then descend to the persona path. Falls back to NEXAAS_WORKSPACE_ROOT
+ * when set.
+ */
+function locatePersonaProfile(manifestPath: string, userHall: string): string {
+  const explicit = process.env.NEXAAS_WORKSPACE_ROOT;
+  if (explicit) {
+    return join(explicit, "agents", "pa", "sub-agents", userHall, "profile.yaml");
+  }
+  let dir = dirname(resolve(manifestPath));
+  // Walk up at most 6 levels looking for a workspace-root marker.
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "agents")) && existsSync(join(dir, "nexaas-skills"))) {
+      return join(dir, "agents", "pa", "sub-agents", userHall, "profile.yaml");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Last-resort guess relative to manifest's dir.
+  return join(dirname(resolve(manifestPath)), "..", "..", "..", "agents", "pa", "sub-agents", userHall, "profile.yaml");
 }
 
 /** Print a CronOverlapWarning block (used by both single + bulk callers). */
@@ -425,9 +496,18 @@ export async function run(args: string[]) {
     if (result.warnings && result.warnings.length > 0) {
       printOverlapWarnings(result.warnings, result.skillId);
     }
+    if (result.paProfile) {
+      const { userHall, summary } = result.paProfile;
+      const parts: string[] = [];
+      if (summary.added.length > 0) parts.push(`${summary.added.length} added`);
+      if (summary.updated.length > 0) parts.push(`${summary.updated.length} updated`);
+      if (summary.unchanged.length > 0) parts.push(`${summary.unchanged.length} unchanged`);
+      if (summary.paused.length > 0) parts.push(`${summary.paused.length} paused`);
+      console.log(`  ✓ PA persona '${userHall}' threads: ${parts.join(", ") || "no changes"}`);
+    }
     if (result.status === "no-triggers") {
       console.log("  ⚠ No cron triggers found in this manifest");
-    } else {
+    } else if (result.registered > 0) {
       console.log(`  ✓ ${result.registered} cron trigger(s) registered`);
     }
     console.log(`\n  Skill registered. Next fire will appear in Bull Board at /queues\n`);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -30,3 +30,17 @@ export {
 } from "./bullmq/index.js";
 export { runCompaction } from "./tasks/closet-compaction.js";
 export { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-reaper.js";
+
+// PA-as-Router persona profile (RFC-0002 Wave 1, #122)
+export {
+  PersonaProfileSchema,
+  PersonaThreadSchema,
+  MAX_THREADS_PER_PERSONA,
+  loadPersonaProfile,
+  upsertPaThreads,
+  detectPaReplyUser,
+  type PersonaProfile,
+  type PersonaThread,
+  type ProfileLoadResult,
+  type UpsertSummary,
+} from "./schemas/persona-profile.js";

--- a/packages/runtime/src/schemas/persona-profile.ts
+++ b/packages/runtime/src/schemas/persona-profile.ts
@@ -1,0 +1,219 @@
+/**
+ * Persona profile schema for PA conversation-turn skills (RFC-0002, #122).
+ *
+ * A persona profile lives at the workspace's agents/pa/sub-agents/<user>/profile.yaml
+ * and declares the small fixed set of domain-scoped threads the PA owns
+ * (e.g. `hr`, `accounting`, `marketing`). Profile data is the authoritative
+ * source; `pa_threads` rows in the palace are a denormalized projection
+ * upserted at skill-registration time.
+ *
+ * This module owns:
+ *   - The Zod schema (`PersonaProfileSchema`) — exact shape validation
+ *   - `loadPersonaProfile(profilePath)` — read + parse + validate
+ *   - `upsertPaThreads(workspace, userHall, profile)` — projection to DB
+ *
+ * The CLI's `register-skill` calls these when a skill manifest declares an
+ * inbound-message trigger with channel_role `pa_reply_<user>` — the profile
+ * must exist and validate, or registration fails loudly.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { load as yamlLoad } from "js-yaml";
+import { z } from "zod";
+import { sql } from "@nexaas/palace";
+
+/**
+ * Thread id is a slug — lowercase + digit + underscore, must start with a
+ * letter/underscore. Constrained so it can be embedded in URLs, channel
+ * roles, and palace room names without escaping.
+ */
+const THREAD_ID_RE = /^[a-z_][a-z0-9_]*$/;
+
+/** Maximum threads per persona — RFC §1: "small fixed set ≤ 5 typical". */
+export const MAX_THREADS_PER_PERSONA = 8;
+
+export const PersonaThreadSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(40)
+    .regex(THREAD_ID_RE, "thread id must match /^[a-z_][a-z0-9_]*$/"),
+  display: z.string().min(1).max(64),
+  /**
+   * Hints for the inference fallback (RFC §3.4) when an inbound has no
+   * explicit `message_thread_id` / `reply_to_message_id`. Not enforcement —
+   * the classifier can still place a message in `hr` even if no alias matched.
+   */
+  domain_aliases: z.array(z.string().min(1).max(40)).default([]),
+});
+
+export const PersonaProfileSchema = z.object({
+  threads: z
+    .array(PersonaThreadSchema)
+    .min(1, "persona profile must declare at least one thread")
+    .max(MAX_THREADS_PER_PERSONA, `persona profile may declare at most ${MAX_THREADS_PER_PERSONA} threads`)
+    .superRefine((threads, ctx) => {
+      const seen = new Set<string>();
+      threads.forEach((t, i) => {
+        if (seen.has(t.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [i, "id"],
+            message: `duplicate thread id '${t.id}'`,
+          });
+        }
+        seen.add(t.id);
+      });
+    }),
+});
+
+export type PersonaThread = z.infer<typeof PersonaThreadSchema>;
+export type PersonaProfile = z.infer<typeof PersonaProfileSchema>;
+
+export interface ProfileLoadError {
+  ok: false;
+  error: string;
+}
+
+export interface ProfileLoadOk {
+  ok: true;
+  profile: PersonaProfile;
+}
+
+export type ProfileLoadResult = ProfileLoadOk | ProfileLoadError;
+
+/**
+ * Read + parse + validate a persona profile. Pure (no DB I/O); pair with
+ * `upsertPaThreads` to project into the palace.
+ *
+ * The profile YAML may carry other top-level keys (avatar, voice, system_prompt,
+ * etc.) we don't validate here — we extract only the framework-owned `threads:`
+ * block. Workspace-side persona authors keep ownership of the rest.
+ */
+export function loadPersonaProfile(profilePath: string): ProfileLoadResult {
+  if (!existsSync(profilePath)) {
+    return { ok: false, error: `persona profile not found at '${profilePath}'` };
+  }
+  let raw: unknown;
+  try {
+    raw = yamlLoad(readFileSync(profilePath, "utf-8"));
+  } catch (err) {
+    return { ok: false, error: `persona profile parse error: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, error: "persona profile must be a YAML mapping" };
+  }
+  // Pluck the threads field only; ignore other persona-author fields.
+  const threadsField = (raw as Record<string, unknown>).threads;
+  const parsed = PersonaProfileSchema.safeParse({ threads: threadsField });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]!;
+    const path = issue.path.length > 0 ? `threads[${issue.path.join("][")}]` : "threads";
+    return { ok: false, error: `${path}: ${issue.message}` };
+  }
+  return { ok: true, profile: parsed.data };
+}
+
+/**
+ * Idempotent projection of a persona profile into `pa_threads`. Threads
+ * present in the profile are upserted (display + aliases refreshed); threads
+ * previously declared but now absent are marked `status='paused'` rather
+ * than deleted (preserves audit + channel_target so a re-add re-uses the
+ * existing topic).
+ *
+ * Returns a summary of what changed for the caller to surface.
+ */
+export interface UpsertSummary {
+  added: string[];     // new thread ids
+  updated: string[];   // thread ids whose display/aliases changed
+  unchanged: string[]; // thread ids already in desired state
+  paused: string[];    // previously declared, now absent
+}
+
+export async function upsertPaThreads(
+  workspace: string,
+  userHall: string,
+  profile: PersonaProfile,
+): Promise<UpsertSummary> {
+  const desired = new Map(profile.threads.map((t) => [t.id, t]));
+
+  // Snapshot existing active rows so we can detect adds/updates/pauses
+  // without N+1 round trips.
+  const existing = await sql<{
+    thread_id: string;
+    display_name: string;
+    domain_aliases: string[] | null;
+    status: string;
+  }>(
+    `SELECT thread_id, display_name, domain_aliases, status
+       FROM nexaas_memory.pa_threads
+      WHERE workspace = $1 AND user_hall = $2`,
+    [workspace, userHall],
+  );
+  const existingMap = new Map(existing.map((r) => [r.thread_id, r]));
+
+  const summary: UpsertSummary = { added: [], updated: [], unchanged: [], paused: [] };
+
+  for (const [id, thread] of desired) {
+    const prior = existingMap.get(id);
+    if (!prior) {
+      await sql(
+        `INSERT INTO nexaas_memory.pa_threads
+           (workspace, user_hall, thread_id, display_name, domain_aliases, status)
+         VALUES ($1, $2, $3, $4, $5, 'active')`,
+        [workspace, userHall, id, thread.display, thread.domain_aliases],
+      );
+      summary.added.push(id);
+      continue;
+    }
+    const aliasesEqual =
+      (prior.domain_aliases ?? []).length === thread.domain_aliases.length &&
+      (prior.domain_aliases ?? []).every((a, i) => a === thread.domain_aliases[i]);
+    const displayEqual = prior.display_name === thread.display;
+    const statusActive = prior.status === "active";
+    if (aliasesEqual && displayEqual && statusActive) {
+      summary.unchanged.push(id);
+      continue;
+    }
+    await sql(
+      `UPDATE nexaas_memory.pa_threads
+          SET display_name = $4,
+              domain_aliases = $5,
+              status = 'active'
+        WHERE workspace = $1 AND user_hall = $2 AND thread_id = $3`,
+      [workspace, userHall, id, thread.display, thread.domain_aliases],
+    );
+    summary.updated.push(id);
+  }
+
+  // Pause threads that exist in the DB but are no longer in the profile.
+  // Don't delete — keeps channel_target intact in case the operator re-adds.
+  for (const [id, prior] of existingMap) {
+    if (desired.has(id) || prior.status !== "active") continue;
+    await sql(
+      `UPDATE nexaas_memory.pa_threads
+          SET status = 'paused'
+        WHERE workspace = $1 AND user_hall = $2 AND thread_id = $3`,
+      [workspace, userHall, id],
+    );
+    summary.paused.push(id);
+  }
+
+  return summary;
+}
+
+/**
+ * Heuristic to detect a "this skill is a PA conversation-turn" trigger.
+ *
+ * Matches `inbound-message` triggers whose channel_role starts with
+ * `pa_reply_` — the convention established for PA skills today. Returns
+ * the user portion (e.g. `pa_reply_alice` → `alice`) or null.
+ *
+ * Kept generous so future convention tweaks (e.g. `pa_reply.<user>` dot
+ * form) can be added here without spreading the heuristic across callers.
+ */
+export function detectPaReplyUser(channelRole: string | undefined): string | null {
+  if (!channelRole) return null;
+  const m = /^pa_reply[_.]([a-z0-9][a-z0-9_-]*)$/.exec(channelRole);
+  return m ? m[1]! : null;
+}

--- a/scripts/test-pa-threads-122.mjs
+++ b/scripts/test-pa-threads-122.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #122 Wave 1 — PA persona profile schema + upsert.
+ *
+ * Covers the Zod-validation half of Wave 1 §1.2 (pure, no DB needed). The
+ * upsertPaThreads + migration apply require a Postgres connection; this
+ * script exercises only the deterministic logic.
+ *
+ * Run: node scripts/test-pa-threads-122.mjs
+ */
+
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  PersonaProfileSchema,
+  loadPersonaProfile,
+  detectPaReplyUser,
+  MAX_THREADS_PER_PERSONA,
+} from "../packages/runtime/src/schemas/persona-profile.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+const tmpDir = join(tmpdir(), `pa-threads-122-${Date.now()}`);
+mkdirSync(tmpDir, { recursive: true });
+
+function writeProfile(name, body) {
+  const path = join(tmpDir, `${name}.yaml`);
+  writeFileSync(path, body);
+  return path;
+}
+
+// ── 1. Schema acceptance ──────────────────────────────────────────
+console.log("\n1. Valid profile shapes");
+{
+  const valid = PersonaProfileSchema.safeParse({
+    threads: [
+      { id: "hr", display: "👥 HR", domain_aliases: ["hr", "onboarding"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: [] },
+    ],
+  });
+  assert(valid.success, "two-thread profile parses");
+  assert(valid.data?.threads.length === 2, "thread count preserved");
+
+  const noAliases = PersonaProfileSchema.safeParse({
+    threads: [{ id: "hr", display: "HR" }],
+  });
+  assert(noAliases.success, "domain_aliases optional, defaults to []");
+  assert(Array.isArray(noAliases.data?.threads[0]?.domain_aliases), "default is array");
+}
+
+// ── 2. Schema rejection ───────────────────────────────────────────
+console.log("\n2. Invalid profile shapes");
+{
+  const empty = PersonaProfileSchema.safeParse({ threads: [] });
+  assert(!empty.success, "empty threads array rejected");
+
+  const dupe = PersonaProfileSchema.safeParse({
+    threads: [
+      { id: "hr", display: "First" },
+      { id: "hr", display: "Second" },
+    ],
+  });
+  assert(!dupe.success, "duplicate ids rejected");
+
+  const badId = PersonaProfileSchema.safeParse({
+    threads: [{ id: "HR-Channel", display: "Bad" }],
+  });
+  assert(!badId.success, "uppercase id rejected");
+
+  const badId2 = PersonaProfileSchema.safeParse({
+    threads: [{ id: "1hr", display: "Bad" }],
+  });
+  assert(!badId2.success, "id starting with digit rejected");
+
+  const emptyDisplay = PersonaProfileSchema.safeParse({
+    threads: [{ id: "hr", display: "" }],
+  });
+  assert(!emptyDisplay.success, "empty display rejected");
+
+  const overlong = PersonaProfileSchema.safeParse({
+    threads: Array.from({ length: MAX_THREADS_PER_PERSONA + 1 }, (_, i) => ({
+      id: `t${i}`, display: `T${i}`,
+    })),
+  });
+  assert(!overlong.success, `${MAX_THREADS_PER_PERSONA + 1} threads rejected (max is ${MAX_THREADS_PER_PERSONA})`);
+}
+
+// ── 3. YAML loader ────────────────────────────────────────────────
+console.log("\n3. loadPersonaProfile()");
+{
+  const validPath = writeProfile("good", `
+display_name: "Test PA"
+threads:
+  - id: hr
+    display: "👥 HR"
+    domain_aliases: [hr, recruitment]
+  - id: accounting
+    display: "💰 Accounting"
+`);
+  const ok = loadPersonaProfile(validPath);
+  assert(ok.ok, "valid profile loads");
+  assert(ok.ok && ok.profile.threads[0]?.id === "hr", "first thread id 'hr'");
+
+  const missing = loadPersonaProfile(join(tmpDir, "nonexistent.yaml"));
+  assert(!missing.ok, "missing file rejected");
+  assert(!missing.ok && missing.error.includes("not found"), "error mentions 'not found'");
+
+  const badYaml = writeProfile("malformed", "threads:\n  - id: hr\n  display: oops");
+  const parsed = loadPersonaProfile(badYaml);
+  assert(!parsed.ok, "malformed YAML rejected");
+
+  const missingThreads = writeProfile("noThreads", `display_name: "PA without threads"`);
+  const noThreads = loadPersonaProfile(missingThreads);
+  assert(!noThreads.ok, "profile without threads rejected");
+
+  // Profile with other top-level fields we don't validate
+  const withExtras = writeProfile("withExtras", `
+voice: friendly
+avatar: /img/a.png
+system_prompt: |
+  You are a helpful PA.
+threads:
+  - id: ops
+    display: "⚙️ Ops"
+`);
+  const extras = loadPersonaProfile(withExtras);
+  assert(extras.ok, "profile with unknown top-level fields still loads (we pluck threads only)");
+}
+
+// ── 4. detectPaReplyUser ──────────────────────────────────────────
+console.log("\n4. detectPaReplyUser()");
+{
+  assert(detectPaReplyUser("pa_reply_alice") === "alice", "underscore form parses");
+  assert(detectPaReplyUser("pa_reply.alice") === "alice", "dot form parses");
+  assert(detectPaReplyUser("pa_reply_user-1") === "user-1", "hyphen in user allowed");
+  assert(detectPaReplyUser("pa_reply_") === null, "empty user rejected");
+  assert(detectPaReplyUser("pa_notify_alice") === null, "wrong prefix rejected");
+  assert(detectPaReplyUser(undefined) === null, "undefined handled");
+  assert(detectPaReplyUser("") === null, "empty string handled");
+  assert(detectPaReplyUser("pa_reply_ALICE") === null, "uppercase user rejected (slug convention)");
+}
+
+rmSync(tmpDir, { recursive: true, force: true });
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test-pa-upsert-122.mjs
+++ b/scripts/test-pa-upsert-122.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Integration test for #122 Wave 1 — upsertPaThreads idempotency + paused state.
+ *
+ * Exercises the DB-touching half of Wave 1 §1.2 against a real Postgres.
+ * Requires DATABASE_URL pointing at a database with migration 020 applied.
+ *
+ * Run:
+ *   DATABASE_URL=postgresql://.../pa_threads_test \
+ *     node --import tsx scripts/test-pa-upsert-122.mjs
+ */
+
+import {
+  upsertPaThreads,
+} from "../packages/runtime/src/schemas/persona-profile.ts";
+import { sql, getPool } from "../packages/palace/src/db.ts";
+
+const WORKSPACE = "test-workspace";
+const USER = "alice";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// Clean slate.
+await sql(`DELETE FROM nexaas_memory.pa_threads WHERE workspace = $1`, [WORKSPACE]);
+
+// ── 1. First insert ───────────────────────────────────────────────
+console.log("\n1. First registration adds rows");
+{
+  const profile = {
+    threads: [
+      { id: "hr", display: "👥 HR", domain_aliases: ["hr", "onboarding"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.added.length === 2, `2 threads added (got ${summary.added.length})`);
+  assert(summary.unchanged.length === 0, "0 unchanged on first run");
+  assert(summary.paused.length === 0, "0 paused on first run");
+
+  const rows = await sql(
+    `SELECT thread_id, status FROM nexaas_memory.pa_threads
+      WHERE workspace = $1 AND user_hall = $2 ORDER BY thread_id`,
+    [WORKSPACE, USER],
+  );
+  assert(rows.length === 2, "2 rows persisted");
+  assert(rows.every((r) => r.status === "active"), "all rows active");
+}
+
+// ── 2. Idempotent re-run ─────────────────────────────────────────
+console.log("\n2. Re-registration is idempotent");
+{
+  const profile = {
+    threads: [
+      { id: "hr", display: "👥 HR", domain_aliases: ["hr", "onboarding"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.added.length === 0, "0 added on second run");
+  assert(summary.unchanged.length === 2, `2 unchanged (got ${summary.unchanged.length})`);
+  assert(summary.updated.length === 0, "0 updated when nothing changed");
+}
+
+// ── 3. Adding a new thread ────────────────────────────────────────
+console.log("\n3. Adding a new thread");
+{
+  const profile = {
+    threads: [
+      { id: "hr", display: "👥 HR", domain_aliases: ["hr", "onboarding"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+      { id: "marketing", display: "📣 Marketing", domain_aliases: ["campaigns"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.added.length === 1 && summary.added[0] === "marketing", "marketing added");
+  assert(summary.unchanged.length === 2, "hr + accounting unchanged");
+}
+
+// ── 4. Updating an existing thread's display ──────────────────────
+console.log("\n4. Updating display refreshes the row");
+{
+  const profile = {
+    threads: [
+      { id: "hr", display: "👥 Human Resources", domain_aliases: ["hr", "onboarding"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+      { id: "marketing", display: "📣 Marketing", domain_aliases: ["campaigns"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.updated.length === 1 && summary.updated[0] === "hr", "hr updated");
+  assert(summary.unchanged.length === 2, "others unchanged");
+
+  const row = await sql(
+    `SELECT display_name FROM nexaas_memory.pa_threads WHERE workspace = $1 AND user_hall = $2 AND thread_id = $3`,
+    [WORKSPACE, USER, "hr"],
+  );
+  assert(row[0]?.display_name === "👥 Human Resources", "display written");
+}
+
+// ── 5. Removing a thread pauses, doesn't delete ──────────────────
+console.log("\n5. Removed thread is paused, not deleted");
+{
+  const profile = {
+    threads: [
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+      { id: "marketing", display: "📣 Marketing", domain_aliases: ["campaigns"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.paused.length === 1 && summary.paused[0] === "hr", "hr paused");
+
+  const row = await sql(
+    `SELECT status FROM nexaas_memory.pa_threads WHERE workspace = $1 AND user_hall = $2 AND thread_id = $3`,
+    [WORKSPACE, USER, "hr"],
+  );
+  assert(row[0]?.status === "paused", "hr row status='paused' (preserved, not deleted)");
+}
+
+// ── 6. Re-adding a paused thread reactivates it ──────────────────
+console.log("\n6. Re-adding a paused thread reactivates");
+{
+  const profile = {
+    threads: [
+      { id: "hr", display: "👥 HR (back)", domain_aliases: ["hr"] },
+      { id: "accounting", display: "💰 Accounting", domain_aliases: ["billing"] },
+      { id: "marketing", display: "📣 Marketing", domain_aliases: ["campaigns"] },
+    ],
+  };
+  const summary = await upsertPaThreads(WORKSPACE, USER, profile);
+  assert(summary.updated.length === 1 && summary.updated[0] === "hr", "hr counted as updated");
+  const row = await sql(
+    `SELECT status, display_name FROM nexaas_memory.pa_threads WHERE workspace = $1 AND user_hall = $2 AND thread_id = $3`,
+    [WORKSPACE, USER, "hr"],
+  );
+  assert(row[0]?.status === "active", "hr back to active");
+  assert(row[0]?.display_name === "👥 HR (back)", "new display written");
+}
+
+// Cleanup + close pool
+await sql(`DELETE FROM nexaas_memory.pa_threads WHERE workspace = $1`, [WORKSPACE]);
+await getPool().end();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #122.

Framework-side half of PA-as-Router Wave 1 (RFC-0002 §3.1, §3.4). Pure-additive foundation. No behavior change until Wave 2 wires the endpoint (#123) and Wave 3 wires the resolver shadow drawer (#124).

## What lands

- **Migration 020** — `events.thread_id` column + partial index; `pa_threads` table with status constraint + active-rows partial index
- **`@nexaas/runtime` persona profile module** — Zod schema (`PersonaProfileSchema`), `loadPersonaProfile()`, idempotent `upsertPaThreads()` with pause-don't-delete semantics, `detectPaReplyUser()` convention heuristic
- **`register-skill` integration** — when a manifest declares `triggers: [{ type: inbound-message, channel_role: pa_reply_<user> }]`, locates and validates the persona profile, projects threads into `pa_threads`, and fails registration loudly on missing/malformed profile

## Out of scope (other actors)

- §1.3 inbound metadata capture (`message_thread_id`, `reply_to_message_id`) lives in the canary workspace's telegram receiver — not this repo

## Test plan

- [x] 25 pure Zod / loader / regex cases (`scripts/test-pa-threads-122.mjs`)
- [x] 18 DB upsert cases including idempotency, pause-on-removal, reactivate-on-readd (`scripts/test-pa-upsert-122.mjs`)
- [x] EXPLAIN confirms `events_user_thread_idx` partial index used for the canonical thread-scoped query
- [x] Full `npm run build` clean
- [ ] Migration applied to populated palace — canary deploy verification

## Acceptance from #122

- [x] Migration runs forward cleanly on a fresh palace
- [x] EXPLAIN ANALYZE shows index used
- [x] Malformed `threads:` block fails registration with a field-level error
- [x] Valid profile populates `pa_threads` on first run
- [x] Re-registering is idempotent (existing preserved, removed marked paused)
- [x] Skill with `channel_role: pa_reply_<user>` requires matching persona profile

Sets up Waves 2/3/4 — they can be developed in parallel against this schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for persona-based router skills with thread management capabilities
  * CLI now validates and registers persona profiles with configurable conversation threads

* **Tests**
  * Added comprehensive regression and integration tests for persona profile validation and thread upserting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->