### PR TITLE
fix(init): three install-path failures on fresh Ubuntu 24.04 VPS

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -97,6 +97,22 @@ export async function run(args: string[]) {
   if (!commandExists("node")) {
     fail("Node.js not found. Install Node.js >= 20: curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - && sudo apt-get install -y nodejs");
   }
+  // Snap-installed Node intercepts CLI flag parsing on classic snaps and
+  // rejects --conditions=production (the flag the worker unit relies on
+  // for compiled-JS routing). Refusing here avoids a silent crash-loop
+  // after install completes.
+  const nodeBinPath = exec("which node", { silent: true });
+  if (nodeBinPath.startsWith("/snap/")) {
+    fail(
+      `Detected snap-installed Node at ${nodeBinPath}.\n` +
+      `  Snap's classic confinement rejects --conditions=production, which the worker\n` +
+      `  service requires for compiled-JS routing. Reinstall Node via NodeSource apt:\n\n` +
+      `    sudo snap remove node\n` +
+      `    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash -\n` +
+      `    sudo apt-get install -y nodejs\n\n` +
+      `  Then rerun nexaas init.`,
+    );
+  }
   const nodeVersion = exec("node -v", { silent: true });
   const nodeMajor = parseInt(nodeVersion.replace("v", "").split(".")[0]!, 10);
   if (nodeMajor < 20) {
@@ -334,6 +350,15 @@ NEXAAS_WORKER_PORT=9090
 
   step(5, TOTAL_STEPS, "Installing services...");
 
+  // Install dependencies including devDeps — every workspace package's
+  // `build` script runs `tsc` directly, and TypeScript is a devDep. A
+  // prior `npm install --omit=dev` (or installing from a deploy script
+  // that defaults to production-only) leaves `tsc: not found` for every
+  // package and the build below 127s. Idempotent when devDeps are
+  // already present.
+  log("Installing dependencies (including devDeps for build)...");
+  exec(`cd ${NEXAAS_ROOT} && npm install --include=dev`);
+
   // Build compiled JS for production (#37). The systemd unit runs
   // `node --conditions=production dist/worker.js` so cross-package
   // imports resolve to compiled JS rather than tsx-transpiled TS at
@@ -372,10 +397,29 @@ WantedBy=multi-user.target
 `;
 
   const servicePath = "/etc/systemd/system/nexaas-worker.service";
+  // Unmask any pre-existing /dev/null override before writing. Some
+  // Ubuntu base images (cloud-init defaults, OVH templates) ship a
+  // masked nexaas-worker.service symlink to /dev/null. Without this,
+  // `sudo tee` silently writes to /dev/null and the systemctl ops
+  // below fail invisibly because exec() swallows non-zero exits.
+  exec("sudo systemctl unmask nexaas-worker.service 2>/dev/null || true", { silent: true });
   exec(`echo '${serviceContent}' | sudo tee ${servicePath} > /dev/null`);
-  exec("sudo systemctl daemon-reload");
-  exec("sudo systemctl enable nexaas-worker");
-  exec("sudo systemctl start nexaas-worker");
+  // Verify the write landed. Without this check, a misconfigured sudo or
+  // a still-masked path would let init continue silently to enable/start.
+  if (!existsSync(servicePath) || readFileSync(servicePath, "utf-8").length < 100) {
+    fail(`Failed to write ${servicePath}. Check sudo permissions and systemctl unmask status.`);
+  }
+  // Promote enable/start failures from warnings to fatals. exec()'s
+  // swallow-and-return-empty behavior demotes masking errors (and
+  // similar) to "Worker may not have started" warnings — failures here
+  // mean the worker won't run and need to surface immediately.
+  try {
+    execSync("sudo systemctl daemon-reload", { stdio: "inherit" });
+    execSync("sudo systemctl enable nexaas-worker", { stdio: "inherit" });
+    execSync("sudo systemctl start nexaas-worker", { stdio: "inherit" });
+  } catch (e) {
+    fail(`systemctl operation failed: ${(e as Error).message}. Run with sudo journalctl -xe for details.`);
+  }
 
   // Wait a moment for the worker to start
   await new Promise((resolve) => setTimeout(resolve, 3000));


### PR DESCRIPTION
Closes #156, #157, #158. All three hit during today's Atmosphere-Hot-Tubs deploy on a fresh Ubuntu 24.04 VPS.

## What changed

`packages/cli/src/init.ts` — three surgical fixes in the install path:

### 1. Detect snap-installed Node (#157)

In step 1 (Prerequisites), after the `commandExists("node")` check: if `which node` returns a path under `/snap/`, refuse with an actionable error telling the operator how to switch to NodeSource apt. Without this, init reports success and the worker silently crash-loops on `error: unknown flag 'conditions'`.

### 2. Install devDeps before build (#156)

In step 5 (Installing services), before `npm run build`: add `npm install --include=dev`. Every workspace package's `build` script calls `tsc` directly (not `npx tsc`), and TypeScript is a devDep. A prior production-only install leaves every package's `tsc -p tsconfig.json` 127ing. The added install is idempotent when devDeps are already present.

### 3. Unmask + strict systemctl (#158)

Before writing the unit:
- `sudo systemctl unmask nexaas-worker.service` (no-op when not masked).
- Verify the unit file landed and has reasonable size; fail loudly otherwise.

After writing:
- Replace `exec(...)` (which silently swallows non-zero exits) with `execSync(...)` for daemon-reload / enable / start. Failures now `fail()` immediately instead of being demoted to a trailing "Worker may not have started" warning.

## Why one PR

All three fixes are in the same install path (`packages/cli/src/init.ts`), all surfaced from the same deploy session, all are small surgical changes. Net diff: +47/-3 lines, one file. Splitting into three PRs would just create rebase churn.

## Test plan

These are install-path failures that need a fresh VPS to reproduce end-to-end. Verified locally:

- `npx tsc --noEmit` in `packages/cli/` — passes.
- Logic review of each branch against its issue reproduction notes.

Recommended pre-merge end-to-end verification:

- [ ] Fresh Ubuntu 24.04 VPS with snap-installed Node → `nexaas init` should now hard-fail in step 1 with the NodeSource instructions, not silently crash-loop later.
- [ ] Fresh VPS with NodeSource Node but no prior `npm install` → step 5 installs devDeps, build succeeds, worker comes up `active`.
- [ ] Fresh VPS with `nexaas-worker.service` masked as `/dev/null` → step 5 unmasks, write succeeds, enable/start succeeds, worker comes up `active`.
- [ ] Fresh VPS with neither pre-existing mask nor snap → still works; no regression on the happy path.

## Cross-repo follow-up (not in this PR)

Nexmatic's `scripts/deploy-instance.sh:53-62` is what installs Node via `sudo snap install node --classic --channel=20`. That's a Nexmatic concern — the framework defends against it (this PR) but the upstream fix is to switch Nexmatic's deploy script to NodeSource. Will file a corresponding issue on the Nexmatic repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)