### PR TITLE
fix(webstudio-mcp): harden safePath against symlink escape (#159)

### DIFF
--- a/mcp/servers/webstudio/src/index.ts
+++ b/mcp/servers/webstudio/src/index.ts
@@ -26,7 +26,8 @@ import { spawnSync } from "child_process";
 import {
   existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync,
 } from "fs";
-import { dirname, isAbsolute, join, normalize, relative, resolve as resolvePath } from "path";
+import { dirname, join, relative, resolve as resolvePath } from "path";
+import { createSafePath, FORBIDDEN_DIRS } from "./safe-path.js";
 
 const REPO_ROOT = process.env.WEBSTUDIO_REPO_ROOT;
 if (!REPO_ROOT) {
@@ -40,12 +41,10 @@ if (!existsSync(ROOT)) {
   process.exit(1);
 }
 
+const safePath = createSafePath(ROOT);
+
 const READ_CAP_BYTES = 100 * 1024; // 100KB per the spec
 const WRITE_CAP_BYTES = 5 * 1024 * 1024; // 5MB ceiling on individual writes
-
-// Hard-block directories. These never make sense for a content-edit
-// loop and writing into them silently corrupts the working copy.
-const FORBIDDEN_DIRS = [".git", "node_modules", ".next", "dist", "build", ".nuxt", ".svelte-kit"];
 
 // Defaults applied when there's no .webstudioignore. Tighter than
 // gitignore so the model sees a useful slice of the project even on
@@ -76,36 +75,6 @@ function jsonResult(data: unknown): { content: Array<{ type: "text"; text: strin
 
 function textResult(text: string): { content: Array<{ type: "text"; text: string }> } {
   return { content: [{ type: "text" as const, text }] };
-}
-
-// Resolve a model-supplied relative path against ROOT. Rejects:
-//   - absolute paths
-//   - paths that escape ROOT via `..`
-//   - paths that land in a forbidden directory
-function safePath(input: string): string {
-  if (typeof input !== "string" || input.length === 0) {
-    throw new Error("path must be a non-empty string");
-  }
-  if (isAbsolute(input)) {
-    throw new Error(`path must be relative to repo root: '${input}'`);
-  }
-  const normalized = normalize(input);
-  if (normalized.startsWith("..") || normalized.includes(`${"/"}..${"/"}`)) {
-    throw new Error(`path escapes repo root: '${input}'`);
-  }
-  const abs = resolvePath(ROOT, normalized);
-  // Resolve symlinks would be safer, but we don't follow them — the
-  // string-prefix check below is sufficient because resolvePath
-  // canonicalizes the joined path.
-  if (abs !== ROOT && !abs.startsWith(ROOT + "/")) {
-    throw new Error(`path escapes repo root: '${input}'`);
-  }
-  // First path segment must not be forbidden.
-  const firstSegment = normalized.split("/")[0];
-  if (firstSegment && FORBIDDEN_DIRS.includes(firstSegment)) {
-    throw new Error(`writes to '${firstSegment}/' are forbidden`);
-  }
-  return abs;
 }
 
 function isInGitRepo(): boolean {

--- a/mcp/servers/webstudio/src/safe-path.ts
+++ b/mcp/servers/webstudio/src/safe-path.ts
@@ -1,0 +1,75 @@
+/**
+ * Path-safety primitive for the Web Studio MCP server.
+ *
+ * Resolves a model-supplied relative path against a configured repo
+ * root and rejects anything that escapes — lexically (absolute paths,
+ * `..` traversal) or via filesystem symlinks (#159). Also rejects
+ * paths that land inside a forbidden directory, including via a
+ * symlink that aliases one (e.g. `nice -> .git`).
+ *
+ * Exposed as `createSafePath(root)` so the validator can be tested
+ * against a temporary tree without booting the full MCP server.
+ */
+
+import { existsSync, realpathSync } from "fs";
+import { dirname, isAbsolute, join, normalize, relative, resolve as resolvePath } from "path";
+
+// Hard-block directories. These never make sense for a content-edit
+// loop and writing into them silently corrupts the working copy.
+export const FORBIDDEN_DIRS = [".git", "node_modules", ".next", "dist", "build", ".nuxt", ".svelte-kit"];
+
+export function createSafePath(root: string): (input: string) => string {
+  const ROOT = resolvePath(root);
+  // Resolve the root itself once — if WEBSTUDIO_REPO_ROOT is a symlink
+  // (e.g. /var/www/site -> /srv/sites/site), the post-resolution
+  // prefix check below would otherwise fail for every valid path.
+  const REAL_ROOT = realpathSync(ROOT);
+
+  return function safePath(input: string): string {
+    if (typeof input !== "string" || input.length === 0) {
+      throw new Error("path must be a non-empty string");
+    }
+    if (isAbsolute(input)) {
+      throw new Error(`path must be relative to repo root: '${input}'`);
+    }
+    const normalized = normalize(input);
+    if (normalized.startsWith("..") || normalized.includes(`${"/"}..${"/"}`)) {
+      throw new Error(`path escapes repo root: '${input}'`);
+    }
+    const abs = resolvePath(ROOT, normalized);
+    if (abs !== ROOT && !abs.startsWith(ROOT + "/")) {
+      throw new Error(`path escapes repo root: '${input}'`);
+    }
+
+    // Symlink check: lexical resolution above can't see that
+    // `cool.txt -> /etc/passwd` escapes the root. Walk up to the
+    // deepest existing ancestor, realpath that, and re-verify the
+    // prefix against REAL_ROOT. Handles the write-new-file case
+    // (target doesn't exist yet) by falling back to the parent dir.
+    let probe = abs;
+    while (!existsSync(probe)) probe = dirname(probe);
+    let realProbe: string;
+    try {
+      realProbe = realpathSync(probe);
+    } catch {
+      throw new Error(`path could not be resolved: '${input}'`);
+    }
+    const tail = relative(probe, abs);
+    const realFull = tail.length === 0 ? realProbe : join(realProbe, tail);
+    if (realFull !== REAL_ROOT && !realFull.startsWith(REAL_ROOT + "/")) {
+      throw new Error(`path resolves outside repo root via symlink: '${input}'`);
+    }
+
+    // Forbidden-dir check on the POST-RESOLUTION relative path, so a
+    // symlink like `safe_name -> .git` is caught too. The pre-resolution
+    // first-segment check alone would miss it.
+    const relSegments = relative(REAL_ROOT, realFull).split("/");
+    for (const seg of relSegments) {
+      if (FORBIDDEN_DIRS.includes(seg)) {
+        throw new Error(`writes to '${seg}/' are forbidden`);
+      }
+    }
+
+    return abs;
+  };
+}

--- a/scripts/test-webstudio-safe-path.mjs
+++ b/scripts/test-webstudio-safe-path.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #159 — symlink hardening in the Web Studio MCP
+ * server's safePath() validator.
+ *
+ * Constructs a temporary repo root with various symlink shapes and
+ * verifies that safePath() rejects the dangerous ones and accepts the
+ * benign ones.
+ *
+ * Run:
+ *   node --import tsx scripts/test-webstudio-safe-path.mjs
+ */
+
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createSafePath } from "../mcp/servers/webstudio/src/safe-path.ts";
+
+const root = mkdtempSync(join(tmpdir(), "webstudio-safepath-"));
+const externalTarget = join(tmpdir(), `safepath-external-${Date.now()}.txt`);
+writeFileSync(externalTarget, "secret\n");
+
+mkdirSync(join(root, "app"));
+mkdirSync(join(root, ".git"));
+writeFileSync(join(root, "app", "page.tsx"), "x\n");
+writeFileSync(join(root, ".git", "config"), "[core]\n");
+
+// Symlink fixtures
+symlinkSync(externalTarget, join(root, "external_file"));            // file → outside ROOT
+symlinkSync(tmpdir(), join(root, "external_dir"));                   // dir  → outside ROOT
+symlinkSync(".git", join(root, "git_alias"));                        // dir-symlink → forbidden inside ROOT
+symlinkSync("app", join(root, "app_alias"));                         // dir-symlink → legit inside ROOT
+symlinkSync("app/page.tsx", join(root, "page_alias"));               // file-symlink → legit inside ROOT
+
+const safePath = createSafePath(root);
+
+let pass = 0;
+let fail = 0;
+function expectThrows(label, fn, matcher) {
+  try {
+    fn();
+    console.log(`  ✗ ${label} — expected to throw, but didn't`);
+    fail++;
+  } catch (err) {
+    if (matcher.test(err.message)) {
+      console.log(`  ✓ ${label}`);
+      pass++;
+    } else {
+      console.log(`  ✗ ${label} — threw but message mismatch: ${err.message}`);
+      fail++;
+    }
+  }
+}
+function expectOk(label, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${label}`);
+    pass++;
+  } catch (err) {
+    console.log(`  ✗ ${label} — unexpected throw: ${err.message}`);
+    fail++;
+  }
+}
+
+console.log("\nLexical guards (existing behavior, no regression)");
+expectThrows("absolute path rejected", () => safePath("/etc/passwd"), /relative to repo root/);
+expectThrows("../ traversal rejected", () => safePath("../escape.txt"), /escapes repo root/);
+expectThrows("nested ../ traversal rejected", () => safePath("app/../../escape.txt"), /escapes repo root/);
+expectThrows("empty string rejected", () => safePath(""), /non-empty/);
+
+console.log("\nSymlink-escape guards (#159)");
+expectThrows(
+  "symlink file → outside ROOT rejected",
+  () => safePath("external_file"),
+  /resolves outside repo root via symlink/,
+);
+expectThrows(
+  "symlink dir → outside ROOT (traversed) rejected",
+  () => safePath("external_dir/child.txt"),
+  /resolves outside repo root via symlink/,
+);
+
+console.log("\nSymlink-to-forbidden-dir guards (#159)");
+expectThrows(
+  "symlink → .git rejected as forbidden",
+  () => safePath("git_alias"),
+  /\.git\/' are forbidden/,
+);
+expectThrows(
+  "writes via symlink → .git/config rejected as forbidden",
+  () => safePath("git_alias/config"),
+  /\.git\/' are forbidden/,
+);
+
+console.log("\nLegit paths still work");
+expectOk("real file in real dir", () => safePath("app/page.tsx"));
+expectOk("symlink dir → real intra-repo dir", () => safePath("app_alias/page.tsx"));
+expectOk("symlink file → real intra-repo file", () => safePath("page_alias"));
+expectOk("new file in existing dir (write_file create)", () => safePath("app/new-component.tsx"));
+expectOk("new file at root (write_file create)", () => safePath("README.md"));
+
+console.log("\nDirect forbidden-dir guards (pre-existing behavior, no regression)");
+expectThrows("writes to .git/ rejected", () => safePath(".git/config"), /\.git\/' are forbidden/);
+expectThrows("writes to node_modules/ rejected", () => safePath("node_modules/foo"), /node_modules\/' are forbidden/);
+
+rmSync(root, { recursive: true, force: true });
+rmSync(externalTarget, { force: true });
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #159. Follow-up to #155 (accepted-with-followup at merge time).

## The hole

\`safePath()\` in the Web Studio MCP server used **lexical** path resolution: it joined the input against \`ROOT\` and verified the resulting string stayed inside \`ROOT\`. But \`readFileSync\`/\`writeFileSync\` then **follow symlinks**.

A cloned repo can carry symlinks (git stores them as real OS symlinks on checkout). Two concrete attack paths:

1. **Confidentiality:** repo contains \`cool.txt -> /etc/passwd\` (or \`-> /opt/nexaas/.env\`, or \`-> /opt/nexaas/.ssh/other-workspace_deploy_key\`). Model reads it (possibly via prompt injection in a poisoned README), echoes the contents back.
2. **Cross-workspace integrity:** \`evil.txt -> \${NEXAAS_ROOT}/.ssh/other-workspace_deploy_key\` → write_file clobbers another workspace's deploy key.

Symlinked **directories** are part of the picture too: \`evil_dir -> /etc\`, then any \`evil_dir/anything\` slips past an \`O_NOFOLLOW\`-only defense.

## The fix

1. Compute \`REAL_ROOT = realpathSync(ROOT)\` once at boot — handles the case where \`WEBSTUDIO_REPO_ROOT\` is itself a symlink.
2. In \`safePath()\`, after the existing lexical checks: walk the resolved path up to the deepest existing ancestor, \`realpathSync\` that, and re-verify the would-be full path stays inside \`REAL_ROOT\`. The walk-up handles the write-create case (target doesn't exist yet).
3. Apply the forbidden-dir check to the **post-realpath** relative segments — catches a symlink that aliases a forbidden directory (e.g. \`safe_name -> .git\`).
4. Extracted into \`safe-path.ts\` so the validator can be tested with a real-filesystem fixture instead of booting the full stdio MCP server.

## Tests

\`scripts/test-webstudio-safe-path.mjs\` — 15 assertions across 5 groups:

- Lexical guards (no regression on absolute paths, \`..\` traversal, empty input)
- Symlink-escape guards: file and directory symlinks pointing outside ROOT
- Symlink-to-forbidden-dir guards: \`alias -> .git\` and \`alias/config\`
- Legit paths: real files, intra-repo symlinks (file and directory), write-create cases
- Pre-existing forbidden-dir guards still fire

Run: \`node --import tsx scripts/test-webstudio-safe-path.mjs\` → \`15 passed, 0 failed\`.

## Out of scope (deliberate)

- \`walkFs()\` and \`grep\`'s recursive walk still follow symlinks. They emit *paths*, not contents — the paths come back through \`read_file\` which is now hardened. Could be tightened later by switching to \`readdirSync({withFileTypes:true})\` + \`lstat\` on each entry, but it's not exploitable on its own.
- TOCTOU between \`realpathSync\` and \`writeFileSync\`. The attacker model here is the language model, not a concurrent process — single-tenant per workspace makes the race impractical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)