### PR TITLE
chore: drop two deprecated internal shims

### DIFF
--- a/packages/runtime/src/models/agentic-loop.ts
+++ b/packages/runtime/src/models/agentic-loop.ts
@@ -207,12 +207,10 @@ export async function runAgenticLoop(params: {
   skillId: string;
   limits?: AgenticLimits;
   modelPricing?: AgenticModelPricing;
-  /** @deprecated use `limits.maxTurns` */
-  maxTurns?: number;
 }): Promise<AgenticResult> {
   const { model, system, tools, executeTool, workspace, runId, skillId, modelPricing } = params;
   const limits: AgenticLimits = params.limits ?? {};
-  const maxTurns = limits.maxTurns ?? params.maxTurns ?? DEFAULT_MAX_TURNS;
+  const maxTurns = limits.maxTurns ?? DEFAULT_MAX_TURNS;
   const maxIdentical = limits.maxConsecutiveIdenticalToolCalls ?? DEFAULT_MAX_CONSECUTIVE_IDENTICAL;
   const maxErrors = limits.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS;
   const maxTokensPerTurn = limits.maxOutputTokensPerTurn ?? DEFAULT_MAX_OUTPUT_TOKENS_PER_TURN;

--- a/packages/runtime/src/pa/service.ts
+++ b/packages/runtime/src/pa/service.ts
@@ -293,7 +293,7 @@ Be helpful, context-aware, and follow the brand voice.`;
         messages: [{ role: "user", content: message.content }],
         tools: allTools,
         executeTool,
-        maxTurns: persona.maxTurns ?? 15,
+        limits: { maxTurns: persona.maxTurns ?? 15 },
         workspace,
         runId,
         skillId: `pa/${persona.id}`,

--- a/packages/runtime/src/subagent.ts
+++ b/packages/runtime/src/subagent.ts
@@ -102,7 +102,7 @@ export async function subagent(params: {
       messages: [{ role: "user", content: userMessage }],
       tools: allTools,
       executeTool,
-      maxTurns: 10,
+      limits: { maxTurns: 10 },
       workspace,
       runId: subRunId,
       skillId: `subagent:${config.id}`,

--- a/packages/runtime/src/tasks/health-monitor.ts
+++ b/packages/runtime/src/tasks/health-monitor.ts
@@ -316,8 +316,3 @@ export async function sendAlerts(report: HealthReport): Promise<void> {
     dedupeWindowMinutes: severity === "critical" ? 5 : 30,
   });
 }
-
-/** @deprecated Use sendAlerts() instead — kept for backward compatibility */
-export async function sendTelegramAlert(report: HealthReport, botToken: string, chatId: string): Promise<void> {
-  await sendAlerts(report);
-}


### PR DESCRIPTION
End-of-session sweep cleanup. Two tiny dead-shim removals surfaced by `grep -r @deprecated`:

1. **`runAgenticLoop({ maxTurns })` top-level param → drop.** Two internal callers (`subagent.ts`, `pa/service.ts`) still used the deprecated top-level form. `ai-skill.ts` already used `limits.maxTurns`. Updated the two stragglers, then dropped the deprecated param entirely — `runAgenticLoop` isn't in `@nexaas/runtime`'s index.ts so no external callers exist.

2. **`sendTelegramAlert` shim in `health-monitor.ts` → delete.** One-line forwarder to `sendAlerts()`, marked `@deprecated`, zero callers anywhere in the framework codebase (or in re-exports). Pure dead code.

Net: −7 lines, +0 functionality. CLAUDE.md's "if certain it's unused, delete it" rule.

## Verification

- [x] `grep -r maxTurns packages/runtime/src` returns only `limits.maxTurns` references
- [x] `grep -r sendTelegramAlert` returns no matches after this change
- [x] Full `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated `maxTurns` parameter from agentic loop initialization. Turn limits are now configured exclusively via `limits.maxTurns`.
  * Removed deprecated `sendTelegramAlert` function from health monitoring exports.

* **Improvements**
  * Enhanced alert deduplication in health monitoring with workspace-specific deduplication keys and dynamic time windows based on alert severity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->