### PR TITLE
feat(webstudio): context-aware edit via MCP tools (#148)

### DIFF
--- a/mcp/servers/webstudio/package.json
+++ b/mcp/servers/webstudio/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nexaas/mcp-webstudio",
+  "version": "0.1.0",
+  "description": "Web Studio MCP server (#148) — file-tool surface for the PA-driven edit loop. Five tools (list_files, read_file, write_file, grep, diff) scoped to a single working copy via WEBSTUDIO_REPO_ROOT.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/mcp/servers/webstudio/src/index.ts
+++ b/mcp/servers/webstudio/src/index.ts
@@ -1,0 +1,431 @@
+/**
+ * Nexaas Web Studio MCP Server (#148).
+ *
+ * Provides the file-tool surface for the PA-driven Web Studio edit loop:
+ *
+ *   - list_files   walk the working copy (respects .gitignore + .webstudioignore)
+ *   - read_file    read a single file (100KB cap, binary-safe)
+ *   - write_file   write a single file (path-traversal + binary-write protection)
+ *   - grep         pattern search across the project (git grep when available)
+ *   - diff         pending uncommitted changes
+ *
+ * Scoped to a single workspace's working copy via the WEBSTUDIO_REPO_ROOT
+ * environment variable. Every path argument from the model is resolved
+ * inside that root and rejected if it escapes; the server NEVER touches
+ * paths outside the configured root.
+ *
+ * Transport: stdio. Companion to the import path (#147) and publish
+ * path (#149). Replaces the single-file-in-prompt pattern that lives in
+ * the original /api/webstudio/edit handler.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { spawnSync } from "child_process";
+import {
+  existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync,
+} from "fs";
+import { dirname, isAbsolute, join, normalize, relative, resolve as resolvePath } from "path";
+
+const REPO_ROOT = process.env.WEBSTUDIO_REPO_ROOT;
+if (!REPO_ROOT) {
+  console.error("[webstudio-mcp] WEBSTUDIO_REPO_ROOT is required");
+  process.exit(1);
+}
+const ROOT = resolvePath(REPO_ROOT);
+
+if (!existsSync(ROOT)) {
+  console.error(`[webstudio-mcp] WEBSTUDIO_REPO_ROOT not found: ${ROOT}`);
+  process.exit(1);
+}
+
+const READ_CAP_BYTES = 100 * 1024; // 100KB per the spec
+const WRITE_CAP_BYTES = 5 * 1024 * 1024; // 5MB ceiling on individual writes
+
+// Hard-block directories. These never make sense for a content-edit
+// loop and writing into them silently corrupts the working copy.
+const FORBIDDEN_DIRS = [".git", "node_modules", ".next", "dist", "build", ".nuxt", ".svelte-kit"];
+
+// Defaults applied when there's no .webstudioignore. Tighter than
+// gitignore so the model sees a useful slice of the project even on
+// repos with no ignore file.
+const DEFAULT_IGNORE = [
+  "node_modules/",
+  ".git/",
+  ".next/",
+  "dist/",
+  "build/",
+  ".nuxt/",
+  ".svelte-kit/",
+  "*.log",
+  "*.lock",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+];
+
+const server = new McpServer({
+  name: "nexaas-webstudio",
+  version: "0.1.0",
+});
+
+function jsonResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function textResult(text: string): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+// Resolve a model-supplied relative path against ROOT. Rejects:
+//   - absolute paths
+//   - paths that escape ROOT via `..`
+//   - paths that land in a forbidden directory
+function safePath(input: string): string {
+  if (typeof input !== "string" || input.length === 0) {
+    throw new Error("path must be a non-empty string");
+  }
+  if (isAbsolute(input)) {
+    throw new Error(`path must be relative to repo root: '${input}'`);
+  }
+  const normalized = normalize(input);
+  if (normalized.startsWith("..") || normalized.includes(`${"/"}..${"/"}`)) {
+    throw new Error(`path escapes repo root: '${input}'`);
+  }
+  const abs = resolvePath(ROOT, normalized);
+  // Resolve symlinks would be safer, but we don't follow them — the
+  // string-prefix check below is sufficient because resolvePath
+  // canonicalizes the joined path.
+  if (abs !== ROOT && !abs.startsWith(ROOT + "/")) {
+    throw new Error(`path escapes repo root: '${input}'`);
+  }
+  // First path segment must not be forbidden.
+  const firstSegment = normalized.split("/")[0];
+  if (firstSegment && FORBIDDEN_DIRS.includes(firstSegment)) {
+    throw new Error(`writes to '${firstSegment}/' are forbidden`);
+  }
+  return abs;
+}
+
+function isInGitRepo(): boolean {
+  return existsSync(join(ROOT, ".git"));
+}
+
+// Cheap binary sniff — null bytes in the first 8KB. Catches images,
+// archives, compiled binaries. Good enough for protecting write_file
+// from clobbering binary assets with text.
+function looksBinary(buf: Buffer): boolean {
+  const sample = buf.length > 8192 ? buf.subarray(0, 8192) : buf;
+  for (let i = 0; i < sample.length; i++) {
+    if (sample[i] === 0) return true;
+  }
+  return false;
+}
+
+// Read .webstudioignore (line-based, gitignore-syntax-ish). Returns
+// the patterns, or DEFAULT_IGNORE if the file isn't there.
+function loadIgnorePatterns(): string[] {
+  const file = join(ROOT, ".webstudioignore");
+  if (!existsSync(file)) return DEFAULT_IGNORE;
+  try {
+    return readFileSync(file, "utf-8")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith("#"));
+  } catch {
+    return DEFAULT_IGNORE;
+  }
+}
+
+// Minimal gitignore-ish matcher. Sufficient for the default skip-list;
+// power users can ship a real .gitignore and we'll route through `git
+// ls-files` instead.
+function matchesIgnore(relPath: string, patterns: string[]): boolean {
+  for (const p of patterns) {
+    if (p.endsWith("/")) {
+      const dir = p.slice(0, -1);
+      if (relPath === dir || relPath.startsWith(dir + "/")) return true;
+    } else if (p.startsWith("*.")) {
+      if (relPath.endsWith(p.slice(1))) return true;
+    } else if (p.includes("*")) {
+      const re = new RegExp("^" + p.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$");
+      if (re.test(relPath)) return true;
+    } else {
+      if (relPath === p || relPath.endsWith("/" + p)) return true;
+    }
+  }
+  return false;
+}
+
+// Glob → regex. Supports `*` (anything except /), `**` (anything),
+// `?` (one char). Anchored at both ends.
+function globToRegex(pattern: string): RegExp {
+  let re = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        re += ".*"; i += 2;
+        if (pattern[i] === "/") i++;
+      } else {
+        re += "[^/]*"; i++;
+      }
+    } else if (c === "?") {
+      re += "[^/]"; i++;
+    } else if (".+()|^$\\[]{}".includes(c!)) {
+      re += "\\" + c; i++;
+    } else {
+      re += c; i++;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}
+
+// ─── list_files ─────────────────────────────────────────────────────
+
+server.tool(
+  "list_files",
+  "List files in the Web Studio working copy. Respects .gitignore (when the project is a git repo) " +
+  "and .webstudioignore (always). Optionally filtered by a glob pattern like 'app/**/*.tsx' or '**/*.css'. " +
+  "Returns relative paths from the repo root. Use this first to discover the layout before reading files.",
+  {
+    pattern: z.string().optional().describe(
+      "Optional glob filter. Supports *, **, ?. Examples: 'app/**/*.tsx', '**/*.css', 'components/Hero.tsx'.",
+    ),
+    limit: z.number().int().positive().max(2000).optional().describe(
+      "Maximum number of paths to return. Default 500.",
+    ),
+  },
+  async (input) => {
+    try {
+      const limit = input.limit ?? 500;
+      let paths: string[];
+      if (isInGitRepo()) {
+        // `git ls-files` is gitignore-aware. Include modified+untracked so
+        // the model sees what the user just created during the session.
+        const out = spawnSync(
+          "git",
+          ["-C", ROOT, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+          { maxBuffer: 50 * 1024 * 1024 },
+        );
+        if (out.status === 0) {
+          paths = out.stdout.toString("utf-8").split("\0").filter((p) => p.length > 0);
+        } else {
+          paths = walkFs();
+        }
+      } else {
+        paths = walkFs();
+      }
+
+      // Always apply .webstudioignore on top (it's the project owner's
+      // way to narrow visibility further, even inside git).
+      const ignore = loadIgnorePatterns();
+      let filtered = paths.filter((p) => !matchesIgnore(p, ignore));
+      if (input.pattern) {
+        const re = globToRegex(input.pattern);
+        filtered = filtered.filter((p) => re.test(p));
+      }
+      const truncated = filtered.length > limit;
+      const result = truncated ? filtered.slice(0, limit) : filtered;
+      return jsonResult({ ok: true, count: result.length, total: filtered.length, truncated, files: result });
+    } catch (err) {
+      return jsonResult({ ok: false, error: (err as Error).message });
+    }
+  },
+);
+
+function walkFs(): string[] {
+  const out: string[] = [];
+  const stack = [ROOT];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      const rel = relative(ROOT, abs);
+      if (entry.isDirectory()) {
+        // Skip forbidden dirs eagerly — saves walking
+        // node_modules/.git on every list.
+        if (FORBIDDEN_DIRS.includes(entry.name)) continue;
+        stack.push(abs);
+      } else if (entry.isFile()) {
+        out.push(rel);
+      }
+    }
+  }
+  return out;
+}
+
+// ─── read_file ──────────────────────────────────────────────────────
+
+server.tool(
+  "read_file",
+  "Read a single file from the working copy. Path is relative to the repo root. " +
+  "Capped at 100KB — larger files return the first 100KB with a '[...truncated]' marker. " +
+  "Binary files (detected by null-byte sniff) return an error rather than garbled text.",
+  {
+    path: z.string().min(1).describe("File path relative to the repo root, e.g. 'app/page.tsx'."),
+  },
+  async (input) => {
+    try {
+      const abs = safePath(input.path);
+      if (!existsSync(abs)) {
+        return jsonResult({ ok: false, error: `file not found: '${input.path}'` });
+      }
+      const stats = statSync(abs);
+      if (!stats.isFile()) {
+        return jsonResult({ ok: false, error: `not a file: '${input.path}'` });
+      }
+      const buf = readFileSync(abs);
+      if (looksBinary(buf)) {
+        return jsonResult({
+          ok: false,
+          error: `'${input.path}' looks like a binary file (null bytes detected) — read_file is text-only`,
+          size_bytes: stats.size,
+        });
+      }
+      const truncated = buf.length > READ_CAP_BYTES;
+      const text = truncated
+        ? buf.subarray(0, READ_CAP_BYTES).toString("utf-8") + "\n\n[...truncated]"
+        : buf.toString("utf-8");
+      return jsonResult({
+        ok: true,
+        path: input.path,
+        size_bytes: stats.size,
+        truncated,
+        content: text,
+      });
+    } catch (err) {
+      return jsonResult({ ok: false, error: (err as Error).message });
+    }
+  },
+);
+
+// ─── write_file ─────────────────────────────────────────────────────
+
+server.tool(
+  "write_file",
+  "Write a single file in the working copy. Path is relative to the repo root and resolved with " +
+  "path-traversal protection — writes to .git/, node_modules/, .next/, dist/, build/ are refused. " +
+  "Refuses to overwrite a file with content that would make it look binary (null bytes). Creates " +
+  "parent directories as needed. Always read a file before writing it.",
+  {
+    path: z.string().min(1).describe("File path relative to the repo root."),
+    content: z.string().describe("New file content. UTF-8 text only."),
+  },
+  async (input) => {
+    try {
+      const abs = safePath(input.path);
+      if (input.content.length > WRITE_CAP_BYTES) {
+        return jsonResult({ ok: false, error: `content exceeds ${WRITE_CAP_BYTES} byte cap` });
+      }
+      const buf = Buffer.from(input.content, "utf-8");
+      if (looksBinary(buf)) {
+        return jsonResult({ ok: false, error: "content contains null bytes — write_file is text-only" });
+      }
+      mkdirSync(dirname(abs), { recursive: true });
+      const existed = existsSync(abs);
+      writeFileSync(abs, buf);
+      return jsonResult({
+        ok: true,
+        path: input.path,
+        bytes_written: buf.length,
+        created: !existed,
+      });
+    } catch (err) {
+      return jsonResult({ ok: false, error: (err as Error).message });
+    }
+  },
+);
+
+// ─── grep ───────────────────────────────────────────────────────────
+
+server.tool(
+  "grep",
+  "Search the working copy for a pattern. Uses 'git grep' when the project is a git repo " +
+  "(gitignore-aware), falls back to a recursive grep with sensible excludes otherwise. " +
+  "Returns matching path:line:text lines.",
+  {
+    pattern: z.string().min(1).describe("Search pattern. Treated as a literal string (use grep_regex for regex)."),
+    files: z.string().optional().describe("Optional path-glob to scope the search, e.g. 'app/**'."),
+    regex: z.boolean().optional().describe("If true, pattern is a regular expression. Default false."),
+    max_matches: z.number().int().positive().max(500).optional().describe("Default 100."),
+  },
+  async (input) => {
+    try {
+      const maxMatches = input.max_matches ?? 100;
+      const flags = ["-n", "--no-color"];
+      if (!input.regex) flags.push("-F");
+      let matches: string[];
+
+      if (isInGitRepo()) {
+        const args = ["-C", ROOT, "grep", ...flags, input.pattern];
+        if (input.files) args.push("--", input.files);
+        const out = spawnSync("git", args, { maxBuffer: 50 * 1024 * 1024 });
+        matches = (out.status === 0 || out.status === 1)
+          ? out.stdout.toString("utf-8").split("\n").filter((l) => l.length > 0)
+          : [];
+      } else {
+        const args = ["-rn", "--no-color"];
+        if (!input.regex) args.push("-F");
+        for (const dir of FORBIDDEN_DIRS) args.push(`--exclude-dir=${dir}`);
+        args.push(input.pattern, input.files ?? ".");
+        const out = spawnSync("grep", args, { cwd: ROOT, maxBuffer: 50 * 1024 * 1024 });
+        matches = (out.status === 0 || out.status === 1)
+          ? out.stdout.toString("utf-8").split("\n").filter((l) => l.length > 0)
+          : [];
+      }
+
+      const truncated = matches.length > maxMatches;
+      return jsonResult({
+        ok: true,
+        pattern: input.pattern,
+        count: Math.min(matches.length, maxMatches),
+        total: matches.length,
+        truncated,
+        matches: truncated ? matches.slice(0, maxMatches) : matches,
+      });
+    } catch (err) {
+      return jsonResult({ ok: false, error: (err as Error).message });
+    }
+  },
+);
+
+// ─── diff ───────────────────────────────────────────────────────────
+
+server.tool(
+  "diff",
+  "Show pending uncommitted changes in the working copy. Uses 'git diff HEAD' when available; " +
+  "for non-git working copies, returns a hint that diff is unavailable. Use this to verify the " +
+  "edits you just made before reporting back to the user.",
+  {},
+  async () => {
+    try {
+      if (!isInGitRepo()) {
+        return jsonResult({ ok: true, available: false, reason: "not a git repository" });
+      }
+      const out = spawnSync("git", ["-C", ROOT, "diff", "HEAD"], { maxBuffer: 50 * 1024 * 1024 });
+      if (out.status !== 0 && out.status !== 1) {
+        return jsonResult({ ok: false, error: `git diff failed: ${out.stderr.toString("utf-8")}` });
+      }
+      const diff = out.stdout.toString("utf-8");
+      // Cap the response — a massive diff blows the model's context.
+      const cap = 50_000;
+      const truncated = diff.length > cap;
+      return textResult(truncated ? diff.slice(0, cap) + "\n\n[...truncated]" : diff);
+    } catch (err) {
+      return jsonResult({ ok: false, error: (err as Error).message });
+    }
+  },
+);
+
+// ─── boot ───────────────────────────────────────────────────────────
+
+console.error(`[webstudio-mcp] root=${ROOT}, git=${isInGitRepo() ? "yes" : "no"}`);
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/servers/webstudio/tsconfig.json
+++ b/mcp/servers/webstudio/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "packages/*",
         "integrations/*",
-        "mcp/servers/email-outbound"
+        "mcp/servers/email-outbound",
+        "mcp/servers/webstudio"
       ],
       "devDependencies": {
         "@changesets/cli": "^2.27.0",
@@ -60,6 +61,18 @@
         "@nexaas/email-provider-resend": "0.1.0",
         "@nexaas/email-provider-sendgrid": "0.1.0",
         "@nexaas/integration-sdk": "0.1.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "mcp/servers/webstudio": {
+      "name": "@nexaas/mcp-webstudio",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -1686,6 +1699,10 @@
     },
     "node_modules/@nexaas/mcp-email-outbound": {
       "resolved": "mcp/servers/email-outbound",
+      "link": true
+    },
+    "node_modules/@nexaas/mcp-webstudio": {
+      "resolved": "mcp/servers/webstudio",
       "link": true
     },
     "node_modules/@nexaas/ops-console-core": {
@@ -4631,6 +4648,7 @@
         "@bull-board/express": "^6.0.0",
         "@nexaas/palace": "^0.1.0",
         "bullmq": "^5.0.0",
+        "cron-parser": "^4.9.0",
         "express": "^4.21.0",
         "ioredis": "^5.0.0",
         "js-yaml": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": [
     "packages/*",
     "integrations/*",
-    "mcp/servers/email-outbound"
+    "mcp/servers/email-outbound",
+    "mcp/servers/webstudio"
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",

--- a/packages/runtime/src/webstudio/edit.ts
+++ b/packages/runtime/src/webstudio/edit.ts
@@ -1,0 +1,188 @@
+/**
+ * Web Studio edit driver (#148).
+ *
+ * Replaces the original /api/webstudio/edit's single-file-in-prompt
+ * pattern with an MCP-tool-driven agentic loop. The PA picks the right
+ * files via list_files/read_file, writes surgical edits via
+ * write_file, and verifies via diff — same shape as Claude Code's
+ * own editing loop.
+ *
+ * The webstudio MCP server is spawned per-request with
+ * WEBSTUDIO_REPO_ROOT set to the workspace's working copy. The server
+ * owns all the path-traversal and binary-write protection — this
+ * driver just glues the model loop to those tools.
+ */
+
+import { randomUUID } from "crypto";
+import { join } from "path";
+import { existsSync } from "fs";
+import { runAgenticLoop, type McpTool } from "../models/agentic-loop.js";
+import { McpClient } from "../mcp/client.js";
+import { runTracker } from "../run-tracker.js";
+
+export interface WebstudioEditInput {
+  instruction: string;
+  senderName?: string;
+  // Max turns the model gets to complete the edit. The default
+  // accommodates several read_file calls + one or two write_file calls
+  // + a diff — most edits land in 4–8 turns.
+  maxTurns?: number;
+}
+
+export interface WebstudioEditResult {
+  response: string;
+  turns: number;
+  toolCalls: number;
+  filesWritten: string[];
+  filesRead: string[];
+  applied: boolean;
+}
+
+const TIER_MAP: Record<string, string> = {
+  cheap: "claude-haiku-4-5-20251001",
+  good: "claude-sonnet-4-6",
+  better: "claude-sonnet-4-6",
+  best: "claude-opus-4-6",
+};
+
+const EDIT_SYSTEM_PROMPT = (instruction: string, senderName: string) => `You are a web developer assistant editing a real project for ${senderName}. The user's instruction:
+
+"""
+${instruction}
+"""
+
+You have five tools, all scoped to the project's working copy:
+
+  - list_files(pattern?)   Discover the project layout. Try this first.
+  - read_file(path)        Read a file. ALWAYS read before writing.
+  - write_file(path, content)  Apply an edit. Surgical changes only — never rewrite a file from memory.
+  - grep(pattern, files?)  Find where a string lives across the project.
+  - diff()                 See what you've changed so far.
+
+Workflow:
+  1. list_files (optionally with a pattern) to understand the layout.
+  2. read_file the candidate files you think need to change.
+  3. write_file with the minimal change that satisfies the instruction.
+  4. diff to verify, then summarize what you did in your final reply.
+
+Hard rules:
+  - Read before writing. Never write_file based on guesses about a file's current content.
+  - Make surgical edits. Don't rewrite an entire file when changing two lines.
+  - Stay focused. Only edit files relevant to the instruction.
+  - When you're done, output a short summary of the files you changed.`;
+
+export async function runWebstudioEdit(
+  workspace: string,
+  repoRoot: string,
+  webstudioMcpEntry: string,
+  input: WebstudioEditInput,
+  options?: { modelTier?: string },
+): Promise<WebstudioEditResult> {
+  if (!existsSync(repoRoot)) {
+    throw new Error(`webstudio edit: repoRoot does not exist: ${repoRoot}`);
+  }
+  if (!existsSync(webstudioMcpEntry)) {
+    throw new Error(`webstudio edit: mcp server entry does not exist: ${webstudioMcpEntry}`);
+  }
+
+  const runId = randomUUID();
+  const modelTier = options?.modelTier ?? "good";
+  const model = TIER_MAP[modelTier] ?? "claude-sonnet-4-6";
+  const senderName = input.senderName ?? "user";
+
+  await runTracker.createRun({
+    runId,
+    workspace,
+    skillId: "webstudio/edit",
+    triggerType: "http:/api/webstudio/edit",
+    triggerPayload: {
+      instruction_preview: input.instruction.slice(0, 200),
+      sender: senderName,
+    },
+  });
+  await runTracker.markStepStarted(runId, "webstudio-edit");
+
+  // Spawn the webstudio MCP server pinned to this workspace's repo.
+  // The server reads WEBSTUDIO_REPO_ROOT — no other channel for the
+  // path, so it physically can't touch any other workspace.
+  const client = new McpClient("webstudio", {
+    command: process.execPath,
+    args: ["--import", "tsx", webstudioMcpEntry],
+    env: { WEBSTUDIO_REPO_ROOT: repoRoot },
+  });
+
+  const filesRead = new Set<string>();
+  const filesWritten = new Set<string>();
+
+  try {
+    await client.connect();
+
+    // Prefix tool names so the model sees them under a single namespace,
+    // matching the framework's standard "<server>__<tool>" convention.
+    const tools: McpTool[] = client.getTools().map((t) => ({
+      name: `webstudio__${t.name}`,
+      description: t.description,
+      input_schema: t.input_schema,
+    }));
+
+    const executeTool = async (toolName: string, args: Record<string, unknown>): Promise<string> => {
+      const parts = toolName.split("__");
+      if (parts.length < 2 || parts[0] !== "webstudio") {
+        throw new Error(`unknown tool: ${toolName}`);
+      }
+      const inner = parts.slice(1).join("__");
+      // Record file activity for the response payload — handy for the
+      // dashboard to surface "edited 2 files" instead of digging through
+      // tool calls.
+      if (inner === "read_file" && typeof args.path === "string") filesRead.add(args.path);
+      if (inner === "write_file" && typeof args.path === "string") filesWritten.add(args.path);
+      return await client.callTool(inner, args);
+    };
+
+    const editTimeoutMs = parseInt(process.env.NEXAAS_WEBSTUDIO_EDIT_TIMEOUT_MS ?? "180000", 10);
+    const result = await Promise.race([
+      runAgenticLoop({
+        model,
+        system: EDIT_SYSTEM_PROMPT(input.instruction, senderName),
+        messages: [{ role: "user", content: input.instruction }],
+        tools,
+        executeTool,
+        limits: { maxTurns: input.maxTurns ?? 12 },
+        workspace,
+        runId,
+        skillId: "webstudio/edit",
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`webstudio edit timed out after ${Math.round(editTimeoutMs / 1000)}s`)),
+          editTimeoutMs,
+        ),
+      ),
+    ]);
+
+    await runTracker.markStepCompleted(runId, "webstudio-edit");
+
+    return {
+      response: result.content,
+      turns: result.turns,
+      toolCalls: result.toolCalls.length,
+      filesWritten: Array.from(filesWritten),
+      filesRead: Array.from(filesRead),
+      applied: filesWritten.size > 0,
+    };
+  } catch (err) {
+    await runTracker.markStepFailed(runId, "webstudio-edit", (err as Error).message);
+    throw err;
+  } finally {
+    await client.disconnect().catch(() => { /* best effort */ });
+  }
+}
+
+// Resolve the webstudio MCP server entry point at boot. In production
+// the framework runs from `dist/`, so prefer that; fall back to the
+// source path for dev (`node --import tsx`).
+export function resolveWebstudioMcpEntry(nexaasRoot: string): string {
+  const distEntry = join(nexaasRoot, "mcp", "servers", "webstudio", "dist", "index.js");
+  if (existsSync(distEntry)) return distEntry;
+  return join(nexaasRoot, "mcp", "servers", "webstudio", "src", "index.ts");
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -40,6 +40,7 @@ import { runAndRecord, sendAlerts } from "./tasks/health-monitor.js";
 import { handlePaMessage } from "./pa/service.js";
 import { loadMcpConfigs } from "./mcp/client.js";
 import { runGitImport, gitImportPaths } from "./webstudio/git-import.js";
+import { runWebstudioEdit, resolveWebstudioMcpEntry } from "./webstudio/edit.js";
 import { ingestDocument } from "./ingest/index.js";
 import { loadWorkspaceManifest } from "./schemas/load-manifest.js";
 import { startNotificationDispatcher } from "./tasks/notification-dispatcher.js";
@@ -677,101 +678,57 @@ async function main() {
     }
   });
 
-  // Edit: AI modifies files in the working copy
-  app.post("/api/webstudio/edit", async (req, res) => {
+  // Edit: PA modifies files in the working copy via the webstudio MCP
+  // server (#148). Resolves the working copy in this priority:
+  //   1. git import (#147): web-studio/<workspace>/repo/
+  //   2. scrape: web-studio/<workspace>/site/<hostname>/  (or site/)
+  app.post("/api/webstudio/edit", bearerAuth(), async (req, res) => {
     try {
       const { instruction, senderName } = req.body;
       if (!instruction) { res.status(400).json({ error: "instruction required" }); return; }
 
+      const nexaasRoot = process.env.NEXAAS_ROOT ?? "/opt/nexaas";
+      const ws = WORKSPACE ?? "default";
+      const gitRepoRoot = join(nexaasRoot, "web-studio", ws, "repo");
+      let repoRoot: string;
+      if (existsSync(gitRepoRoot)) {
+        repoRoot = gitRepoRoot;
+      } else {
+        // Fall back to the scrape layout. Use the hostname subdir if
+        // wget created one (its usual behavior); otherwise the bare site
+        // dir.
+        const hostname = existsSync(WS_SITE_DIR)
+          ? readdirSync(WS_SITE_DIR).find(d => !d.startsWith("."))
+          : undefined;
+        repoRoot = hostname ? join(WS_SITE_DIR, hostname) : WS_SITE_DIR;
+      }
 
-      // Find the site root
-      const hostname = readdirSync(WS_SITE_DIR).find(d => !d.startsWith("."));
-      const siteRoot = hostname ? join(WS_SITE_DIR, hostname) : WS_SITE_DIR;
-
-      // List HTML files
-      const htmlFiles: string[] = [];
-      const walkHtml = (dir: string, prefix = ""): void => {
-        try {
-          for (const entry of readdirSync(dir, { withFileTypes: true })) {
-            const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
-            if (entry.isDirectory() && !entry.name.startsWith(".")) walkHtml(join(dir, entry.name), rel);
-            else if (entry.name.endsWith(".html") || entry.name.endsWith(".htm")) htmlFiles.push(rel);
-          }
-        } catch {}
-      };
-      walkHtml(siteRoot);
-
-      // Read the main HTML file (index.html or first found)
-      const mainFile = htmlFiles.find(f => f === "index.html") ?? htmlFiles[0];
-      if (!mainFile) {
-        res.json({ ok: false, error: "No HTML files found in working copy" });
+      if (!existsSync(repoRoot)) {
+        res.status(400).json({
+          ok: false,
+          error: "No working copy found. Run /api/webstudio/import first.",
+        });
         return;
       }
 
-      const mainContent = readFileSync(join(siteRoot, mainFile), "utf-8");
-
-      // Use the PA to generate the edit
-      const result = await handlePaMessage(WORKSPACE!, {
-        id: "webstudio-editor",
-        displayName: "WebStudio Editor",
-        type: "human-facing" as const,
-        owner: senderName ?? "user",
-        modelTier: "good",
-        systemPrompt: `You are a web developer assistant. The user wants to modify their website.
-
-Current HTML file (${mainFile}):
-\`\`\`html
-${mainContent.slice(0, 15000)}
-\`\`\`
-
-${htmlFiles.length > 1 ? `Other files: ${htmlFiles.join(", ")}` : ""}
-
-The user's instruction: "${instruction}"
-
-Generate the COMPLETE modified HTML file with the requested changes applied. Output ONLY the full HTML — no explanations, no markdown code blocks, just the raw HTML that should replace the file.`,
-        mcpServers: [],
-        palaceAccess: { read: ["*"], deny: [] },
-        channels: ["web-studio"],
-        maxTurns: 3,
-      }, {
-        channel: "web-studio",
-        senderId: "webstudio",
-        senderName: senderName ?? "User",
-        content: instruction,
+      const mcpEntry = resolveWebstudioMcpEntry(nexaasRoot);
+      const result = await runWebstudioEdit(ws, repoRoot, mcpEntry, {
+        instruction,
+        senderName,
       });
 
-      // Extract the HTML from the response
-      let newHtml = result.response;
-
-      // Clean up — remove markdown code fences if present
-      const htmlMatch = newHtml.match(/```html?\n([\s\S]*?)```/);
-      if (htmlMatch) newHtml = htmlMatch[1];
-
-      // If it looks like complete HTML, write it
-      if (newHtml.includes("<") && newHtml.includes(">")) {
-        writeFileSync(join(siteRoot, mainFile), newHtml);
-
-        res.json({
-          ok: true,
-          data: {
-            file: mainFile,
-            description: instruction,
-            previewUrl: `http://localhost:${WS_PORT}`,
-            applied: true,
-          },
-        });
-      } else {
-        res.json({
-          ok: true,
-          data: {
-            file: mainFile,
-            description: result.response.slice(0, 200),
-            previewUrl: `http://localhost:${WS_PORT}`,
-            applied: false,
-            response: result.response,
-          },
-        });
-      }
+      res.json({
+        ok: true,
+        data: {
+          previewUrl: `http://localhost:${WS_PORT}`,
+          response: result.response,
+          turns: result.turns,
+          toolCalls: result.toolCalls,
+          filesWritten: result.filesWritten,
+          filesRead: result.filesRead,
+          applied: result.applied,
+        },
+      });
     } catch (e) {
       res.status(500).json({ ok: false, error: (e as Error).message });
     }


### PR DESCRIPTION
Closes #148. Reopen of #151 (auto-closed when its #150 base branch was deleted on merge).

## Summary

- New stdio MCP server `mcp/servers/webstudio/` with five tools: `list_files`, `read_file`, `write_file`, `grep`, `diff`.
- `/api/webstudio/edit` rewritten to spawn that server (pinned to the workspace's working copy via `WEBSTUDIO_REPO_ROOT`) and run a focused agentic loop. No more single-file-in-prompt + full-file overwrite.
- Endpoint is `bearerAuth()`-gated.

## Safety

- **Path traversal**: every model-supplied path is resolved inside `WEBSTUDIO_REPO_ROOT` and rejected if it escapes via `..` or absolute paths.
- **Forbidden dirs**: writes to `.git/`, `node_modules/`, `.next/`, `dist/`, `build/` (and friends) are refused at the first path segment.
- **Binary writes**: `write_file` null-byte-sniffs content before writing; refuses to clobber text files with binary garbage.
- **Read cap**: 100KB per file with a truncation marker.
- **Workspace isolation**: the server has no way to learn another workspace's path; it only honors `WEBSTUDIO_REPO_ROOT` from its env.

## Known follow-up: symlink hardening

Reviewed and accepted-with-followup: `safePath()` uses lexical resolution, so a malicious repo containing a symlink (e.g. `cool.txt -> /etc/passwd` or `evil -> ${NEXAAS_ROOT}/.ssh/other-workspace_deploy_key`) can be read/written through. Will be hardened in a follow-up by adding `realpathSync` on the deepest existing ancestor before any read/write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)