### PR TITLE
feat(pa-router): routing-decisions sub-object on notifications-emitted audit drawer

### DIFF
--- a/packages/runtime/src/api/pa-notify.ts
+++ b/packages/runtime/src/api/pa-notify.ts
@@ -243,16 +243,44 @@ export interface ExecuteDeps {
 }
 
 /**
+ * Routing-decision metadata stamped onto the audit drawer so workspace
+ * dashboards can answer "which path did this notification take" without
+ * cross-referencing WAL. Optional on the call — callers that don't care
+ * about observability (e.g. tests) can omit it; the audit drawer just
+ * carries `routing: null` in that case.
+ *
+ *   version  — resolved per-user pa_routing flag at decision time.
+ *              "v2" when the call came through the rewire (which only
+ *              fires when the flag is v2). Omitted (null) for direct
+ *              calls since the gate isn't on that path.
+ *   source   — "rewire" when the notifications-dispatcher invoked us
+ *              for a `pa_notify_<user>` envelope; "direct" when a skill
+ *              called `/api/pa/<user>/notify` itself.
+ *   decision — "delivered" on the happy path; "skipped" for paths that
+ *              didn't actually queue a delivery (e.g. v1_pinned).
+ *   reason   — free-form short string detailing the decision. "success"
+ *              when delivered; otherwise one of the documented skip
+ *              reasons (v1_pinned, dedup_hit, etc.).
+ */
+export interface PaRoutingMeta {
+  version?: "v1" | "v2";
+  source: "rewire" | "direct";
+  decision: "delivered" | "skipped";
+  reason: string;
+}
+
+/**
  * End-to-end PA notify flow:
  *   1. Resolve user's active threads
  *   2. 404 if requested thread isn't among them
  *   3. Idempotency check — return original notification_id on hit
  *   4. Mint notification_id + write pending-routed drawer (PA picks up)
- *   5. Best-effort audit drawer
+ *   5. Best-effort audit drawer with routing-decision metadata
  */
 export async function executePaNotify(
   input: PaNotifyInput,
   deps: ExecuteDeps,
+  routing?: PaRoutingMeta,
 ): Promise<PaNotifyOutcome> {
   const threads = await deps.listActiveThreads(deps.workspace, input.user);
   const matching = threads.find((t) => t.thread_id === input.threadId);
@@ -337,6 +365,7 @@ export async function executePaNotify(
       payload: {
         ...corePayload,
         delivery_status: "queued",
+        routing: routing ?? null,
       },
     });
   } catch (err) {
@@ -355,6 +384,46 @@ export async function executePaNotify(
       },
     },
   };
+}
+
+/**
+ * Write a stub audit-drawer entry for a notification that the dispatcher
+ * declined to rewire (e.g. v1_pinned). Lets dashboard queries over
+ * `inbox/<user>/notifications-emitted` see EVERY routing decision,
+ * including skips that never minted a notification_id.
+ *
+ * The legacy direct-dispatch path still runs after this — the audit
+ * record is purely observability, not a delivery commitment.
+ */
+export async function writeSkipAuditDrawer(
+  deps: ExecuteDeps,
+  entry: {
+    user: string;
+    channelRole: string;
+    idempotencyKey?: string;
+    routing: PaRoutingMeta;
+  },
+): Promise<void> {
+  try {
+    await deps.writeAuditDrawer({
+      workspace: deps.workspace,
+      user: entry.user,
+      // No notification_id minted for a skip — use a stable, queryable
+      // sentinel so downstream queries can filter it out if needed.
+      notificationId: "skip",
+      threadId: "",
+      payload: {
+        delivery_status: "skipped",
+        user: entry.user,
+        channel_role: entry.channelRole,
+        idempotency_key: entry.idempotencyKey ?? null,
+        received_at: new Date().toISOString(),
+        routing: entry.routing,
+      },
+    });
+  } catch (err) {
+    console.error("[nexaas] pa-notify skip audit drawer write failed (non-fatal):", err);
+  }
 }
 
 /**

--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -32,7 +32,9 @@ import {
   detectPaNotifyUser,
   defaultPaNotifyDeps,
   executePaNotify,
+  writeSkipAuditDrawer,
   type PaNotifyInput,
+  type PaRoutingMeta,
 } from "../api/pa-notify.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
@@ -421,6 +423,20 @@ async function tryPaRewire(
         reason: "v1_pinned",
       },
     });
+    // Stub audit drawer so dashboards over notifications-emitted see
+    // every routing decision, not just successful deliveries. The legacy
+    // direct-dispatch path still runs after we return fallthrough.
+    await writeSkipAuditDrawer(defaultPaNotifyDeps(workspace), {
+      user: paUser,
+      channelRole: envelope.channel_role,
+      idempotencyKey: envelope.idempotency_key,
+      routing: {
+        version: "v1",
+        source: "rewire",
+        decision: "skipped",
+        reason: "v1_pinned",
+      },
+    });
     return "fallthrough";
   }
 
@@ -474,9 +490,15 @@ async function tryPaRewire(
     ...(mappedActions && mappedActions.length > 0 ? { actions: mappedActions } : {}),
   };
 
+  const rewireRouting: PaRoutingMeta = {
+    version: "v2",
+    source: "rewire",
+    decision: "delivered",
+    reason: "success",
+  };
   let outcome;
   try {
-    outcome = await executePaNotify(input, defaultPaNotifyDeps(workspace));
+    outcome = await executePaNotify(input, defaultPaNotifyDeps(workspace), rewireRouting);
   } catch (err) {
     // Rewire blew up (DB transient, etc.). Don't lose the notification —
     // emit a warning and fall through. The direct path will retry next tick.

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -477,7 +477,11 @@ async function main() {
         res.status(500).json({ error: "worker has no NEXAAS_WORKSPACE configured" });
         return;
       }
-      const outcome = await executePaNotify(validated, defaultPaNotifyDeps(WORKSPACE));
+      const outcome = await executePaNotify(validated, defaultPaNotifyDeps(WORKSPACE), {
+        source: "direct",
+        decision: "delivered",
+        reason: "success",
+      });
       if ("error" in outcome) {
         res.status(outcome.status).json({ error: outcome.error, details: outcome.details });
         return;

--- a/scripts/test-pa-routing-audit.mjs
+++ b/scripts/test-pa-routing-audit.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Regression test for routing-decisions audit-drawer enhancement (#164).
+ *
+ * Mocks ExecuteDeps to capture exactly what writeAuditDrawer receives.
+ * Verifies the `routing` sub-object appears on every audit-drawer write
+ * across the four scenarios that produce one:
+ *
+ *   1. rewire path → audit drawer has routing.source = "rewire", version = "v2"
+ *   2. direct HTTP call → audit drawer has routing.source = "direct"
+ *   3. no routing arg supplied → audit drawer has routing = null
+ *   4. v1_pinned skip → stub audit drawer with delivery_status = "skipped"
+ *
+ * Pure: no Postgres required. The mock deps capture calls in memory.
+ *
+ * Run:
+ *   node --import tsx scripts/test-pa-routing-audit.mjs
+ */
+
+import {
+  executePaNotify,
+  writeSkipAuditDrawer,
+} from "../packages/runtime/src/api/pa-notify.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+function mockDeps() {
+  const captured = { audit: null, pending: null, marker: null };
+  return {
+    deps: {
+      workspace: "test-ws",
+      listActiveThreads: async () => [{ thread_id: "inbox", display_name: "Inbox" }],
+      findRecentByIdempotency: async () => null,
+      writePendingDrawer: async (entry) => {
+        captured.pending = entry;
+        return { drawer_id: "drw-mock-1" };
+      },
+      enqueueDeliveryMarker: async (entry) => { captured.marker = entry; },
+      writeAuditDrawer: async (entry) => { captured.audit = entry; },
+    },
+    captured,
+  };
+}
+
+const baseInput = {
+  user: "alice",
+  threadId: "inbox",
+  urgency: "normal",
+  kind: "alert",
+  content: "Test message",
+  contentFormat: "html",
+};
+
+// ── 1. Rewire path → routing stamped on audit drawer ───────────────
+console.log("\n1. Dispatcher rewire path stamps routing on audit drawer");
+{
+  const { deps, captured } = mockDeps();
+  const result = await executePaNotify(baseInput, deps, {
+    version: "v2",
+    source: "rewire",
+    decision: "delivered",
+    reason: "success",
+  });
+  assert(result.status === 202, "202 returned on happy path");
+  assert(captured.audit != null, "audit drawer was written");
+  assert(captured.audit.payload.routing != null, "routing field on audit payload");
+  assert(captured.audit.payload.routing.source === "rewire", "routing.source = rewire");
+  assert(captured.audit.payload.routing.version === "v2", "routing.version = v2");
+  assert(captured.audit.payload.routing.decision === "delivered", "routing.decision = delivered");
+  assert(captured.audit.payload.delivery_status === "queued", "delivery_status preserved");
+}
+
+// ── 2. Direct HTTP call → source=direct, version omitted ───────────
+console.log("\n2. Direct HTTP call stamps source=direct, no version");
+{
+  const { deps, captured } = mockDeps();
+  await executePaNotify(baseInput, deps, {
+    source: "direct",
+    decision: "delivered",
+    reason: "success",
+  });
+  assert(captured.audit.payload.routing.source === "direct", "routing.source = direct");
+  assert(captured.audit.payload.routing.version === undefined, "version omitted for direct");
+}
+
+// ── 3. No routing arg → routing = null on the drawer ────────────────
+console.log("\n3. Omitted routing arg → routing = null (backwards-compat)");
+{
+  const { deps, captured } = mockDeps();
+  await executePaNotify(baseInput, deps);
+  assert(captured.audit.payload.routing === null, "routing = null when omitted");
+  assert(captured.audit.payload.delivery_status === "queued", "delivery_status preserved");
+}
+
+// ── 4. v1_pinned skip → stub audit drawer ───────────────────────────
+console.log("\n4. writeSkipAuditDrawer stamps a skip-shaped drawer");
+{
+  const { deps, captured } = mockDeps();
+  await writeSkipAuditDrawer(deps, {
+    user: "alice",
+    channelRole: "pa_notify_alice",
+    idempotencyKey: "k-skip-1",
+    routing: {
+      version: "v1",
+      source: "rewire",
+      decision: "skipped",
+      reason: "v1_pinned",
+    },
+  });
+  assert(captured.audit != null, "skip audit drawer written");
+  assert(captured.audit.notificationId === "skip", "notificationId sentinel for skip");
+  assert(captured.audit.payload.delivery_status === "skipped", "delivery_status = skipped");
+  assert(captured.audit.payload.routing.reason === "v1_pinned", "routing.reason = v1_pinned");
+  assert(captured.audit.payload.routing.decision === "skipped", "routing.decision = skipped");
+  assert(captured.audit.payload.channel_role === "pa_notify_alice", "channel_role preserved");
+  assert(captured.audit.payload.idempotency_key === "k-skip-1", "idempotency_key preserved");
+}
+
+// ── 5. Audit drawer shape preserves all pre-existing fields ─────────
+console.log("\n5. Pre-existing audit-drawer fields are untouched");
+{
+  const { deps, captured } = mockDeps();
+  await executePaNotify({
+    ...baseInput,
+    originatingSkill: "hr/example",
+    waitpointId: "wp-123",
+    idempotencyKey: "k-ok",
+    metadata: { foo: "bar" },
+  }, deps, { source: "direct", decision: "delivered", reason: "success" });
+  const p = captured.audit.payload;
+  assert(p.user === "alice", "user preserved");
+  assert(p.thread_id === "inbox", "thread_id preserved");
+  assert(p.urgency === "normal", "urgency preserved");
+  assert(p.kind === "alert", "kind preserved");
+  assert(p.originating_skill === "hr/example", "originating_skill preserved");
+  assert(p.waitpoint_id === "wp-123", "waitpoint_id preserved");
+  assert(p.idempotency_key === "k-ok", "idempotency_key preserved");
+  assert(p.metadata?.foo === "bar", "metadata preserved");
+  assert(typeof p.received_at === "string", "received_at populated");
+  assert(typeof p.notification_id === "string" && p.notification_id.startsWith("n-"),
+    "notification_id minted");
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #164. Follow-up to PR #163 (\`pa_routing\` workspace flag) and PR #165 (delivery helpers).

Every PA notify call now stamps a \`routing\` sub-object on the audit drawer at \`inbox/<user>/notifications-emitted\` so workspace dashboards can see which path produced each notification — dispatcher rewire vs. direct skill call — without cross-referencing WAL.

## Shape

\`\`\`jsonc
// audit drawer payload at inbox/<user>/notifications-emitted
{
  // ... existing fields preserved ...
  \"delivery_status\": \"queued\" | \"skipped\",
  \"routing\": {
    \"version\": \"v1\" | \"v2\" | undefined,   // resolved pa_routing flag; undefined for direct calls
    \"source\": \"rewire\" | \"direct\",
    \"decision\": \"delivered\" | \"skipped\",
    \"reason\": \"success\" | \"v1_pinned\" | ...
  } | null
}
\`\`\`

## Three call sites

| Call site | Routing meta supplied |
|---|---|
| Dispatcher rewire (\`tryPaRewire\` → \`executePaNotify\`) | \`{version: \"v2\", source: \"rewire\", decision: \"delivered\", reason: \"success\"}\` |
| HTTP endpoint \`/api/pa/<user>/notify\` | \`{source: \"direct\", decision: \"delivered\", reason: \"success\"}\` — version omitted because direct calls bypass the dispatcher gate |
| v1_pinned skip path | New \`writeSkipAuditDrawer\` helper writes a stub drawer with \`delivery_status: \"skipped\"\` and \`routing: {version: \"v1\", source: \"rewire\", decision: \"skipped\", reason: \"v1_pinned\"}\` |

## v1_pinned stub drawer rationale

The \`pa_routing\` flag from PR #163 added a gate that skips the rewire when a user is pinned to v1. Without this PR, those skips only landed in WAL — invisible to dashboard queries that read \`notifications-emitted\`. The stub drawer makes every routing decision (including skips) queryable from the same room.

Stub drawer fields:
- \`notificationId: \"skip\"\` — sentinel so consumers can filter
- \`delivery_status: \"skipped\"\`
- \`channel_role\`, \`idempotency_key\`, \`received_at\` for trace context
- \`routing\` sub-object as above

## Backwards-compat

- \`executePaNotify\`'s new \`routing\` param is **optional**. Callers that omit it get \`routing: null\` on the audit drawer. Existing audit-drawer consumers reading other fields aren't affected.
- New \`writeSkipAuditDrawer\` is opt-in. The legacy direct-dispatch path still runs after \`tryPaRewire\` returns fallthrough — the stub drawer is purely observability.

## Out of scope

- \`inferred_confidence\` field mentioned in the original #164 design — that's set by the workspace-side conversation-turn skill, not the framework. Workspaces that want to track inference can extend the schema themselves.
- Stub drawers for other fallthrough reasons (\`no_active_threads\`, \`missing_thread\`, \`missing_content\`). Those are already in WAL and represent \"user not migrated\" / config errors rather than active routing decisions. Easy to extend later if dashboards need it.

## Test

\`scripts/test-pa-routing-audit.mjs\` — 28 assertions, 5 groups, **no Postgres required** (mocks \`ExecuteDeps\` in-memory and inspects the captured audit-drawer payloads):

1. Rewire path stamps \`routing.source = \"rewire\"\`, \`version = \"v2\"\`
2. Direct path stamps \`routing.source = \"direct\"\`, version omitted
3. Omitted routing arg → \`routing: null\` (backwards-compat)
4. \`writeSkipAuditDrawer\` produces a skip-shaped drawer with all fields
5. Pre-existing audit-drawer fields (user, thread_id, urgency, kind, originating_skill, waitpoint_id, idempotency_key, metadata, received_at, notification_id) untouched

Run: \`node --import tsx scripts/test-pa-routing-audit.mjs\` → \`28 passed, 0 failed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)