### PR TITLE
feat(batch): at_from_field — per-item deadline triggers (#136)

### DIFF
--- a/docs/adoption-patterns/batch-trigger.md
+++ b/docs/adoption-patterns/batch-trigger.md
@@ -90,10 +90,51 @@ The consumer's run receives `triggerPayload.batch_items` as an array:
 | `oldest_age_at_least: "1h"` | duration string (`s`/`m`/`h`/`d`) or seconds | Fires when the oldest pending item exceeds the threshold |
 | `cron: "0 9 * * MON"` | standard 5- or 6-field cron expression | Fires when the cron crosses, evaluated each poll tick |
 | `at: "2026-05-15T00:00:00Z"` | ISO-8601 timestamp | One-shot deadline; fires the first poll after the time passes |
+| `at_from_field: "scheduled_for"` | identifier naming a top-level field in drawer content | **Per-item deadline.** The dispatcher reads each pending drawer's value at that field, parses it as ISO 8601, and fires the item individually once its deadline passes. Each due drawer fires as a length-1 batch. Use for skills that schedule per-payload actions (delayed email broadcasts, T+N hour onboarding nudges, sequenced outreach) without needing to write a polling skill. |
 
 Multiple conditions in `any_of` fire on whichever matches first. Use
 `fire_when.any_of` exclusively in v1; `all_of` semantics aren't supported
 (file an issue if needed).
+
+### `at_from_field` semantics
+
+Unlike the bucket-wide conditions (`count_at_least`, `oldest_age_at_least`,
+`cron`, `at`), `at_from_field` is evaluated **per item**. Each pending drawer's
+content is read; the value at the named field is parsed as ISO 8601; the
+drawer fires the first poll after that timestamp passes.
+
+```yaml
+# Skill that sends an email at the per-recipient scheduled time.
+triggers:
+  - type: batch
+    bucket: email-broadcasts
+    fire_when:
+      any_of:
+        - at_from_field: "scheduled_for"   # per-payload deadline
+        - count_at_least: 100              # safety: drain if 100 pile up
+```
+
+```jsonc
+// Producer writes a drawer like:
+{
+  "wing": "batch",
+  "hall": "email-broadcasts",
+  "room": "pending.<uuid>",
+  "content": {
+    "to": "user@example.com",
+    "subject": "Welcome",
+    "scheduled_for": "2026-05-15T09:00:00Z"   // <-- the framework reads this
+  }
+}
+```
+
+Items where the field is missing, not a string, or not a parseable timestamp
+are skipped (they wait for another condition like `count_at_least` to fire).
+The field name must be a plain identifier (`[a-zA-Z_][a-zA-Z0-9_]*$`) — no
+JSONPath, no nested traversal in v1.
+
+Mixing `at_from_field` with bucket-wide conditions is supported: per-item
+firing happens first; bucket-wide firing then evaluates the *remainder*.
 
 ## `on_empty` policy
 

--- a/packages/runtime/src/tasks/batch-dispatcher.ts
+++ b/packages/runtime/src/tasks/batch-dispatcher.ts
@@ -81,7 +81,16 @@ type BatchCondition =
   | { kind: "count_at_least"; n: number }
   | { kind: "oldest_age_at_least"; seconds: number }
   | { kind: "cron"; expression: string; lastEvaluatedAt: number }
-  | { kind: "at"; iso: string };
+  | { kind: "at"; iso: string }
+  /**
+   * Per-item deadline (#136). `field` names a top-level key in drawer
+   * content (parsed as JSON). The dispatcher reads each pending drawer's
+   * value at that key, parses as ISO 8601, and fires the item individually
+   * once its deadline is past. Unlike the bucket-wide conditions, this
+   * fires one batch per due drawer (item_drawer_ids length-1), letting
+   * skills declare per-payload scheduled actions without a polling skill.
+   */
+  | { kind: "at_from_field"; field: string };
 
 /** bucket → subscribers (only one supported in v1; flagged in #80 follow-up) */
 type BatchIndex = Map<string, BatchTriggerSubscriber>;
@@ -133,7 +142,31 @@ function parseCondition(raw: Record<string, unknown>): BatchCondition | null {
     if (!iso || !Number.isFinite(Date.parse(iso))) return null;
     return { kind: "at", iso };
   }
+  if ("at_from_field" in raw) {
+    const field = typeof raw.at_from_field === "string" ? raw.at_from_field.trim() : "";
+    // Constrain to a plain identifier — no JSONPath, no nested traversal.
+    // Keeps the schema validatable + the SQL ->> path simple. The 95% case
+    // is a single top-level field like "scheduled_for"; nested paths can
+    // ship in a follow-up if a real adopter asks (per issue §"Why this matters").
+    if (!field || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(field)) return null;
+    return { kind: "at_from_field", field };
+  }
   return null;
+}
+
+/**
+ * Extract a per-item deadline from a drawer's JSON content (#136). Returns
+ * the epoch ms when the item is due, or null when the field is missing /
+ * unparseable / not a valid timestamp. Pure — no SQL.
+ */
+export function extractItemDeadlineMs(content: string, field: string): number | null {
+  let parsed: unknown;
+  try { parsed = JSON.parse(content); } catch { return null; }
+  if (!parsed || typeof parsed !== "object") return null;
+  const v = (parsed as Record<string, unknown>)[field];
+  if (typeof v !== "string") return null;
+  const ms = Date.parse(v);
+  return Number.isFinite(ms) ? ms : null;
 }
 
 function findSkillManifests(skillsRoot: string): string[] {
@@ -311,9 +344,44 @@ function evaluateFireWhen(items: PendingItem[], sub: BatchTriggerSubscriber, now
         if (Number.isFinite(dueAt) && dueAt <= now) return { fire: true, reason: `at:${c.iso}` };
         break;
       }
+      case "at_from_field":
+        // Per-item condition (#136) — handled separately by findPerItemDue
+        // before this function is called. evaluateFireWhen only decides on
+        // bucket-wide fires; per-item firing fires one batch per drawer.
+        break;
     }
   }
   return { fire: false, reason: "no_condition_matched" };
+}
+
+/**
+ * Return the subset of pending items that are individually due per any
+ * `at_from_field` condition on the subscriber (#136). Items returned here
+ * fire as length-1 batches; the bucket-wide evaluator then runs on the
+ * remainder for any other conditions in the same `any_of` block.
+ */
+export function findPerItemDue(
+  items: PendingItem[],
+  sub: BatchTriggerSubscriber,
+  now: number,
+): Array<{ item: PendingItem; field: string }> {
+  const fieldConds = sub.conditions.filter(
+    (c): c is { kind: "at_from_field"; field: string } => c.kind === "at_from_field",
+  );
+  if (fieldConds.length === 0) return [];
+
+  const out: Array<{ item: PendingItem; field: string }> = [];
+  for (const item of items) {
+    for (const c of fieldConds) {
+      const dueAt = extractItemDeadlineMs(item.content, c.field);
+      if (dueAt !== null && dueAt <= now) {
+        out.push({ item, field: c.field });
+        break; // one match is enough — don't double-fire when multiple
+               // at_from_field conditions are declared (rare but defensible)
+      }
+    }
+  }
+  return out;
 }
 
 async function claimBatch(
@@ -356,6 +424,78 @@ async function markDispatched(workspace: string, batchId: string): Promise<void>
   );
 }
 
+/**
+ * Claim + enqueue a single batch. Shared between bucket-wide firing
+ * and per-item (`at_from_field`) firing. Returns true on success.
+ */
+async function claimAndDispatch(
+  workspace: string,
+  bucket: string,
+  sub: BatchTriggerSubscriber,
+  itemsForBatch: PendingItem[],
+  fireReason: string,
+): Promise<boolean> {
+  const itemIds = itemsForBatch.map((i) => i.id);
+  const batchId = await claimBatch(workspace, bucket, sub.skillId, itemIds, fireReason);
+  if (!batchId) return false;
+
+  const runId = randomUUID();
+  const jobData: SkillJobData & { manifestPath?: string } = {
+    workspace,
+    runId,
+    skillId: sub.skillId,
+    stepId: sub.execType,
+    triggerType: "batch",
+    triggerPayload: {
+      bucket,
+      batch_id: batchId,
+      fire_reason: fireReason,
+      items: itemsForBatch.map((i) => ({
+        drawer_id: i.id,
+        content: i.content,
+        created_at: i.created_at,
+      })),
+    },
+    manifestPath: sub.manifestPath,
+  };
+
+  try {
+    await enqueueSkillStep(jobData);
+    await markDispatched(workspace, batchId);
+    await appendWal({
+      workspace,
+      op: "batch_dispatched",
+      actor: "batch-dispatcher",
+      payload: {
+        bucket,
+        batch_id: batchId,
+        skill_id: sub.skillId,
+        run_id: runId,
+        fire_reason: fireReason,
+        item_count: itemsForBatch.length,
+      },
+    });
+    return true;
+  } catch (err) {
+    // Enqueue failed AFTER claim — leave the dispatch in 'claimed' so it's
+    // visible; reaper / operator can clear it. The items remain associated
+    // via item_drawer_ids so they don't re-fire under another batch_id.
+    await sql(
+      `UPDATE nexaas_memory.batch_dispatches
+          SET status = 'failed', last_error = $3
+        WHERE workspace = $1 AND batch_id = $2`,
+      [workspace, batchId, (err as Error).message.slice(0, 1000)],
+    ).catch(() => { /* best effort */ });
+    await appendWal({
+      workspace,
+      op: "batch_consumer_failed",
+      actor: "batch-dispatcher",
+      payload: { bucket, batch_id: batchId, error: (err as Error).message.slice(0, 200) },
+    }).catch(() => { /* best effort */ });
+    return false;
+  }
+}
+
 export async function dispatchPendingBatches(workspace: string): Promise<{
   evaluated: number;
   fired: number;
@@ -368,68 +508,38 @@ export async function dispatchPendingBatches(workspace: string): Promise<{
   for (const [bucket, sub] of index) {
     evaluated++;
     const items = await selectPendingItems(workspace, bucket, sub.ordering, MAX_BATCH_SIZE);
-    const decision = evaluateFireWhen(items, sub, now);
-    if (!decision.fire) { skipped++; continue; }
 
-    const itemIds = items.map((i) => i.id);
-    const batchId = await claimBatch(workspace, bucket, sub.skillId, itemIds, decision.reason);
-    if (!batchId) { skipped++; continue; }
-
-    const runId = randomUUID();
-    const jobData: SkillJobData & { manifestPath?: string } = {
-      workspace,
-      runId,
-      skillId: sub.skillId,
-      stepId: sub.execType,
-      triggerType: "batch",
-      triggerPayload: {
-        bucket,
-        batch_id: batchId,
-        fire_reason: decision.reason,
-        items: items.map((i) => ({
-          drawer_id: i.id,
-          content: i.content,
-          created_at: i.created_at,
-        })),
-      },
-      manifestPath: sub.manifestPath,
-    };
-
-    try {
-      await enqueueSkillStep(jobData);
-      await markDispatched(workspace, batchId);
-      await appendWal({
-        workspace,
-        op: "batch_dispatched",
-        actor: "batch-dispatcher",
-        payload: {
-          bucket,
-          batch_id: batchId,
-          skill_id: sub.skillId,
-          run_id: runId,
-          fire_reason: decision.reason,
-          item_count: items.length,
-        },
-      });
-      fired++;
-    } catch (err) {
-      // Enqueue failed AFTER claim — leave the dispatch in 'claimed' so it's
-      // visible; reaper / operator can clear it. The items remain associated
-      // via item_drawer_ids so they don't re-fire under another batch_id.
-      await sql(
-        `UPDATE nexaas_memory.batch_dispatches
-            SET status = 'failed', last_error = $3
-          WHERE workspace = $1 AND batch_id = $2`,
-        [workspace, batchId, (err as Error).message.slice(0, 1000)],
-      ).catch(() => { /* best effort */ });
-      await appendWal({
-        workspace,
-        op: "batch_consumer_failed",
-        actor: "batch-dispatcher",
-        payload: { bucket, batch_id: batchId, error: (err as Error).message.slice(0, 200) },
-      }).catch(() => { /* best effort */ });
-      skipped++;
+    // Per-item due (#136) — fire one length-1 batch per drawer whose
+    // `at_from_field` deadline has passed. Bucket-wide evaluation then
+    // runs on the remainder for any other `any_of` conditions.
+    const perItemDue = findPerItemDue(items, sub, now);
+    const perItemFiredIds = new Set<string>();
+    for (const due of perItemDue) {
+      const ok = await claimAndDispatch(
+        workspace, bucket, sub, [due.item],
+        `at_from_field:${due.field}`,
+      );
+      if (ok) {
+        fired++;
+        perItemFiredIds.add(due.item.id);
+      } else {
+        skipped++;
+      }
     }
+
+    const remaining = perItemFiredIds.size === 0
+      ? items
+      : items.filter((i) => !perItemFiredIds.has(i.id));
+
+    const decision = evaluateFireWhen(remaining, sub, now);
+    if (!decision.fire) {
+      if (perItemDue.length === 0) skipped++;
+      continue;
+    }
+
+    const ok = await claimAndDispatch(workspace, bucket, sub, remaining, decision.reason);
+    if (ok) fired++;
+    else skipped++;
   }
 
   return { evaluated, fired, skipped };

--- a/scripts/test-batch-at-from-field-136.mjs
+++ b/scripts/test-batch-at-from-field-136.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #136 — batch trigger `at_from_field` per-item deadline.
+ *
+ * Pure unit tests for the field extractor + the per-item-due selector. The
+ * full dispatcher flow (claim + enqueue per-item batch) is covered indirectly
+ * via the existing test-batch-dispatcher tests; this script focuses on the
+ * decision logic so we can assert on edge cases without DB or BullMQ.
+ *
+ * Run: node --import tsx scripts/test-batch-at-from-field-136.mjs
+ */
+
+import {
+  extractItemDeadlineMs,
+  findPerItemDue,
+} from "../packages/runtime/src/tasks/batch-dispatcher.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+const NOW = Date.parse("2026-05-12T10:00:00Z");
+
+// ── 1. extractItemDeadlineMs ──────────────────────────────────────
+console.log("\n1. extractItemDeadlineMs()");
+{
+  // Valid ISO string in the named field
+  const past = JSON.stringify({ scheduled_for: "2026-05-12T09:00:00Z", body: "x" });
+  assert(extractItemDeadlineMs(past, "scheduled_for") === Date.parse("2026-05-12T09:00:00Z"), "past ISO parsed");
+
+  const future = JSON.stringify({ scheduled_for: "2026-05-12T11:00:00Z" });
+  assert(extractItemDeadlineMs(future, "scheduled_for") === Date.parse("2026-05-12T11:00:00Z"), "future ISO parsed");
+
+  // Missing field
+  assert(extractItemDeadlineMs(JSON.stringify({ other: "x" }), "scheduled_for") === null, "missing field → null");
+
+  // Non-string field
+  assert(extractItemDeadlineMs(JSON.stringify({ scheduled_for: 1715515200 }), "scheduled_for") === null, "number value → null (we require ISO string)");
+  assert(extractItemDeadlineMs(JSON.stringify({ scheduled_for: null }), "scheduled_for") === null, "null value → null");
+  assert(extractItemDeadlineMs(JSON.stringify({ scheduled_for: ["a"] }), "scheduled_for") === null, "array value → null");
+
+  // Unparseable string
+  assert(extractItemDeadlineMs(JSON.stringify({ scheduled_for: "not-a-date" }), "scheduled_for") === null, "unparseable string → null");
+  assert(extractItemDeadlineMs(JSON.stringify({ scheduled_for: "" }), "scheduled_for") === null, "empty string → null");
+
+  // Malformed JSON
+  assert(extractItemDeadlineMs("{not json", "scheduled_for") === null, "malformed JSON → null");
+
+  // Non-object root
+  assert(extractItemDeadlineMs(JSON.stringify("plain string"), "scheduled_for") === null, "non-object root → null");
+  assert(extractItemDeadlineMs(JSON.stringify(null), "scheduled_for") === null, "null root → null");
+}
+
+// ── 2. findPerItemDue — no at_from_field condition ────────────────
+console.log("\n2. findPerItemDue() with no at_from_field returns []");
+{
+  const items = [
+    { id: "a", content: JSON.stringify({ scheduled_for: "2026-05-12T09:00:00Z" }), created_at: "2026-05-12T00:00:00Z" },
+  ];
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [{ kind: "count_at_least", n: 10 }],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  const due = findPerItemDue(items, sub, NOW);
+  assert(due.length === 0, "no at_from_field condition → no per-item due");
+}
+
+// ── 3. findPerItemDue — mixed past + future items ─────────────────
+console.log("\n3. findPerItemDue() returns only past items");
+{
+  const items = [
+    { id: "past1", content: JSON.stringify({ scheduled_for: "2026-05-12T09:00:00Z" }), created_at: "2026-05-12T00:00:00Z" },
+    { id: "past2", content: JSON.stringify({ scheduled_for: "2026-05-12T09:30:00Z" }), created_at: "2026-05-12T00:00:00Z" },
+    { id: "future", content: JSON.stringify({ scheduled_for: "2026-05-12T11:00:00Z" }), created_at: "2026-05-12T00:00:00Z" },
+    { id: "missing", content: JSON.stringify({ body: "no deadline" }), created_at: "2026-05-12T00:00:00Z" },
+  ];
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [{ kind: "at_from_field", field: "scheduled_for" }],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  const due = findPerItemDue(items, sub, NOW);
+  assert(due.length === 2, `2 due items (got ${due.length})`);
+  const dueIds = due.map((d) => d.item.id).sort();
+  assert(dueIds[0] === "past1" && dueIds[1] === "past2", "past1 + past2 due, future + missing skipped");
+  assert(due.every((d) => d.field === "scheduled_for"), "field captured");
+}
+
+// ── 4. Item exactly at deadline → fires (boundary inclusive) ──────
+console.log("\n4. Item with deadline == now fires (inclusive boundary)");
+{
+  const items = [
+    { id: "exact", content: JSON.stringify({ scheduled_for: new Date(NOW).toISOString() }), created_at: "x" },
+  ];
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [{ kind: "at_from_field", field: "scheduled_for" }],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  assert(findPerItemDue(items, sub, NOW).length === 1, "deadline == now fires");
+}
+
+// ── 5. Custom field name ──────────────────────────────────────────
+console.log("\n5. Custom field name parses");
+{
+  const items = [
+    { id: "a", content: JSON.stringify({ fire_at: "2026-05-12T09:00:00Z" }), created_at: "x" },
+  ];
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [{ kind: "at_from_field", field: "fire_at" }],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  assert(findPerItemDue(items, sub, NOW).length === 1, "custom field works");
+}
+
+// ── 6. Multiple at_from_field conditions → first match wins ──────
+console.log("\n6. Multiple at_from_field conditions don't double-fire one item");
+{
+  const items = [
+    { id: "a", content: JSON.stringify({ scheduled_for: "2026-05-12T09:00:00Z", fire_at: "2026-05-12T09:00:00Z" }), created_at: "x" },
+  ];
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [
+      { kind: "at_from_field", field: "scheduled_for" },
+      { kind: "at_from_field", field: "fire_at" },
+    ],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  const due = findPerItemDue(items, sub, NOW);
+  assert(due.length === 1, `1 entry for the item (got ${due.length}) — no duplicate firing`);
+}
+
+// ── 7. Empty items list ───────────────────────────────────────────
+console.log("\n7. Empty pending list → no per-item due");
+{
+  const sub = {
+    skillId: "x", manifestPath: "/x", execType: "ai-exec",
+    conditions: [{ kind: "at_from_field", field: "scheduled_for" }],
+    onEmpty: "skip", ordering: "arrival",
+  };
+  assert(findPerItemDue([], sub, NOW).length === 0, "empty list handled");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #136.

Adds a new `fire_when.at_from_field` condition to the batch trigger primitive (#80). Reads a per-drawer deadline from drawer content; each due drawer fires as its own length-1 batch.

## Why

Today's `at:` only accepts a static ISO literal. Adopters wanting per-payload scheduling (Email Autopilot scheduled broadcasts, T+N onboarding nudges, drip enrollment) have to write a polling skill — Nexmatic shipped exactly such a workaround today (`marketing/email-broadcast-scheduler`). This primitive replaces those pollers with a few YAML lines.

## Usage

```yaml
triggers:
  - type: batch
    bucket: email-broadcasts
    fire_when:
      any_of:
        - at_from_field: "scheduled_for"   # per-payload deadline
        - count_at_least: 100              # safety cap
```

Producer side: drawer's `content.scheduled_for` is an ISO 8601 string. Dispatcher reads it each poll, fires due drawers individually.

## Semantics

- **Per-item, not bucket-wide.** Each pending drawer fires as a length-1 batch when its declared deadline passes
- **Inclusive boundary.** Deadline == now fires (matches the existing static `at:` semantics)
- **Skip on missing/unparseable.** Items without a valid field value wait for other conditions
- **Mixes with bucket-wide.** Per-item firing runs first; bucket-wide conditions evaluate the remainder
- **Plain field identifier only.** `^[a-zA-Z_][a-zA-Z0-9_]*$` — no JSONPath in v1 (per issue §"Why this matters", 95% of cases are single top-level fields)

## Test plan

- [x] 19 cases in `scripts/test-batch-at-from-field-136.mjs`: ISO parsing variations, missing/non-string/unparseable field, malformed JSON, boundary-inclusive, custom field name, multiple at_from_field conditions don't double-fire one item, empty list, mixed conditions
- [x] `tsc --noEmit -p packages/runtime/tsconfig.json` clean
- [x] Full `npm run build` clean
- [x] Adoption pattern doc updated with usage + semantics + producer-side example

## Follow-up for Nexmatic

Once merged, `marketing/email-broadcast-scheduler` (the poller workaround shipped today) can be deprecated. `marketing/email-broadcast` declares `at_from_field: "scheduled_for"` and consumes its own pending drawers directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch triggers now support per-item deadline evaluation, allowing each item to fire individually when its deadline is reached based on an ISO-8601 date from a specified field.

* **Documentation**
  * Added comprehensive documentation for the per-item deadline feature, including worked examples and interaction with bucket-wide conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->