### PR TITLE
fix(cli): null-guard sched entries in findCronOverlaps

### DIFF
--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -270,7 +270,10 @@ export async function findCronOverlaps(
   const warningsByGroup = new Map<string, CronOverlapWarning>();
 
   for (const sched of existing) {
-    if (!sched.name || sched.name === sameJobName) continue;
+    // BullMQ's getJobSchedulers() can return entries with undefined fields
+    // (sparse-array quirk observed when a scheduler is mid-deletion). Skip
+    // any malformed entry rather than crashing the whole register-skill run.
+    if (!sched || !sched.name || sched.name === sameJobName) continue;
     if (!sched.pattern) continue;
 
     const data = sched.template?.data as


### PR DESCRIPTION
One-line fix. BullMQ's \`getJobSchedulers()\` can return sparse-array entries with undefined fields (observed when a scheduler is being deleted concurrently). The cron-overlap check from #115 then crashes on \`sched.name\`, taking down the entire register-skill run.

## Repro

Register any skill with \`concurrency_groups\` declared while another scheduler is mid-deletion. Hit on Phoenix canary while registering \`pa/routed-deliver\` (Systemsaholic/Phoenix-Voyages#3):

\`\`\`
TypeError: Cannot read properties of undefined (reading 'name')
    at findCronOverlaps (packages/cli/src/register-skill.ts:273:16)
\`\`\`

## Fix

\`\`\`diff
   for (const sched of existing) {
-    if (!sched.name || sched.name === sameJobName) continue;
+    if (!sched || !sched.name || sched.name === sameJobName) continue;
     if (!sched.pattern) continue;
\`\`\`

Same semantics as the existing \`!sched.name\` check, just extended to the parent. Other null-safe checks in the function (\`!data?.skillId\`, \`!Array.isArray(data.concurrencyGroups)\`) already follow this pattern.

Workaround if not merged: register-skill aborts mid-run, but the underlying Bull operations have already succeeded, so a retry typically goes through. Less reliable than the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential CLI crashes caused by malformed scheduler entries during skill registration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->