### PR TITLE
feat(webstudio): /api/webstudio/import accept method=git (#147)

### DIFF
--- a/packages/runtime/src/webstudio/framework-detect.ts
+++ b/packages/runtime/src/webstudio/framework-detect.ts
@@ -1,0 +1,109 @@
+/**
+ * Framework detection for Web Studio's git-import path (#147).
+ *
+ * Inspects a cloned repo's package.json and picks the right dev-server
+ * command. Pure / no side effects so it's unit-testable without a real
+ * git clone.
+ *
+ * Falls back to `static` when no recognized framework is detected — the
+ * caller can then serve the working copy with the same static-serve used
+ * by the scrape path.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+export type Framework = "next" | "vite" | "cra" | "gatsby" | "static";
+
+export interface FrameworkDetection {
+  framework: Framework;
+  // Command + args to spawn the dev server. `static` returns null —
+  // caller handles fallback via the scrape path's `serve`.
+  devCommand: { command: string; args: string[] } | null;
+  // Detected package manager (lockfile-based). `npm` is the default fallback.
+  packageManager: "npm" | "pnpm" | "yarn";
+  // Whether to use `ci` install (lockfile present) vs `install`.
+  hasLockfile: boolean;
+}
+
+export function detectFramework(repoRoot: string): FrameworkDetection {
+  const packageManager = detectPackageManager(repoRoot);
+  const hasLockfile = packageManager !== "npm"
+    || existsSync(join(repoRoot, "package-lock.json"));
+
+  const pkgPath = join(repoRoot, "package.json");
+  if (!existsSync(pkgPath)) {
+    return { framework: "static", devCommand: null, packageManager, hasLockfile };
+  }
+
+  let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string>; scripts?: Record<string, string> };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  } catch {
+    return { framework: "static", devCommand: null, packageManager, hasLockfile };
+  }
+
+  const allDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+  const scripts = pkg.scripts ?? {};
+
+  // Order matters: Next.js takes precedence over react/vite since
+  // Next.js apps frequently depend on react too. Gatsby before react
+  // for the same reason.
+  if ("next" in allDeps) {
+    return {
+      framework: "next",
+      devCommand: scriptOrFallback(scripts, "dev", packageManager, ["next", "dev", "--port", "3002"]),
+      packageManager,
+      hasLockfile,
+    };
+  }
+  if ("gatsby" in allDeps) {
+    return {
+      framework: "gatsby",
+      devCommand: scriptOrFallback(scripts, "develop", packageManager, ["gatsby", "develop", "--port", "3002"]),
+      packageManager,
+      hasLockfile,
+    };
+  }
+  if ("vite" in allDeps) {
+    return {
+      framework: "vite",
+      devCommand: scriptOrFallback(scripts, "dev", packageManager, ["vite", "--port", "3002"]),
+      packageManager,
+      hasLockfile,
+    };
+  }
+  if ("react-scripts" in allDeps) {
+    return {
+      framework: "cra",
+      // CRA insists on its own port logic; PORT env is the only stable knob.
+      devCommand: scriptOrFallback(scripts, "start", packageManager, ["react-scripts", "start"]),
+      packageManager,
+      hasLockfile,
+    };
+  }
+
+  return { framework: "static", devCommand: null, packageManager, hasLockfile };
+}
+
+function detectPackageManager(repoRoot: string): "npm" | "pnpm" | "yarn" {
+  if (existsSync(join(repoRoot, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(repoRoot, "yarn.lock"))) return "yarn";
+  return "npm";
+}
+
+// Prefer a script defined in package.json (e.g. `npm run dev`) over the
+// raw binary invocation — projects often need bespoke flags that the
+// script wraps. Fall back to the raw command if the script is missing.
+function scriptOrFallback(
+  scripts: Record<string, string>,
+  scriptName: string,
+  pm: "npm" | "pnpm" | "yarn",
+  fallback: string[],
+): { command: string; args: string[] } {
+  if (scripts[scriptName]) {
+    const runArg = pm === "npm" ? "run" : pm === "yarn" ? "run" : "run";
+    return { command: pm, args: [runArg, scriptName] };
+  }
+  return { command: "npx", args: ["-y", ...fallback] };
+}

--- a/packages/runtime/src/webstudio/git-import.ts
+++ b/packages/runtime/src/webstudio/git-import.ts
@@ -70,6 +70,10 @@ export async function runGitImport(
   paths: GitImportPaths,
 ): Promise<GitImportResult> {
   if (!input.url) throw new Error("git import: url required");
+  // Reject URLs starting with `-` so they can't masquerade as a git flag
+  // (e.g. `--upload-pack=...` is a remote-code-execution vector via git
+  // clone). Defense-in-depth alongside the `--` separator below.
+  if (input.url.startsWith("-")) throw new Error("git import: url must not start with '-'");
   const branch = input.branch ?? "main";
 
   // 1. Wipe any prior clone — re-importing the same workspace should
@@ -95,7 +99,7 @@ export async function runGitImport(
   // 3. Clone.
   try {
     await execAsync(
-      `git clone --depth=1 --branch=${shellEscape(branch)} ${shellEscape(input.url)} ${shellEscape(paths.repoRoot)}`,
+      `git clone --depth=1 --branch=${shellEscape(branch)} -- ${shellEscape(input.url)} ${shellEscape(paths.repoRoot)}`,
       { env: gitEnv, timeout: 120_000 },
     );
   } catch (err) {

--- a/packages/runtime/src/webstudio/git-import.ts
+++ b/packages/runtime/src/webstudio/git-import.ts
@@ -1,0 +1,235 @@
+/**
+ * Git-clone import path for Web Studio (#147).
+ *
+ * Companion to the existing wget-scrape path in worker.ts — same
+ * endpoint, different `method`. Where scrape downloads a static mirror
+ * (good only for marketing sites), git-clone pulls a real repo, detects
+ * the framework, installs dependencies, and spawns the project's dev
+ * server. This unblocks framework-based sites (Next.js, Vite, CRA,
+ * Gatsby) where the scrape snapshot is unusable.
+ *
+ * The dev server takes over the WebStudio preview port (3002) — the
+ * scrape path's static `serve` and the git path's dev server are
+ * mutually exclusive per workspace. The caller `fuser -k`s the port
+ * before invoking either, so the import always wins over a stale
+ * preview.
+ */
+
+import { spawn } from "child_process";
+import {
+  chmodSync, existsSync, mkdirSync, openSync, readdirSync, statSync, writeFileSync,
+} from "fs";
+import { join } from "path";
+import { promisify } from "util";
+import { exec as execCallback } from "child_process";
+
+const execAsync = promisify(execCallback);
+
+import { detectFramework, type Framework } from "./framework-detect.js";
+
+export interface GitImportInput {
+  url: string;
+  branch?: string;            // default 'main'
+  deployKey?: string;         // ed25519 private key body
+  auth?: "deploy_key" | "https_token";  // honored only when deployKey is present
+}
+
+export interface GitImportResult {
+  previewUrl: string;
+  framework: Framework;
+  packageManager: "npm" | "pnpm" | "yarn";
+  devServerPid: number | null;
+  repoRoot: string;
+  branch: string;
+  commitSha: string;
+}
+
+export interface GitImportPaths {
+  // ${NEXAAS_ROOT}/web-studio/<workspace>/repo
+  repoRoot: string;
+  // ${NEXAAS_ROOT}/web-studio/<workspace>/dev-server.log
+  logFile: string;
+  // ${NEXAAS_ROOT}/.ssh/<workspace>_deploy_key
+  deployKeyPath: string;
+}
+
+const MAX_REPO_BYTES = 500 * 1024 * 1024;        // 500MB
+const NPM_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;    // 5 minutes
+const PREVIEW_PORT = 3002;
+
+export function gitImportPaths(nexaasRoot: string, workspace: string): GitImportPaths {
+  return {
+    repoRoot: join(nexaasRoot, "web-studio", workspace, "repo"),
+    logFile: join(nexaasRoot, "web-studio", workspace, "dev-server.log"),
+    deployKeyPath: join(nexaasRoot, ".ssh", `${workspace}_deploy_key`),
+  };
+}
+
+export async function runGitImport(
+  input: GitImportInput,
+  paths: GitImportPaths,
+): Promise<GitImportResult> {
+  if (!input.url) throw new Error("git import: url required");
+  const branch = input.branch ?? "main";
+
+  // 1. Wipe any prior clone — re-importing the same workspace should
+  //    yield a fresh checkout. Resist the urge to git-fetch + reset,
+  //    since the user may have switched repos entirely.
+  if (existsSync(paths.repoRoot)) {
+    await execAsync(`rm -rf ${shellEscape(paths.repoRoot)}`);
+  }
+  mkdirSync(paths.repoRoot, { recursive: true });
+
+  // 2. If a deploy key was supplied, write it (0600) and arrange for
+  //    git to use it via GIT_SSH_COMMAND. The ssh `-o IdentitiesOnly=yes`
+  //    bit prevents ssh-agent from offering some other key first and
+  //    getting the connection rate-limited.
+  let gitEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (input.deployKey) {
+    mkdirSync(join(paths.deployKeyPath, ".."), { recursive: true, mode: 0o700 });
+    writeFileSync(paths.deployKeyPath, ensureTrailingNewline(input.deployKey), { mode: 0o600 });
+    chmodSync(paths.deployKeyPath, 0o600);
+    gitEnv.GIT_SSH_COMMAND = `ssh -i ${shellEscape(paths.deployKeyPath)} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new`;
+  }
+
+  // 3. Clone.
+  try {
+    await execAsync(
+      `git clone --depth=1 --branch=${shellEscape(branch)} ${shellEscape(input.url)} ${shellEscape(paths.repoRoot)}`,
+      { env: gitEnv, timeout: 120_000 },
+    );
+  } catch (err) {
+    throw new Error(`git clone failed: ${(err as Error).message}`);
+  }
+
+  // 4. Enforce 500MB cap post-clone. A pathological repo could blow the
+  //    disk before we noticed; this just catches the obvious cases
+  //    (LFS without quotas, accidentally-vendored node_modules).
+  const sizeBytes = directorySizeBytes(paths.repoRoot);
+  if (sizeBytes > MAX_REPO_BYTES) {
+    await execAsync(`rm -rf ${shellEscape(paths.repoRoot)}`);
+    throw new Error(`repo exceeds ${MAX_REPO_BYTES} byte cap (got ${sizeBytes})`);
+  }
+
+  // 5. Capture the commit sha while .git is still there. Some projects
+  //    have a `prepare` script that mucks with .git so do this before
+  //    `npm install`.
+  let commitSha = "";
+  try {
+    const { stdout } = await execAsync(`git -C ${shellEscape(paths.repoRoot)} rev-parse HEAD`);
+    commitSha = stdout.trim();
+  } catch { /* non-fatal */ }
+
+  // 6. Framework detect → choose install command.
+  const detection = detectFramework(paths.repoRoot);
+
+  // 7. Install deps. `static` framework still gets an install attempted
+  //    if there's a package.json — projects without one skip cleanly.
+  const pkgJsonExists = existsSync(join(paths.repoRoot, "package.json"));
+  if (pkgJsonExists) {
+    const installCmd = installCommand(detection.packageManager, detection.hasLockfile);
+    try {
+      await execAsync(installCmd, {
+        cwd: paths.repoRoot,
+        timeout: NPM_INSTALL_TIMEOUT_MS,
+        // Some installs need MUCH more than the default 1MB stdio buffer.
+        maxBuffer: 50 * 1024 * 1024,
+      });
+    } catch (err) {
+      throw new Error(`dependency install failed: ${(err as Error).message}`);
+    }
+  }
+
+  // 8. Free the preview port from any prior tenant (scrape's `serve`,
+  //    a previous dev server, etc.). Best effort — `fuser` returns
+  //    non-zero when nothing is listening, which is fine.
+  await execAsync(`fuser -k ${PREVIEW_PORT}/tcp 2>/dev/null || true`).catch(() => { /* ignore */ });
+
+  // 9. Spawn the dev server (if we have one) or fall back to static-serve.
+  let devServerPid: number | null = null;
+  if (detection.devCommand) {
+    devServerPid = await spawnDevServer(detection.devCommand, paths.repoRoot, paths.logFile);
+  } else {
+    // No detected framework — serve the working copy with `npx serve`
+    // so the preview still works for static-only repos.
+    devServerPid = await spawnStaticServe(paths.repoRoot, paths.logFile);
+  }
+
+  return {
+    previewUrl: `http://localhost:${PREVIEW_PORT}`,
+    framework: detection.framework,
+    packageManager: detection.packageManager,
+    devServerPid,
+    repoRoot: paths.repoRoot,
+    branch,
+    commitSha,
+  };
+}
+
+function installCommand(pm: "npm" | "pnpm" | "yarn", hasLockfile: boolean): string {
+  if (pm === "pnpm") return hasLockfile ? "pnpm install --frozen-lockfile" : "pnpm install";
+  if (pm === "yarn") return hasLockfile ? "yarn install --frozen-lockfile" : "yarn install";
+  return hasLockfile ? "npm ci" : "npm install";
+}
+
+async function spawnDevServer(
+  cmd: { command: string; args: string[] },
+  cwd: string,
+  logFile: string,
+): Promise<number | null> {
+  const out = openSync(logFile, "a");
+  const child = spawn(cmd.command, cmd.args, {
+    cwd,
+    detached: true,
+    stdio: ["ignore", out, out],
+    // PORT is the universal env contract for Node-based dev servers
+    // (Next, CRA, Vite all honor it; Gatsby has its own flag we set
+    // explicitly in framework-detect).
+    env: { ...process.env, PORT: String(PREVIEW_PORT) },
+  });
+  child.unref();
+  return child.pid ?? null;
+}
+
+async function spawnStaticServe(cwd: string, logFile: string): Promise<number | null> {
+  const out = openSync(logFile, "a");
+  const child = spawn("npx", ["-y", "serve", "-l", String(PREVIEW_PORT), "-s", cwd], {
+    cwd,
+    detached: true,
+    stdio: ["ignore", out, out],
+    env: { ...process.env },
+  });
+  child.unref();
+  return child.pid ?? null;
+}
+
+function directorySizeBytes(root: string): number {
+  let total = 0;
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      const p = join(dir, entry.name);
+      try {
+        if (entry.isDirectory()) {
+          stack.push(p);
+        } else if (entry.isFile()) {
+          total += statSync(p).size;
+        }
+      } catch { /* skip unstatable entries */ }
+    }
+  }
+  return total;
+}
+
+function ensureTrailingNewline(s: string): string {
+  return s.endsWith("\n") ? s : s + "\n";
+}
+
+function shellEscape(s: string): string {
+  // Single-quote wrap; close-and-escape any embedded single quotes.
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -39,6 +39,7 @@ import { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-r
 import { runAndRecord, sendAlerts } from "./tasks/health-monitor.js";
 import { handlePaMessage } from "./pa/service.js";
 import { loadMcpConfigs } from "./mcp/client.js";
+import { runGitImport, gitImportPaths } from "./webstudio/git-import.js";
 import { ingestDocument } from "./ingest/index.js";
 import { loadWorkspaceManifest } from "./schemas/load-manifest.js";
 import { startNotificationDispatcher } from "./tasks/notification-dispatcher.js";
@@ -584,14 +585,35 @@ async function main() {
   const WS_SITE_DIR = join(process.env.NEXAAS_ROOT ?? "/opt/nexaas", "web-studio", WORKSPACE ?? "default", "site");
   const WS_PORT = 3002;
 
-  // Import: download site with wget
-  app.post("/api/webstudio/import", async (req, res) => {
+  // Import: download site with wget (method=scrape) or clone a git
+  // repo + spawn its dev server (method=git, #147).
+  app.post("/api/webstudio/import", bearerAuth(), async (req, res) => {
     try {
       const { url, method } = req.body;
       if (!url) { res.status(400).json({ error: "url required" }); return; }
 
 
       mkdirSync(WS_SITE_DIR, { recursive: true });
+
+      if (method === "git") {
+        const paths = gitImportPaths(
+          process.env.NEXAAS_ROOT ?? "/opt/nexaas",
+          WORKSPACE ?? "default",
+        );
+        try {
+          const result = await runGitImport({
+            url,
+            branch: typeof req.body.branch === "string" ? req.body.branch : undefined,
+            deployKey: typeof req.body.deployKey === "string" ? req.body.deployKey : undefined,
+            auth: req.body.auth,
+          }, paths);
+          console.log(`[webstudio] Git import: ${url}@${result.branch} (${result.framework}), pid=${result.devServerPid}`);
+          res.json({ ok: true, data: { ...result, method: "git" } });
+        } catch (err) {
+          res.status(400).json({ ok: false, error: (err as Error).message });
+        }
+        return;
+      }
 
       if (method === "scrape" || !method) {
         // Download site with wget mirror — async so we don't wedge the
@@ -648,7 +670,7 @@ async function main() {
           },
         });
       } else {
-        res.status(400).json({ error: `Import method '${method}' not yet implemented` });
+        res.status(400).json({ error: `Import method '${method}' not supported (use 'scrape' or 'git')` });
       }
     } catch (e) {
       res.status(500).json({ ok: false, error: (e as Error).message });


### PR DESCRIPTION
Closes #147. First of the Web Studio shippability trio (#147/#148/#149).

## Summary

- New `method: "git"` branch on `/api/webstudio/import` — clones a repo to `web-studio/<workspace>/repo/`, detects the framework, installs deps, and spawns the dev server on port 3002.
- Framework detection: Next.js, Gatsby, Vite, CRA, static fallback. Honors `npm`, `pnpm`, `yarn` based on lockfile.
- Deploy key support: when provided, written 0600 to `${NEXAAS_ROOT}/.ssh/<workspace>_deploy_key` and pinned via `GIT_SSH_COMMAND` with `IdentitiesOnly=yes` so ssh-agent can't trip us up.
- 500MB clone cap, 5min `npm install` timeout, dev-server stdout/stderr → `web-studio/<workspace>/dev-server.log`.
- `bearerAuth()` now gates `/api/webstudio/import` — same posture as `/api/waitpoints/*`, `/api/skills/trigger`, `/api/drawers/inbound`.

## Why this matters

The scrape path (wget mirror) is unusable for any framework-based site. Atmosphere Hot Tubs (next.js, first paying Web Studio customer) is the immediate blocker; this also unblocks every future Web Studio customer who runs anything more interactive than a static HTML site.

## Acceptance (from #147)

- [x] `method: "git"` clones a public repo and starts the dev server
- [x] Private repos work with a provided deploy key (`GIT_SSH_COMMAND`)
- [x] Framework detection sets the right dev-server command for Next.js / Vite / CRA / Gatsby / static
- [x] Clear errors on clone failure, install failure
- [x] Existing `method: "scrape"` unchanged

## Test plan

- [ ] Public Next.js repo: `POST /api/webstudio/import { url: ..., method: "git" }` → preview renders on :3002, `dev-server.log` shows Next.js boot
- [ ] Private repo with deploy key: same flow, key gets written 0600, clone succeeds
- [ ] Vite + CRA + Gatsby repos each pick their right script
- [ ] Repo over 500MB returns the cap error and leaves no half-clone behind
- [ ] `method: "scrape"` on the same workspace afterwards: wget still works, port still flips correctly
- [ ] Bearer enforcement: with `NEXAAS_CROSS_VPS_BEARER_TOKEN` set, unauthenticated request rejected

## Follow-ups

- #148 — context-aware edit (depends on the cloned-repo path this PR establishes)
- #149 — `git push` publish (uses the same deploy key written here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import Web Studio projects directly from git repositories with automatic framework detection and setup for Next.js, Gatsby, Vite, and Create React App, including intelligent dependency installation and integrated development server for instant previews.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/150)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->