### PR TITLE
feat(palace): pa_delivery_marker sidecar for workspace PA delivery

### DIFF
--- a/database/migrations/021_pa_delivery_marker.sql
+++ b/database/migrations/021_pa_delivery_marker.sql
@@ -1,0 +1,48 @@
+-- PA-Router outbound delivery marker (RFC-0002, workspace consumer half).
+--
+-- The /api/pa/<user>/notify endpoint writes pending drawers at
+-- `notifications.pending.pa-routed.<thread_id>`. Workspace-side delivery
+-- skills (e.g. Phoenix's pa/routed-deliver) consume those drawers and
+-- forward to the user's channel target (Telegram today; email/SMS later).
+--
+-- This table records delivery state per drawer so the delivery skill can
+-- enforce at-least-once delivery + retry semantics without mutating the
+-- pending drawer itself (event-sourcing principle — drawers are immutable;
+-- delivery state lives in a sidecar table). Same pattern as
+-- inbound_dispatches (#17) and notification_dispatches (#16).
+--
+-- Status state machine:
+--   queued  → claimed by a delivery worker (insert with status='queued')
+--   sent    → channel returned success; channel_message_id captured
+--   failed  → transient failure; retries < 3; eligible for re-pickup
+--   dead    → exhausted retries; ops alert fired; no further attempts
+--   skipped → pa_threads row missing or status != 'active' for this
+--             (user, thread); drawer logged + acknowledged + not retried
+
+CREATE TABLE IF NOT EXISTS nexaas_memory.pa_delivery_marker (
+  workspace            text NOT NULL,
+  drawer_id            uuid NOT NULL,
+  user_hall            text NOT NULL,
+  thread_id            text NOT NULL,
+  channel_message_id   text,                   -- e.g. Telegram message_id; null until 'sent'
+  status               text NOT NULL DEFAULT 'queued',
+  retries              integer NOT NULL DEFAULT 0,
+  last_error           text,
+  claimed_at           timestamptz NOT NULL DEFAULT now(),
+  sent_at              timestamptz,
+  PRIMARY KEY (workspace, drawer_id),
+  CONSTRAINT pa_delivery_marker_status_chk
+    CHECK (status IN ('queued', 'sent', 'failed', 'dead', 'skipped'))
+);
+
+-- "What did we deliver to this (user, thread) in the last N?" — supports
+-- per-thread digest assembly, audit views, observability dashboards.
+CREATE INDEX IF NOT EXISTS ix_pa_delivery_marker_thread
+  ON nexaas_memory.pa_delivery_marker (workspace, user_hall, thread_id, sent_at DESC)
+  WHERE status = 'sent';
+
+-- Delivery-worker scan: "which markers are eligible for (re-)delivery?"
+-- Partial index on retryable states keeps it compact even at scale.
+CREATE INDEX IF NOT EXISTS ix_pa_delivery_marker_pending
+  ON nexaas_memory.pa_delivery_marker (workspace, status, claimed_at)
+  WHERE status IN ('queued', 'failed');


### PR DESCRIPTION
Framework migration that lets workspace-side delivery skills (e.g. Phoenix's `pa/routed-deliver`) consume `notifications.pending.pa-routed.<thread_id>` drawers safely with at-least-once + retry semantics.

## Why

The `/api/pa/<user>/notify` endpoint (#134) writes pending drawers but doesn't deliver them anywhere — workspace consumers own that half. Without a sidecar table to record delivery state, the consumer would have to either:

- **Mutate the pending drawer** (violates event-sourcing — drawers are immutable in this system)
- **Maintain a workspace-local SQLite** (every workspace reinvents idempotency; tight ops surface; no audit across workspaces)

Neither is good. Sidecar table matches the existing pattern (`inbound_dispatches` #17, `notification_dispatches` #16): one row per dispatch outcome, immutable pending drawers stay immutable.

## What lands

`database/migrations/021_pa_delivery_marker.sql`:

```sql
CREATE TABLE nexaas_memory.pa_delivery_marker (
  workspace            text NOT NULL,
  drawer_id            uuid NOT NULL,
  user_hall            text NOT NULL,
  thread_id            text NOT NULL,
  channel_message_id   text,
  status               text NOT NULL DEFAULT 'queued',
  retries              integer NOT NULL DEFAULT 0,
  last_error           text,
  claimed_at           timestamptz NOT NULL DEFAULT now(),
  sent_at              timestamptz,
  PRIMARY KEY (workspace, drawer_id),
  CONSTRAINT pa_delivery_marker_status_chk
    CHECK (status IN ('queued', 'sent', 'failed', 'dead', 'skipped'))
);
```

Plus two partial indexes:

- `ix_pa_delivery_marker_thread (workspace, user_hall, thread_id, sent_at DESC) WHERE status='sent'` — per-thread digest / audit queries
- `ix_pa_delivery_marker_pending (workspace, status, claimed_at) WHERE status IN ('queued','failed')` — delivery-worker scan

## Status state machine

```
queued  → claimed by a delivery worker (insert)
sent    → channel returned success; channel_message_id captured
failed  → transient failure; retries < 3; eligible for re-pickup
dead    → exhausted retries; ops alert fired; no further attempts
skipped → pa_threads row missing or status != 'active'; logged + acknowledged
```

`channel_message_id` is `text` (not `bigint`) so the same column serves Telegram message_id, future email Message-Id, future SMS provider ids, etc. — no migration needed when RFC §3.8 lands.

## Validation

Applied to Phoenix canary (`nexaas_palace`):

- ✓ Clean apply on populated palace (no data loss)
- ✓ Both partial indexes confirmed used by EXPLAIN on canonical queries:
  - thread-scoped: `Index Scan using ix_pa_delivery_marker_thread`
  - pending scan: `Index Scan using ix_pa_delivery_marker_pending`
- ✓ CHECK constraint rejects unknown status values (manual test)
- ✓ schema_migrations row recorded

## Why this isn't bundled with workspace work

The workspace-side consumer skill is per-workspace (Phoenix has Telegram; another canary might wire email/SMS). The schema is canonical and shared. Splitting them keeps the framework PR minimal and lets workspaces ship their consumer on their own cadence.

Workspace-side consumer that uses this table is tracked in Systemsaholic/Phoenix-Voyages#3 — Phoenix's `pa/routed-deliver` skill design is in `agents/pa/PA-ROUTER-PHOENIX-PLAN.md`.

## Test plan

- [x] Migration applies forward cleanly on populated palace
- [x] Both partial indexes used by `EXPLAIN ANALYZE` on the queries the workspace consumer will run
- [x] CHECK constraint enforces status enum
- [ ] First workspace consumer (Phoenix `pa/routed-deliver`) round-trips end-to-end against this table — tracked in Systemsaholic/Phoenix-Voyages#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database infrastructure to support message delivery tracking and status management, enabling improved monitoring and retry capabilities for outbound messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->