### PR TITLE
feat(cli): register-skill accepts contract.yaml format natively (#139)

### DIFF
--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -106,6 +106,17 @@ If your skill needs to call external tools (email, database, API), it MUST decla
 
 ## 3. Skill Manifest Reference
 
+### Manifest filename: `skill.yaml` or `contract.yaml`
+
+The framework's CLI (`nexaas register-skill` / `nexaas register-skills`) accepts both:
+
+- **`skill.yaml`** — the framework-native shape, documented in the rest of this section. `id:`, `version:`, `triggers:[]`, `execution.timeout` (in milliseconds)
+- **`contract.yaml`** — the richer shape used by some adopters (Nexmatic skill packages, for instance). `skill: <name>` + `category: <cat>` instead of `id:`, top-level `schedule:` instead of `triggers:[]`, `execution.timeout_seconds:` instead of `execution.timeout` (ms), plus product-level fields the framework safely ignores (`produces:`, `outputs:`, `tag_defaults:`, `client_must_configure:`, etc.)
+
+`registerOneSkill` detects the contract shape by absence of `id:` + presence of `skill:` and translates it in-process. Both `nexaas register-skill <path/to/contract.yaml>` and bulk `nexaas register-skills <skills-root>` walk both filenames.
+
+When a skill directory contains both (rare; during a migration), `skill.yaml` wins as the operator-authored translation. See `normalizeManifest()` in `packages/cli/src/register-skill.ts` for the exact field-by-field translation.
+
 ### Timezone
 
 All cron schedules should declare a timezone. Without one, the system defaults to `America/Toronto` (Eastern Time). The VPS clock runs UTC but cron expressions are interpreted in the declared timezone.

--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -51,6 +51,81 @@ export interface SkillManifest {
   };
 }
 
+/**
+ * Normalize a YAML-parsed manifest into the framework's `SkillManifest`
+ * shape (#139). Accepts both:
+ *
+ *   1. The framework's `skill.yaml` format — `id:`, `version:`, `triggers:[]`,
+ *      `execution.timeout` (ms). Pass-through.
+ *
+ *   2. The richer `contract.yaml` format used by some adopters (Nexmatic
+ *      skill packages, for instance) — `skill:` + `category:` instead of
+ *      `id:`, top-level `schedule:` instead of `triggers:[]`,
+ *      `execution.timeout_seconds:` instead of `execution.timeout` (ms).
+ *      Plus product-level fields (`produces:`, `outputs:`, `tag_defaults:`,
+ *      `client_must_configure:`, etc.) the framework already ignores as
+ *      unknown fields.
+ *
+ * Detection heuristic: missing `id` AND present `skill` → contract shape.
+ * Otherwise treated as native skill.yaml.
+ *
+ * Pure helper: no I/O, no side effects. Tested in
+ * `scripts/test-manifest-normalize-139.mjs`.
+ */
+export function normalizeManifest(raw: Record<string, unknown> | null): SkillManifest {
+  if (!raw || typeof raw !== "object") {
+    return {} as SkillManifest;
+  }
+  const r = raw as Record<string, unknown>;
+  const isContract = typeof r.id !== "string" && typeof r.skill === "string";
+  if (!isContract) {
+    return r as unknown as SkillManifest;
+  }
+
+  // ── contract.yaml → skill.yaml translation ────────────────────────
+  const skill = String(r.skill);
+  // If `skill:` already contains a slash, skip the category prefix.
+  // Otherwise, prepend `category:` when present.
+  const id = skill.includes("/")
+    ? skill
+    : typeof r.category === "string" && r.category.length > 0
+      ? `${r.category}/${skill}`
+      : skill;
+
+  // Triggers: prefer explicit `triggers:[]` when present; otherwise lift
+  // top-level `schedule:` into a cron trigger.
+  let triggers = Array.isArray(r.triggers) ? (r.triggers as SkillManifest["triggers"]) : undefined;
+  if (!triggers && typeof r.schedule === "string" && r.schedule.length > 0) {
+    triggers = [{ type: "cron", schedule: r.schedule }];
+  }
+
+  // Execution: prefer `execution.timeout` (ms) when present; otherwise
+  // convert `execution.timeout_seconds` (s) → ms.
+  const execIn = (r.execution as Record<string, unknown> | undefined) ?? undefined;
+  let execution: SkillManifest["execution"] | undefined;
+  if (execIn) {
+    const timeoutMs = typeof execIn.timeout === "number"
+      ? (execIn.timeout as number)
+      : typeof execIn.timeout_seconds === "number"
+        ? Math.floor((execIn.timeout_seconds as number) * 1000)
+        : undefined;
+    execution = {
+      type: typeof execIn.type === "string" ? (execIn.type as string) : "shell",
+      ...(typeof execIn.command === "string" ? { command: execIn.command as string } : {}),
+      ...(typeof timeoutMs === "number" ? { timeout: timeoutMs } : {}),
+      ...(typeof execIn.working_directory === "string" ? { working_directory: execIn.working_directory as string } : {}),
+    };
+  }
+
+  return {
+    ...r,
+    id,
+    version: typeof r.version === "string" ? r.version : "0",
+    ...(triggers ? { triggers } : {}),
+    ...(execution ? { execution } : {}),
+  } as unknown as SkillManifest;
+}
+
 export interface RegisterContext {
   queue: Queue;
   workspace: string;
@@ -258,7 +333,8 @@ export async function registerOneSkill(
   let manifest: SkillManifest;
   try {
     const content = readFileSync(manifestPath, "utf-8");
-    manifest = yamlLoad(content) as SkillManifest;
+    const raw = yamlLoad(content) as Record<string, unknown> | null;
+    manifest = normalizeManifest(raw);
     if (!manifest?.id || !manifest?.version) {
       return {
         skillId: manifestPath,

--- a/packages/cli/src/register-skills.ts
+++ b/packages/cli/src/register-skills.ts
@@ -47,9 +47,17 @@ function printUsage(): void {
   process.stdout.write(USAGE);
 }
 
-/** Walk a directory tree, collect every `skill.yaml` we find. */
+/**
+ * Walk a directory tree, collect every framework-readable manifest.
+ * Matches both `skill.yaml` (framework-native) and `contract.yaml`
+ * (Nexmatic-style, #139 — normalized at load time by registerOneSkill).
+ *
+ * When a skill directory contains BOTH (rare but possible during
+ * migration), `skill.yaml` wins — the operator-authored translation
+ * is treated as the authoritative shape.
+ */
 function findManifests(dir: string): string[] {
-  const out: string[] = [];
+  const matched = new Map<string, string>();   // skill dir → preferred manifest
   const stack: string[] = [dir];
   while (stack.length > 0) {
     const cur = stack.pop()!;
@@ -64,12 +72,14 @@ function findManifests(dir: string): string[] {
       if (st.isDirectory()) {
         stack.push(path);
       } else if (basename(path) === "skill.yaml") {
-        out.push(path);
+        matched.set(cur, path);     // skill.yaml wins unconditionally
+      } else if (basename(path) === "contract.yaml" && !matched.has(cur)) {
+        matched.set(cur, path);
       }
     }
   }
   // Stable order so successive runs print the same sequence.
-  return out.sort();
+  return [...matched.values()].sort();
 }
 
 interface Options {

--- a/scripts/test-manifest-normalize-139.mjs
+++ b/scripts/test-manifest-normalize-139.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #139 — register-skill accepts contract.yaml natively.
+ *
+ * Pure test of `normalizeManifest` — exercises both the pass-through case
+ * (framework-native skill.yaml) and the contract→manifest translation
+ * (Nexmatic-style contract.yaml).
+ *
+ * Run: node --import tsx scripts/test-manifest-normalize-139.mjs
+ */
+
+import { normalizeManifest } from "../packages/cli/src/register-skill.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. Pass-through: framework-native skill.yaml ──────────────────
+console.log("\n1. Framework-native skill.yaml passes through");
+{
+  const raw = {
+    id: "crm/lead-sync-all",
+    version: "1.0.0",
+    triggers: [{ type: "cron", schedule: "*/30 * * * *" }],
+    execution: { type: "shell", command: "do.sh", timeout: 600000 },
+  };
+  const m = normalizeManifest(raw);
+  assert(m.id === "crm/lead-sync-all", "id unchanged");
+  assert(m.version === "1.0.0", "version unchanged");
+  assert(m.triggers?.[0]?.schedule === "*/30 * * * *", "triggers unchanged");
+  assert(m.execution?.timeout === 600000, "timeout (ms) unchanged");
+}
+
+// ── 2. Contract: skill + category → id ────────────────────────────
+console.log("\n2. contract.yaml: skill + category → id");
+{
+  const raw = {
+    skill: "lead-sync-all",
+    category: "crm",
+    version: "1.0.0",
+    schedule: "*/30 * * * *",
+    execution: { type: "shell", command: "do.sh", timeout_seconds: 600 },
+  };
+  const m = normalizeManifest(raw);
+  assert(m.id === "crm/lead-sync-all", `id assembled (got '${m.id}')`);
+  assert(m.version === "1.0.0", "version preserved");
+}
+
+// ── 3. Contract: top-level schedule → cron trigger ────────────────
+console.log("\n3. contract.yaml: top-level schedule → cron trigger");
+{
+  const raw = {
+    skill: "marketing/email-broadcast",
+    version: "0.1.0",
+    schedule: "0 9 * * MON",
+    execution: { type: "ai-skill" },
+  };
+  const m = normalizeManifest(raw);
+  assert(Array.isArray(m.triggers), "triggers array created");
+  assert(m.triggers?.length === 1, "one trigger");
+  assert(m.triggers?.[0]?.type === "cron", "type=cron");
+  assert(m.triggers?.[0]?.schedule === "0 9 * * MON", "schedule preserved");
+}
+
+// ── 4. Contract: timeout_seconds → timeout (ms) ───────────────────
+console.log("\n4. contract.yaml: timeout_seconds → timeout (ms)");
+{
+  const raw = {
+    skill: "ops/cleanup",
+    category: "ops",
+    version: "0.1.0",
+    schedule: "0 3 * * *",
+    execution: { type: "shell", command: "cleanup.sh", timeout_seconds: 600 },
+  };
+  const m = normalizeManifest(raw);
+  assert(m.execution?.timeout === 600000, `600s → 600000ms (got ${m.execution?.timeout})`);
+}
+
+// ── 5. Contract with slash in `skill:` skips category prefix ──────
+console.log("\n5. contract.yaml with category-prefixed skill: doesn't double-prefix");
+{
+  const raw = {
+    skill: "hr/onboarding-intake",
+    category: "hr",       // already in skill
+    version: "0.1.0",
+    schedule: "0 9 * * MON",
+  };
+  const m = normalizeManifest(raw);
+  assert(m.id === "hr/onboarding-intake", `id stays single-prefix (got '${m.id}')`);
+}
+
+// ── 6. Contract without category falls back to bare skill ─────────
+console.log("\n6. contract.yaml without category uses bare skill");
+{
+  const raw = {
+    skill: "standalone",
+    version: "0.1.0",
+    schedule: "0 * * * *",
+  };
+  const m = normalizeManifest(raw);
+  assert(m.id === "standalone", "id is the bare skill name");
+}
+
+// ── 7. Contract-only fields pass through (produces, outputs, etc.) ─
+console.log("\n7. Contract-only fields pass through");
+{
+  const raw = {
+    skill: "email-broadcast",
+    category: "marketing",
+    version: "0.1.0",
+    schedule: "0 * * * *",
+    produces: { type: "outbound_email" },
+    outputs: ["scheduled_email"],
+    tag_defaults: { approval_required: false },
+    client_must_configure: ["postmark_api_key"],
+    mcp_servers: ["email-outbound"],
+    rag: { rooms: ["marketing.templates"] },
+  };
+  const m = normalizeManifest(raw);
+  assert(m.id === "marketing/email-broadcast", "id translated");
+  assert(m.produces?.type === "outbound_email", "produces passes through");
+  assert(m.outputs?.[0] === "scheduled_email", "outputs passes through");
+  assert(m.tag_defaults?.approval_required === false, "tag_defaults passes through");
+  assert(Array.isArray(m.client_must_configure), "client_must_configure passes through");
+  assert(Array.isArray(m.mcp_servers), "mcp_servers passes through");
+  assert(m.rag?.rooms?.[0] === "marketing.templates", "rag passes through");
+}
+
+// ── 8. Explicit triggers array wins over schedule ─────────────────
+console.log("\n8. Explicit triggers wins over top-level schedule");
+{
+  const raw = {
+    skill: "hybrid",
+    category: "x",
+    version: "0.1.0",
+    schedule: "0 * * * *",
+    triggers: [{ type: "cron", schedule: "*/15 * * * *" }],
+  };
+  const m = normalizeManifest(raw);
+  assert(m.triggers?.[0]?.schedule === "*/15 * * * *", "explicit triggers used");
+  assert(m.triggers?.length === 1, "schedule did NOT add a second trigger");
+}
+
+// ── 9. Empty / malformed inputs ───────────────────────────────────
+console.log("\n9. Empty / malformed");
+{
+  assert(normalizeManifest(null).id === undefined, "null → empty manifest");
+  assert(normalizeManifest({}).id === undefined, "empty → empty manifest");
+  // YAML parse fail upstream returns null/undefined; normalizeManifest shouldn't crash.
+  assert(normalizeManifest(undefined).id === undefined, "undefined → empty manifest");
+}
+
+// ── 10. Contract with execution.timeout (ms) wins over timeout_seconds ─
+console.log("\n10. execution.timeout (ms) wins over timeout_seconds");
+{
+  const raw = {
+    skill: "x",
+    category: "y",
+    version: "0.1.0",
+    schedule: "* * * * *",
+    execution: { type: "shell", timeout: 30000, timeout_seconds: 999 },
+  };
+  const m = normalizeManifest(raw);
+  assert(m.execution?.timeout === 30000, `explicit ms wins (got ${m.execution?.timeout})`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #139.

Adopters using the Nexmatic-style `contract.yaml` format (or any other adopter following the same convention) can now register skills via the framework CLI without a pre-translation step. Unblocks every fresh client deploy from Nexmatic.

## Field translation

| contract.yaml | → | skill.yaml |
|---|---|---|
| `skill:` + `category:` | → | `id: <category>/<skill>` |
| `skill: hr/onboarding` (already-prefixed) | → | no double-prefix |
| top-level `schedule:` | → | `triggers: [{ type: cron, schedule: … }]` |
| `execution.timeout_seconds: 600` | → | `execution.timeout: 600000` (ms) |
| `produces:`, `outputs:`, `tag_defaults:`, `client_must_configure:`, `mcp_servers:`, `rag:` | → | passed through |

Detection: missing `id:` + present `skill:` → contract shape. Otherwise pass-through. Explicit `triggers:[]` always wins over top-level `schedule:`.

## Changes

- **`normalizeManifest()`** — new exported pure helper in `register-skill.ts`. Called from `registerOneSkill` before the `id`/`version` check
- **Bulk walker** in `register-skills.ts` matches both `skill.yaml` and `contract.yaml`. When a directory contains both (during migration), `skill.yaml` wins as the operator-authored translation
- **Doc note** in `skill-authoring.md` §3 documenting the dual-format support

## Test plan

- [x] 26 cases in `scripts/test-manifest-normalize-139.mjs`: pass-through, contract → skill translation, skill-with-slash skipping category prefix, bare skill without category, contract-only fields preserved (`produces` / `outputs` / `tag_defaults` / etc.), explicit triggers wins over schedule, timeout_seconds → ms, ms wins over seconds, empty / malformed inputs
- [x] `tsc --noEmit -p packages/cli/tsconfig.json` clean
- [x] Full `npm run build` clean

## Nexmatic follow-up

Once merged, Nexmatic can delete `scripts/translate-skill-manifests.mjs` and drop the translation step from `scripts/provision-workspace.sh`. The framework now natively understands what the script was doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now supports both `skill.yaml` and `contract.yaml` manifest files
  * When both files exist in the same directory, `skill.yaml` takes precedence over `contract.yaml`

* **Documentation**
  * Added "Skill Manifest Reference" subsection clarifying supported manifest filenames and precedence rules

* **Tests**
  * Added regression tests for manifest handling and validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/141)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->