### PR TITLE
fix(dispatcher): map inline_buttons → actions on PA rewire (#153)

### DIFF
--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -429,14 +429,28 @@ async function tryPaRewire(
         ? "html"
         : "html";
 
+  // Map legacy `inline_buttons[{text, button_id}]` → v2 `actions[{label, button_id}]`.
+  // Without this, legacy `send_telegram_sync(buttons=...)` callers (e.g.
+  // Phoenix's join-webhook) silently lost their approval buttons after
+  // the PA-Router rewire — content arrived as a passive alert and the
+  // downstream skill waiting on the button reply never got a path
+  // forward. See #153.
+  const mappedActions = envelope.inline_buttons
+    ?.filter((b) => b && b.button_id && b.text)
+    .map((b) => ({ label: b.text, button_id: b.button_id }));
+
   const input: PaNotifyInput = {
     user: paUser,
     threadId: "inbox",      // default fallback bucket per RFC Wave 5 §5.1 mapping
     urgency: "normal",
-    kind: "alert",
+    // Switch to "approval" when actions are present so the receiver
+    // renders the decision UI instead of a passive alert.
+    // validatePaNotifyInput() enforces "actions required when kind=approval".
+    kind: mappedActions && mappedActions.length > 0 ? "approval" : "alert",
     content: envelope.content,
     contentFormat: mappedFormat,
     idempotencyKey: envelope.idempotency_key,
+    ...(mappedActions && mappedActions.length > 0 ? { actions: mappedActions } : {}),
   };
 
   let outcome;

--- a/scripts/test-pa-rewire-126.mjs
+++ b/scripts/test-pa-rewire-126.mjs
@@ -55,15 +55,22 @@ async function tryPaRewire(workspace, envelope) {
     return { decision: "fallthrough", reason: "missing_content" };
   }
 
+  // Mirror production's inline_buttons → actions mapping (#153). Without
+  // this, legacy callers that pass buttons silently lose them on rewire.
+  const mappedActions = envelope.inline_buttons
+    ?.filter((b) => b && b.button_id && b.text)
+    .map((b) => ({ label: b.text, button_id: b.button_id }));
+
   const outcome = await executePaNotify(
     {
       user: paUser,
       threadId: "inbox",
       urgency: "normal",
-      kind: "alert",
+      kind: mappedActions && mappedActions.length > 0 ? "approval" : "alert",
       content: envelope.content,
       contentFormat: "html",
       idempotencyKey: envelope.idempotency_key,
+      ...(mappedActions && mappedActions.length > 0 ? { actions: mappedActions } : {}),
     },
     defaultPaNotifyDeps(workspace),
   );
@@ -168,6 +175,70 @@ await sql(
   });
   assert(out.decision === "fallthrough", `decision=fallthrough (got ${out.decision})`);
   assert(out.reason === "missing_content", "reason captured");
+}
+
+// ── Test 7: inline_buttons → actions mapping (#153) ──────────────
+console.log("\n7. Legacy inline_buttons → v2 actions mapped + kind flips to 'approval'");
+{
+  const out = await tryPaRewire(WORKSPACE, {
+    channel_role: "pa_notify_bob",
+    content: "Approve onboarding for Sam Burton?",
+    idempotency_key: "k7",
+    inline_buttons: [
+      { text: "Approve", button_id: "onboarding_review:approve:sam-123" },
+      { text: "Reject",  button_id: "onboarding_review:reject:sam-123" },
+      { text: "Need Info", button_id: "onboarding_review:info:sam-123" },
+    ],
+  });
+  assert(out.decision === "delivered", `decision=delivered (got ${out.decision})`);
+
+  const rows = await sql(
+    `SELECT content::jsonb AS payload FROM nexaas_memory.events
+      WHERE workspace = $1 AND wing = 'notifications' AND hall = 'pending'
+        AND room LIKE 'pa-routed.%' AND content::jsonb ->> 'user' = 'bob'
+        AND content::jsonb ->> 'idempotency_key' = 'k7'
+      LIMIT 1`,
+    [WORKSPACE],
+  );
+  const payload = rows[0]?.payload;
+  assert(payload != null, "pa-routed drawer landed for bob");
+  assert(payload?.kind === "approval", `kind=approval (got ${payload?.kind})`);
+  assert(Array.isArray(payload?.actions), "actions is an array");
+  assert(payload?.actions?.length === 3, `actions has 3 entries (got ${payload?.actions?.length})`);
+  assert(payload?.actions?.[0]?.label === "Approve" && payload?.actions?.[0]?.button_id === "onboarding_review:approve:sam-123",
+    "first action mapped text→label, button_id preserved");
+}
+
+// ── Test 8: empty/garbage inline_buttons → kind stays 'alert' ─────
+console.log("\n8. Empty / malformed inline_buttons → no actions, kind stays 'alert'");
+await sql(
+  `INSERT INTO nexaas_memory.pa_threads (workspace, user_hall, thread_id, display_name, status)
+   VALUES ($1, 'carol', 'inbox', 'Inbox', 'active')`,
+  [WORKSPACE],
+);
+{
+  const out = await tryPaRewire(WORKSPACE, {
+    channel_role: "pa_notify_carol",
+    content: "FYI",
+    idempotency_key: "k8",
+    inline_buttons: [
+      { text: "", button_id: "bad" },          // empty label — filtered
+      { text: "valid-but-no-id" },              // missing button_id — filtered
+      null,                                      // null — filtered
+    ],
+  });
+  assert(out.decision === "delivered", `decision=delivered (got ${out.decision})`);
+  const rows = await sql(
+    `SELECT content::jsonb AS payload FROM nexaas_memory.events
+      WHERE workspace = $1 AND wing = 'notifications' AND hall = 'pending'
+        AND room LIKE 'pa-routed.%' AND content::jsonb ->> 'user' = 'carol'
+      LIMIT 1`,
+    [WORKSPACE],
+  );
+  const payload = rows[0]?.payload;
+  assert(payload?.kind === "alert", `kind=alert (got ${payload?.kind})`);
+  assert(payload?.actions === null || payload?.actions === undefined,
+    `actions absent (got ${JSON.stringify(payload?.actions)})`);
 }
 
 await sql(`DELETE FROM nexaas_memory.events WHERE workspace = $1`, [WORKSPACE]);


### PR DESCRIPTION
Closes #153.

## Summary

\`tryPaRewire()\` was copying \`content\` / \`parse_mode\` / \`idempotency_key\` but dropping \`envelope.inline_buttons\` entirely. Legacy \`send_telegram_sync(buttons=...)\` calls against \`pa_notify_<user>\` channel_roles for v2-migrated users landed as passive alerts with no buttons — silently broke approval workflows since the Phase 1 cutover.

This PR is the upstream of the hotfix already running in Phoenix-Voyages.

## What changed

\`packages/runtime/src/tasks/notification-dispatcher.ts\`:
- Maps \`envelope.inline_buttons[{text, button_id}]\` → \`PaNotifyInput.actions[{label, button_id}]\`.
- Filters out malformed entries (missing \`text\` or \`button_id\`).
- Flips \`kind\` to \`"approval"\` when actions are present so the receiver renders the decision UI. Matches the rule \`validatePaNotifyInput()\` already enforces.

\`scripts/test-pa-rewire-126.mjs\`:
- Mirrors the same mapping in the test's local \`tryPaRewire\` shadow.
- Case 7: three valid buttons map cleanly, \`kind=approval\`, payload \`actions[]\` has the expected shape (label, button_id).
- Case 8: malformed/empty entries get filtered, no actions on the routed drawer, \`kind\` stays \`alert\`.

## Acceptance (from #153)

- [x] inline_buttons mapped to actions with field+sub-field rename
- [x] kind flips to "approval" when actions present (validatePaNotifyInput requirement)
- [x] Malformed buttons filtered (defensive vs partial legacy payloads)
- [x] Smoke test in scripts/test-pa-rewire-126.mjs covers both the happy path and the filter path
- [x] Phoenix hotfix matches this exactly — drawer 559e009f… verified post-restart there

## Test plan

- [ ] \`DATABASE_URL=... node --import tsx scripts/test-pa-rewire-126.mjs\` — all 8 cases pass
- [ ] On a v2-migrated workspace: legacy caller sending \`inline_buttons=[Approve/Reject/Need Info]\` to \`pa_notify_<user>\` produces a \`pa-routed.inbox\` drawer with non-null \`actions\`, and the downstream skill's \`pa_reply_<user>\` waitpoint resolves on the button click

## Severity

High. Affected anyone with a legacy \`send_telegram_sync(buttons=...)\` call into a v2-migrated user. No advisor-facing impact on content delivery, only action UI was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications containing inline buttons now support approval-style actions, automatically translating legacy button format to the modern v2 action format.

* **Tests**
  * Added test coverage validating inline button-to-action conversion, approval notification type detection, and edge cases with empty or malformed button data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->