### PR TITLE
feat(pa-router): workspace flag for v1/v2 cutover (RFC-0002 §9, Wave 5)

### DIFF
--- a/packages/runtime/src/schemas/workspace-manifest.ts
+++ b/packages/runtime/src/schemas/workspace-manifest.ts
@@ -90,6 +90,28 @@ export const ModelPolicy = z.object({
 }).passthrough();
 
 /**
+ * pa_routing — Wave 5 cutover flag (RFC-0002 §9).
+ *
+ * Controls whether `pa_notify_<user>` envelopes get rewired through the
+ * /api/pa/<user>/notify endpoint (v2) or stay on the legacy notifications-
+ * dispatcher direct path (v1). Lets workspaces stagger their canary
+ * (per-user override) and keeps a kill-switch (default = "v1") for
+ * emergency rollback.
+ *
+ * Framework default: "v2". Absence of `pa_routing` on a manifest
+ * preserves the de-facto current behavior — if a user has declared
+ * persona threads, their envelopes get rewired.
+ *
+ * Per-user override semantics: pinning a user to "v1" routes their
+ * envelopes via the legacy direct path. That path requires their
+ * `pa_notify_<user>` entry in `channel_bindings` to still resolve.
+ */
+export const PaRoutingPolicy = z.object({
+  default: z.enum(["v1", "v2"]).default("v2"),
+  users: z.record(z.string(), z.enum(["v1", "v2"])).default({}),
+}).passthrough();
+
+/**
  * custom_domains — client-owned domains routed to this workspace VPS.
  * Self-service per architecture.md §17 (network topology).
  */
@@ -126,6 +148,7 @@ export const WorkspaceManifest = z.object({
     overrides: [],
   }),
   custom_domains: z.array(CustomDomain).default([]),
+  pa_routing: PaRoutingPolicy.default({ default: "v2", users: {} }),
 }).passthrough();
 
 export type WorkspaceManifest = z.infer<typeof WorkspaceManifest>;
@@ -133,6 +156,21 @@ export type CapabilityBinding = z.infer<typeof CapabilityBinding>;
 export type ChannelBinding = z.infer<typeof ChannelBinding>;
 export type BehavioralContract = z.infer<typeof BehavioralContract>;
 export type ModelPolicy = z.infer<typeof ModelPolicy>;
+export type PaRoutingPolicy = z.infer<typeof PaRoutingPolicy>;
+
+/**
+ * Resolve the PA routing version for a given user. Returns "v2" when the
+ * manifest is missing entirely so a fresh deployment preserves the de-
+ * facto current behavior of "if threads exist, rewire".
+ */
+export function resolvePaRoutingVersion(
+  manifest: WorkspaceManifest | null,
+  user: string,
+): "v1" | "v2" {
+  return manifest?.pa_routing?.users?.[user]
+    ?? manifest?.pa_routing?.default
+    ?? "v2";
+}
 
 /**
  * Validation result — warnings are non-fatal, errors indicate the manifest

--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -25,7 +25,7 @@
 import { sql, appendWal, palace } from "@nexaas/palace";
 import { McpClient, loadMcpConfigs } from "../mcp/client.js";
 import { loadWorkspaceManifest } from "../schemas/load-manifest.js";
-import type { WorkspaceManifest, ChannelBinding } from "../schemas/workspace-manifest.js";
+import { resolvePaRoutingVersion, type WorkspaceManifest, type ChannelBinding } from "../schemas/workspace-manifest.js";
 import { reportMissingRelation } from "./_consistency-warning.js";
 import {
   detectPaNotifyUser,
@@ -399,10 +399,30 @@ async function writeOutcomeDrawer(
  */
 async function tryPaRewire(
   workspace: string,
+  manifest: WorkspaceManifest | null,
   drawer: PendingDrawer,
   envelope: DispatchEnvelope,
   paUser: string,
 ): Promise<"delivered" | "already_delivered" | "fallthrough"> {
+  // Wave 5 cutover flag — workspace-manifest pa_routing controls whether
+  // this user's envelopes get rewired (v2) or stay on the legacy direct
+  // path (v1). Per-user override lets ops stagger a canary without
+  // flipping every PA at once. See RFC-0002 §9.
+  if (resolvePaRoutingVersion(manifest, paUser) === "v1") {
+    await appendWal({
+      workspace,
+      op: "pa_rewire_skipped",
+      actor: "notification-dispatcher",
+      payload: {
+        drawer_id: drawer.id,
+        channel_role: envelope.channel_role,
+        user: paUser,
+        reason: "v1_pinned",
+      },
+    });
+    return "fallthrough";
+  }
+
   // Cheap pre-check: does the user have any active threads at all? If not,
   // they haven't been migrated to v2 — keep going on the direct path.
   const activeCount = await sql<{ n: string }>(
@@ -583,7 +603,7 @@ export async function dispatchPendingNotifications(
     // unchanged — the migration is opt-in by declaring a persona profile.
     const paUser = detectPaNotifyUser(envelope.channel_role);
     if (paUser) {
-      const rewired = await tryPaRewire(workspace, drawer, envelope, paUser);
+      const rewired = await tryPaRewire(workspace, workspaceManifest, drawer, envelope, paUser);
       if (rewired === "delivered") {
         dispatched++;
         continue;

--- a/scripts/test-pa-routing-flag.mjs
+++ b/scripts/test-pa-routing-flag.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Regression test for the PA-routing workspace flag (#126 Wave 5 §9).
+ *
+ * Exercises resolvePaRoutingVersion() across the matrix of manifest
+ * shapes so the dispatcher's gate behaves correctly during canary
+ * rollouts (per-user pin to v1) and after a workspace-wide flip to v2.
+ *
+ * Run:
+ *   node --import tsx scripts/test-pa-routing-flag.mjs
+ */
+
+import {
+  resolvePaRoutingVersion,
+  validateManifest,
+} from "../packages/runtime/src/schemas/workspace-manifest.ts";
+
+let pass = 0;
+let fail = 0;
+function check(label, actual, expected) {
+  if (actual === expected) { console.log(`  ✓ ${label}`); pass++; }
+  else { console.log(`  ✗ ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`); fail++; }
+}
+
+function manifest(pa_routing) {
+  const raw = { id: "ws", manifest_version: "0.2" };
+  if (pa_routing !== undefined) raw.pa_routing = pa_routing;
+  const r = validateManifest(raw);
+  if (!r.ok) throw new Error(`manifest invalid: ${r.errors.join("; ")}`);
+  return r.manifest;
+}
+
+console.log("\nDefault behavior (no flag set)");
+check("absent manifest → v2 (preserves current behavior)",
+  resolvePaRoutingVersion(null, "alice"), "v2");
+check("manifest without pa_routing → v2",
+  resolvePaRoutingVersion(manifest(), "alice"), "v2");
+check("explicit default v2, no users → v2",
+  resolvePaRoutingVersion(manifest({ default: "v2" }), "alice"), "v2");
+
+console.log("\nKill-switch (workspace-wide v1)");
+check("default v1, no users → v1",
+  resolvePaRoutingVersion(manifest({ default: "v1" }), "alice"), "v1");
+check("default v1 overrides Zod default (was v2)",
+  resolvePaRoutingVersion(manifest({ default: "v1", users: {} }), "anyone"), "v1");
+
+console.log("\nPer-user overrides (canary granularity)");
+check("default v2, user pinned v1 → v1 (typical canary holdback)",
+  resolvePaRoutingVersion(manifest({ default: "v2", users: { seb: "v1" } }), "seb"), "v1");
+check("default v2, different user → v2 (default applies)",
+  resolvePaRoutingVersion(manifest({ default: "v2", users: { seb: "v1" } }), "al"), "v2");
+check("default v1, user opted in v2 → v2 (early canary)",
+  resolvePaRoutingVersion(manifest({ default: "v1", users: { al: "v2" } }), "al"), "v2");
+check("default v1, different user → v1 (held back)",
+  resolvePaRoutingVersion(manifest({ default: "v1", users: { al: "v2" } }), "mireille"), "v1");
+
+console.log("\nMixed-state staggered rollout (Wave 5 ceremony shape)");
+const staggered = manifest({
+  default: "v1",
+  users: { alice: "v2", bob: "v2", carol: "v1" },
+});
+check("alice migrated → v2", resolvePaRoutingVersion(staggered, "alice"), "v2");
+check("bob migrated → v2", resolvePaRoutingVersion(staggered, "bob"), "v2");
+check("carol held back → v1", resolvePaRoutingVersion(staggered, "carol"), "v1");
+check("new unknown user falls to default", resolvePaRoutingVersion(staggered, "newjoiner"), "v1");
+
+console.log("\nSchema validation rejects garbage");
+const bad1 = validateManifest({ id: "ws", pa_routing: { default: "v3" } });
+check("default = v3 rejected", bad1.ok, false);
+const bad2 = validateManifest({ id: "ws", pa_routing: { default: "v2", users: { alice: "experimental" } } });
+check("user override = experimental rejected", bad2.ok, false);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Adds the workspace-config flag that RFC-0002 §9 calls for: lets ops gate the notifications-dispatcher PA rewire per workspace and per user. Unblocks the staggered canary ceremony described in #126 (Wave 5.2) without forcing every PA to flip at once.

Part of #126. Does not close it — Wave 5 also needs Phoenix-side migration + observation, which lives in the workspace repo, plus the routing-decisions drawer enhancement (deferred to a follow-up).

## What changed

`packages/runtime/src/schemas/workspace-manifest.ts`:

- New `PaRoutingPolicy` schema (Zod).
- Field on `WorkspaceManifest`: \`pa_routing: { default: \"v1\"|\"v2\", users: { <user>: \"v1\"|\"v2\" } }\`.
- New pure helper \`resolvePaRoutingVersion(manifest, user)\`: per-user override > default > framework fallback (\"v2\").

`packages/runtime/src/tasks/notification-dispatcher.ts`:

- \`tryPaRewire\` now takes the manifest as an arg and checks the resolved version up front.
- If the resolved version is \"v1\", logs a WAL \`pa_rewire_skipped\` event with reason \`v1_pinned\` and falls through to the legacy direct path.
- v2-resolved users keep going through the existing rewire (no change to the happy path).

`scripts/test-pa-routing-flag.mjs`:

- 15 assertions across the matrix of manifest shapes — absent manifest, no flag, default-only, per-user overrides, mixed-state staggered rollout, and schema-validation negative tests.
- Pure unit test (no DB required). Run: \`node --import tsx scripts/test-pa-routing-flag.mjs\`.

## Manifest shape

\`\`\`yaml
pa_routing:
  default: v2          # framework default; preserves current behavior
  users:
    alice: v2          # explicit
    bob: v1            # pinned to legacy direct path
\`\`\`

## Default policy

**Framework default: \"v2\".** Absence of \`pa_routing\` ⇒ rewire applies whenever a user has declared persona threads, which is the de-facto behavior on \`main\` today. Setting \`pa_routing.default: v1\` is the kill-switch.

## Pinning a user to v1 — caveat

When a user resolves to v1, the dispatcher falls through to the legacy direct path. That path needs the user's \`pa_notify_<user>\` entry in \`channel_bindings\` to still resolve — pinning v1 doesn't bring the channel binding back if it was removed.

## Out of scope (separate PRs / issues)

- **Routing-decisions audit drawer enhancement** — adding a \`routing\` sub-object to \`inbox/<user>/notifications-emitted\`. Useful for the calibration report in #126 §5.3 but not needed for the canary flag itself. Will file as a follow-up.
- **Per-thread BullMQ queues** (Wave 2.2 — open design questions on queue lifecycle).
- **Urgency-tier dispatch policy** (Wave 2.4 — open design questions on digest timing + low-tier deferral).
- **Phoenix-side canary execution** (Wave 5.2 — lives in Systemsaholic/Phoenix-Voyages, not Nexaas).

## Test plan

- [x] \`node --import tsx scripts/test-pa-routing-flag.mjs\` → 15/15 pass
- [x] \`npx tsc --noEmit\` in \`packages/runtime\` → clean
- [ ] Live workspace with \`pa_routing.default: v1\` set on the manifest → \`pa_notify_<user>\` envelopes deliver via legacy direct path; \`pa_rewire_skipped\` WAL row with reason \`v1_pinned\` appears
- [ ] Same workspace flipped to \`pa_routing.default: v2\` → envelopes rewire as today
- [ ] Mixed-state manifest with one user pinned to v1 → only that user's envelopes skip the rewire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PA routing policy configuration to workspace manifests, enabling per-user control over notification delivery paths with versioning support for legacy and rewired implementations.

* **Tests**
  * Added regression test coverage for PA routing configuration and per-user routing resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/163)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->