### PR TITLE
feat(palace): approval-shadow drawer on resolveWaitpoint (#124)

### DIFF
--- a/packages/palace/src/palace.ts
+++ b/packages/palace/src/palace.ts
@@ -209,9 +209,118 @@ export async function resolveWaitpoint(
     payload: { signal, resolution, drawer_id: drawer.id },
   });
 
+  // PA-as-Router shadow drawer (RFC-0002 §3.5 / Wave 3, #124).
+  //
+  // When the resolved waitpoint was created for an approval flow (has
+  // `action_kind` AND `channel_role` in its state, the shape written by
+  // `engine/apply.ts` for TAG approval_required outputs), emit one extra
+  // drawer to `notifications.delivered.telegram` so the user's PA can
+  // observe the decision and log it in-thread.
+  //
+  // Inbound-match waitpoints, raw timeout-only waitpoints, and anything
+  // else that doesn't carry channel_role get skipped — they aren't
+  // user-facing and the PA doesn't need to know.
+  //
+  // Failures here are swallowed (logged only). The waitpoint's own
+  // callbacks have already completed; a shadow-drawer write failure
+  // mustn't roll back the real resolution.
+  try {
+    await emitApprovalShadowDrawer(drawer, signal, resolution, actor);
+  } catch (err) {
+    console.error("[nexaas] approval shadow drawer emit failed (non-fatal):", err);
+  }
+
   return {
     runId: drawer.run_id!,
     skillId: drawer.skill_id!,
     stepId: drawer.step_id!,
   };
+}
+
+/**
+ * Parse the waitpoint's content and determine whether it looks like a
+ * TAG approval waitpoint. Approval state carries both `action_kind` and
+ * `channel_role` (see `engine/apply.ts` createWaitpoint call). Anything
+ * else returns null and the caller skips the shadow emit.
+ */
+function detectApprovalState(content: string | null | undefined): { channel_role: string; action_kind?: string; payload?: unknown } | null {
+  if (!content) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(content); } catch { return null; }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.channel_role !== "string" || obj.channel_role.length === 0) return null;
+  // action_kind is the strongest signal — engine/apply.ts always sets it
+  // for approvals. Be tolerant if it's absent (e.g. future approval shapes
+  // that omit it); presence of channel_role is enough to indicate "this
+  // was a user-facing waitpoint that the PA may care about".
+  return {
+    channel_role: obj.channel_role,
+    action_kind: typeof obj.action_kind === "string" ? obj.action_kind : undefined,
+    payload: obj.payload,
+  };
+}
+
+async function emitApprovalShadowDrawer(
+  drawer: Drawer,
+  signal: string,
+  resolution: Record<string, unknown>,
+  actor: string,
+): Promise<void> {
+  const approval = detectApprovalState((drawer as unknown as { content: string }).content);
+  if (!approval) return;
+
+  // `decision` is the most natural surface — resolution.decision when the
+  // adapter follows the convention, otherwise the full resolution payload
+  // (preserves info for non-decision approvals like "approve with edits").
+  const decision =
+    typeof (resolution as { decision?: unknown }).decision === "string"
+      ? (resolution as { decision: string }).decision
+      : resolution;
+
+  // Channel-keyed room. v1 ships Telegram only (RFC §3.8); future
+  // channels add their own (e.g. `notifications/delivered/email`).
+  // We infer telegram from channel_role naming convention; if a future
+  // role uses a different prefix, this needs explicit channel_kind from
+  // the workspace manifest — left as a Wave 5 / future-channel concern.
+  const channelKind = approval.channel_role.startsWith("pa_") || approval.channel_role.startsWith("telegram_")
+    ? "telegram"
+    : "telegram"; // single-channel v1; widen when more land
+
+  const session = createSession({
+    workspace: drawer.workspace,
+    runId: drawer.run_id,
+    skillId: drawer.skill_id,
+  });
+
+  await session.writeDrawer(
+    { wing: "notifications", hall: "delivered", room: channelKind },
+    JSON.stringify({
+      kind: "approval_resolved",
+      waitpoint_signal: signal,
+      decision,
+      resolved_at: new Date().toISOString(),
+      resolved_by: actor,
+      channel_role: approval.channel_role,
+      action_kind: approval.action_kind,
+      // original_notification_id is populated when the approval came through
+      // POST /api/pa/<user>/notify (Wave 2's audit field). Legacy direct-path
+      // approvals don't carry it; the PA gracefully skips correlation.
+      original_notification_id:
+        (drawer as unknown as { content: string }).content && (() => {
+          try {
+            const c = JSON.parse((drawer as unknown as { content: string }).content);
+            return typeof c.original_notification_id === "string" ? c.original_notification_id : null;
+          } catch { return null; }
+        })(),
+    }),
+    { run_id: drawer.run_id, step_id: drawer.step_id } as DrawerMeta,
+  );
+
+  await appendWal({
+    workspace: drawer.workspace,
+    op: "approval_shadow_emit",
+    actor,
+    payload: { signal, channel_role: approval.channel_role, drawer_id: drawer.id },
+  });
 }

--- a/scripts/test-shadow-drawer-124.mjs
+++ b/scripts/test-shadow-drawer-124.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #124 Wave 3 — approval-shadow drawer emit on
+ * resolveWaitpoint success.
+ *
+ * Requires a minimal palace schema (events + wal) and DATABASE_URL.
+ *
+ * Cases:
+ *   1. Resolving an approval-shaped waitpoint emits one shadow drawer
+ *      to notifications.delivered.telegram with the expected fields.
+ *   2. Resolving a non-approval waitpoint (no channel_role in state) does
+ *      NOT emit a shadow drawer.
+ *   3. Resolving an inbound-match-shaped waitpoint (channel_role absent)
+ *      does NOT emit.
+ *   4. Shadow drawer carries `original_notification_id` when the
+ *      approval state had one set; null otherwise.
+ *   5. resolveWaitpoint still returns runId/skillId/stepId unchanged.
+ *   6. The existing resolution drawer (in events/skill/pending-approval)
+ *      is written exactly once, not duplicated by the shadow path.
+ *
+ * Run:
+ *   DATABASE_URL=postgresql://nexaas:password@localhost/shadow_drawer_test \
+ *     node --import tsx scripts/test-shadow-drawer-124.mjs
+ */
+
+import { randomUUID } from "crypto";
+import { resolveWaitpoint, palace } from "../packages/palace/src/palace.ts";
+import { sql, getPool } from "../packages/palace/src/db.ts";
+
+const WORKSPACE = `test-${Date.now()}`;
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+async function createApprovalWaitpoint(state) {
+  const signal = `approval:${randomUUID()}`;
+  const runId = randomUUID();
+  const session = palace.enter({ workspace: WORKSPACE, runId, skillId: "test/skill", stepId: "step1" });
+  await session.createWaitpoint({
+    signal,
+    room: { wing: "events", hall: "skill", room: "pending-approval" },
+    state,
+    timeout: "1h",
+  });
+  return { signal, runId };
+}
+
+async function countShadows() {
+  const rows = await sql(
+    `SELECT id, content FROM nexaas_memory.events
+      WHERE workspace = $1 AND wing = 'notifications' AND hall = 'delivered' AND room = 'telegram'`,
+    [WORKSPACE],
+  );
+  return rows;
+}
+
+async function countResolutionDrawers() {
+  const rows = await sql(
+    `SELECT id FROM nexaas_memory.events
+      WHERE workspace = $1 AND wing = 'events' AND hall = 'skill' AND room = 'pending-approval'
+        AND dormant_signal IS NULL`,
+    [WORKSPACE],
+  );
+  return rows.length;
+}
+
+// ── 1. Approval waitpoint → one shadow drawer ─────────────────────
+console.log("\n1. Approval waitpoint emits one shadow drawer");
+{
+  const { signal } = await createApprovalWaitpoint({
+    action_kind: "external_send",
+    payload: { to: "alice@example.com" },
+    channel_role: "pa_notify_alice",
+    notify: { channel_role: "pa_notify_alice" },
+    original_notification_id: "n-abc-123",
+  });
+  const result = await resolveWaitpoint(signal, { decision: "approve" }, "user_alice");
+  assert(typeof result.runId === "string", "returns runId");
+  assert(typeof result.skillId === "string", "returns skillId");
+
+  const shadows = await countShadows();
+  assert(shadows.length === 1, `1 shadow drawer (got ${shadows.length})`);
+
+  const c = JSON.parse(shadows[0].content);
+  assert(c.kind === "approval_resolved", "kind=approval_resolved");
+  assert(c.waitpoint_signal === signal, "carries signal");
+  assert(c.decision === "approve", "carries decision");
+  assert(c.resolved_by === "user_alice", "carries resolved_by");
+  assert(c.channel_role === "pa_notify_alice", "carries channel_role");
+  assert(c.original_notification_id === "n-abc-123", "carries original_notification_id");
+  assert(typeof c.resolved_at === "string" && c.resolved_at.includes("T"), "resolved_at ISO");
+}
+
+// ── 2. Non-approval waitpoint (no channel_role) → no shadow ───────
+console.log("\n2. Waitpoint without channel_role emits no shadow");
+{
+  const shadowsBefore = (await countShadows()).length;
+  const { signal } = await createApprovalWaitpoint({
+    action_kind: "raw_timeout",
+    payload: { foo: "bar" },
+    // no channel_role
+  });
+  await resolveWaitpoint(signal, { decision: "approve" }, "user_x");
+  const shadowsAfter = (await countShadows()).length;
+  assert(shadowsAfter === shadowsBefore, `no shadow added (was ${shadowsBefore}, now ${shadowsAfter})`);
+}
+
+// ── 3. Inbound-match-shaped waitpoint → no shadow ─────────────────
+console.log("\n3. Inbound-match waitpoint emits no shadow");
+{
+  const shadowsBefore = (await countShadows()).length;
+  // Inbound-match has neither action_kind nor channel_role in state
+  const { signal } = await createApprovalWaitpoint({
+    match_signal: "inbox_match",
+    match_room: "inbox.messaging.al",
+    content_regex: "^[0-9]{6}$",
+  });
+  await resolveWaitpoint(signal, { matched: true, code: "123456" }, "telegram-adapter");
+  const shadowsAfter = (await countShadows()).length;
+  assert(shadowsAfter === shadowsBefore, `no shadow added (was ${shadowsBefore}, now ${shadowsAfter})`);
+}
+
+// ── 4. Approval without original_notification_id → null ───────────
+console.log("\n4. Approval without original_notification_id → field is null");
+{
+  const { signal } = await createApprovalWaitpoint({
+    action_kind: "external_send",
+    payload: { to: "bob@example.com" },
+    channel_role: "pa_notify_bob",
+  });
+  await resolveWaitpoint(signal, { decision: "reject" }, "user_bob");
+  const shadows = await sql(
+    `SELECT content FROM nexaas_memory.events
+      WHERE workspace = $1 AND wing = 'notifications' AND hall = 'delivered' AND room = 'telegram'
+      ORDER BY created_at DESC LIMIT 1`,
+    [WORKSPACE],
+  );
+  const c = JSON.parse(shadows[0].content);
+  assert(c.original_notification_id === null, "original_notification_id is null when not set");
+  assert(c.decision === "reject", "decision propagates");
+}
+
+// ── 5. Resolution drawer not duplicated ───────────────────────────
+console.log("\n5. Existing resolution path unaffected — no duplicate resolution drawer");
+{
+  // Each resolveWaitpoint leaves: the original waitpoint drawer (cleared,
+  // dormant_signal=NULL) AND one new resolution drawer in the same room.
+  // 4 resolves → 4 cleared originals + 4 resolutions = 8 rows.
+  // The shadow path writes to a different room (notifications/delivered/telegram),
+  // so this count must stay at 8, not 12.
+  const count = await countResolutionDrawers();
+  assert(count === 8, `8 drawers in pending-approval (4 cleared + 4 resolutions), got ${count} — shadow path didn't pollute`);
+}
+
+// ── 6. WAL row for shadow emit ────────────────────────────────────
+console.log("\n6. WAL row written for shadow emit");
+{
+  const walRows = await sql(
+    `SELECT payload FROM nexaas_memory.wal
+      WHERE workspace = $1 AND op = 'approval_shadow_emit'`,
+    [WORKSPACE],
+  );
+  assert(walRows.length === 2, `2 WAL rows for approval_shadow_emit (one per approval-shaped resolve), got ${walRows.length}`);
+}
+
+await getPool().end();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #124.

Wave 3 of PA-as-Router (RFC-0002 §3.5). Smallest framework change in Phase 1 — one shadow-drawer emit appended to `resolveWaitpoint` so the user's PA observes approval decisions without changing any existing resolver semantics.

## What's safe-by-default

- Existing waitpoint consumers (every external_send approval, Seb's insurance taps, inbound-match codes, raw timeouts) see **zero behavior change**
- Shadow emit failures don't roll back the real resolution (caught + logged)
- Non-approval waitpoints (no `channel_role` in state) emit no shadow at all — only `engine/apply.ts`-created TAG approval waitpoints qualify

## Shape

`notifications/delivered/telegram` (channel-keyed; v1 ships Telegram only per RFC §3.8) with:
- `kind: "approval_resolved"`, `waitpoint_signal`, `decision`, `resolved_at`, `resolved_by`
- `channel_role`, `action_kind` (when present in waitpoint state)
- `original_notification_id` (null for legacy direct-path approvals; PA skips correlation gracefully in Wave 3.2 workspace code)

WAL emits `approval_shadow_emit` per shadow.

## Test plan

- [x] 16 cases in `scripts/test-shadow-drawer-124.mjs` (approval emits one shadow, non-channel waitpoints emit none, inbound-match shape skipped, original_notification_id flows + nullable, resolution drawer not duplicated, WAL row written)
- [x] `tsc --noEmit -p packages/palace/tsconfig.json` clean
- [x] Full `npm run build` clean
- [ ] Phoenix canary end-to-end approval test — workspace-side (Wave 3 §3.3), not framework

## Out of scope (workspace side)

- §3.2 PA `conversation-turn` skill rewrite to consume the shadow drawer
- §3.3 end-to-end canary test wiring

Both happen in the canary's repo. Framework-side scope is complete with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waitpoint resolution now emits shadow drawer notifications for approval-shaped requests with decision and resolution tracking.

* **Tests**
  * Added regression test to validate approval shadow drawer behavior, event emission, and audit trail recording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->