### PR TITLE
feat(pa-router): urgency-tier release gating on pa_delivery_marker (Wave 2.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,9 @@ Set in `.env` (never committed):
 - `NEXAAS_FLEET_ENDPOINT` + `NEXAAS_FLEET_TOKEN` — fleet-heartbeat target (operator-managed only; leave unset for direct adopters — sender becomes a silent no-op)
 - `NEXAAS_PA_TIMEOUT_MS` — per-request PA handler timeout (default: 120000 = 2 min)
 - `NEXAAS_PA_MAX_RETRIES` — max delivery attempts for a PA-routed pending drawer before the marker transitions to `dead` and an `ops_alert` is emitted (default: 3; minimum: 1)
+- `NEXAAS_PA_NORMAL_HOLD_MINUTES` — hold duration for `urgency: normal` PA notifications before they become claimable. Lets workspaces batch/digest if they choose (default: 15)
+- `NEXAAS_PA_LOW_RELEASE_HOUR` — local-time hour at which `urgency: low` PA notifications become claimable (default: 7, i.e. 07:xx)
+- `NEXAAS_PA_LOW_RELEASE_MINUTE` — minute within the configured hour for low-tier release (default: 30, i.e. 07:30 by default)
 - `NEXAAS_WAL_RETENTION_DAYS` — enable WAL retention policy (default: unset = keep forever)
 - `NEXAAS_WAITPOINT_MAX_TIMEOUT_DAYS` — upper bound on inbound-match waitpoint timeouts (default: 1 day). Raise for state-machine hold patterns (e.g. `7` for week-scale approval loops). See #66.
 - `NEXAAS_SILENT_FAILURE_THRESHOLD` — consecutive-failure count that triggers a silent-failure alert (default: 5; minimum: 2). See #69.

--- a/database/migrations/023_pa_delivery_release_at.sql
+++ b/database/migrations/023_pa_delivery_release_at.sql
@@ -1,0 +1,31 @@
+-- Add release_at gate to pa_delivery_marker so the framework can hold
+-- a notification until its tier-specific release time without coupling
+-- delivery scheduling to any particular consumer architecture.
+--
+-- claimNextDelivery filters by `release_at <= now()`, so held rows are
+-- invisible to workspace consumers; once the timestamp passes, the row
+-- becomes claimable on the next tick.
+--
+-- Tier → release_at mapping is computed at enqueue time by the
+-- framework helper, with workspace-overridable defaults via env vars:
+--   immediate → now()
+--   normal    → now() + NEXAAS_PA_NORMAL_HOLD_MINUTES (default 15)
+--   low       → next NEXAAS_PA_LOW_RELEASE_HOUR:MINUTE (default 07:30)
+--
+-- DEFAULT now() means existing rows from before this migration are
+-- treated as "release-immediately" — backwards-compatible for any
+-- consumer already draining the table.
+
+ALTER TABLE nexaas_memory.pa_delivery_marker
+  ADD COLUMN IF NOT EXISTS release_at timestamptz NOT NULL DEFAULT now();
+
+-- Pending-scan index must include release_at so the dispatcher's
+-- claim query stays index-only on the common case of "what's eligible
+-- right now". The existing partial index on (workspace, status,
+-- claimed_at) WHERE status IN ('queued','failed') doesn't help once
+-- the WHERE clause adds release_at <= now() — Postgres still has to
+-- check each candidate row's release_at.
+DROP INDEX IF EXISTS nexaas_memory.ix_pa_delivery_marker_pending;
+CREATE INDEX IF NOT EXISTS ix_pa_delivery_marker_pending
+  ON nexaas_memory.pa_delivery_marker (workspace, status, release_at, claimed_at)
+  WHERE status IN ('queued', 'failed');

--- a/packages/runtime/src/api/pa-notify.ts
+++ b/packages/runtime/src/api/pa-notify.ts
@@ -221,12 +221,17 @@ export interface ExecuteDeps {
    * Auto-called by executePaNotify after writePendingDrawer succeeds, so
    * any workspace consumer using the framework's delivery helpers picks
    * up the row without a separate enqueue step.
+   *
+   * `urgency` flows through to release_at gating — immediate releases
+   * now; normal holds for the configured window; low releases at the
+   * next configured wall-clock time.
    */
   enqueueDeliveryMarker: (entry: {
     workspace: string;
     drawerId: string;
     user: string;
     threadId: string;
+    urgency: "immediate" | "normal" | "low";
   }) => Promise<void>;
   /**
    * Write the audit drawer to `inbox/<user>/notifications-emitted`. The PA
@@ -351,6 +356,7 @@ export async function executePaNotify(
       drawerId: drawer_id,
       user: input.user,
       threadId: input.threadId,
+      urgency: input.urgency,
     });
   } catch (err) {
     console.error("[nexaas] pa-notify delivery marker insert failed (non-fatal):", err);
@@ -483,7 +489,7 @@ export function defaultPaNotifyDeps(workspace: string): ExecuteDeps {
       return { drawer_id: rows[0]!.id };
     },
     enqueueDeliveryMarker: async (entry) => {
-      await enqueueDelivery(entry.workspace, entry.drawerId, entry.user, entry.threadId);
+      await enqueueDelivery(entry.workspace, entry.drawerId, entry.user, entry.threadId, entry.urgency);
     },
     writeAuditDrawer: async (entry) => {
       await sql(

--- a/packages/runtime/src/pa/delivery.ts
+++ b/packages/runtime/src/pa/delivery.ts
@@ -35,6 +35,50 @@ const MAX_RETRIES = (() => {
  *  abandoned by a dead consumer and gets reset to 'failed' for re-pickup. */
 const STALE_CLAIM_INTERVAL = "2 minutes";
 
+/** Hold duration for normal-tier notifications before they become
+ *  claimable. Lets workspaces batch/digest if they choose; the framework
+ *  primitive just enforces the hold. */
+const NORMAL_HOLD_MINUTES = (() => {
+  const raw = parseInt(process.env.NEXAAS_PA_NORMAL_HOLD_MINUTES ?? "15", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 15;
+})();
+
+/** Wall-clock release point for low-tier notifications. Two env vars so
+ *  ops can shift the morning rollup independently of the dispatcher tick. */
+const LOW_RELEASE_HOUR = (() => {
+  const raw = parseInt(process.env.NEXAAS_PA_LOW_RELEASE_HOUR ?? "7", 10);
+  return Number.isFinite(raw) && raw >= 0 && raw <= 23 ? raw : 7;
+})();
+const LOW_RELEASE_MINUTE = (() => {
+  const raw = parseInt(process.env.NEXAAS_PA_LOW_RELEASE_MINUTE ?? "30", 10);
+  return Number.isFinite(raw) && raw >= 0 && raw <= 59 ? raw : 30;
+})();
+
+export type Urgency = "immediate" | "normal" | "low";
+
+/**
+ * Compute the release timestamp for a marker given its urgency tier.
+ * `immediate` → now (released right away). `normal` → now + hold.
+ * `low` → next occurrence of the configured release hour/minute in
+ * the worker's local timezone. Exported for tests; not part of the
+ * stable runtime API.
+ */
+export function computeReleaseAt(urgency: Urgency, now: Date = new Date()): Date {
+  if (urgency === "immediate") return now;
+  if (urgency === "normal") {
+    return new Date(now.getTime() + NORMAL_HOLD_MINUTES * 60_000);
+  }
+  // low → next wall-clock occurrence of LOW_RELEASE_HOUR:MINUTE in
+  // local timezone. If we've already passed it today, schedule for
+  // tomorrow.
+  const target = new Date(now);
+  target.setHours(LOW_RELEASE_HOUR, LOW_RELEASE_MINUTE, 0, 0);
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1);
+  }
+  return target;
+}
+
 export interface DeliveryClaim {
   workspace: string;
   drawer_id: string;
@@ -49,19 +93,27 @@ export interface DeliveryClaim {
  * Insert a marker row for a pending delivery. Idempotent — re-running
  * with the same drawer_id is a no-op (allows the caller to safely
  * retry after a transient db failure).
+ *
+ * The marker's release_at is computed from the urgency tier so
+ * claimNextDelivery can gate dispatch without the consumer having to
+ * implement tier-aware scheduling itself. `immediate` releases now;
+ * `normal` holds for the configured window; `low` releases at the next
+ * configured wall-clock time.
  */
 export async function enqueueDelivery(
   workspace: string,
   drawer_id: string,
   user_hall: string,
   thread_id: string,
+  urgency: Urgency = "normal",
 ): Promise<void> {
+  const releaseAt = computeReleaseAt(urgency);
   await sql(
     `INSERT INTO nexaas_memory.pa_delivery_marker
-       (workspace, drawer_id, user_hall, thread_id, status)
-     VALUES ($1, $2, $3, $4, 'queued')
+       (workspace, drawer_id, user_hall, thread_id, status, release_at)
+     VALUES ($1, $2, $3, $4, 'queued', $5)
      ON CONFLICT (workspace, drawer_id) DO NOTHING`,
-    [workspace, drawer_id, user_hall, thread_id],
+    [workspace, drawer_id, user_hall, thread_id, releaseAt],
   );
 }
 
@@ -92,6 +144,7 @@ export async function claimNextDelivery(
           AND thread_id = $3
           AND status IN ('queued', 'failed')
           AND retries < $4
+          AND release_at <= now()
         ORDER BY claimed_at ASC
         FOR UPDATE SKIP LOCKED
         LIMIT 1

--- a/scripts/test-pa-urgency-release.mjs
+++ b/scripts/test-pa-urgency-release.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Regression test for urgency-tier release gating (#123 Wave 2.4).
+ *
+ * Verifies that enqueueDelivery picks the right release_at per urgency
+ * tier and that claimNextDelivery refuses to surface held rows.
+ *
+ * Pure helpers are tested with computeReleaseAt; the integration
+ * (immediate is claimable now / normal is held / past-release becomes
+ * claimable) runs against a real Postgres.
+ *
+ * Run:
+ *   DATABASE_URL=postgresql://nexaas_test:test@127.0.0.1/pa_delivery_test \
+ *     NEXAAS_PA_NORMAL_HOLD_MINUTES=15 \
+ *     NEXAAS_PA_LOW_RELEASE_HOUR=7 \
+ *     NEXAAS_PA_LOW_RELEASE_MINUTE=30 \
+ *     node --import tsx scripts/test-pa-urgency-release.mjs
+ */
+
+import {
+  enqueueDelivery,
+  claimNextDelivery,
+  computeReleaseAt,
+} from "../packages/runtime/src/pa/delivery.ts";
+import { sql, getPool } from "../packages/palace/src/db.ts";
+import { randomUUID } from "crypto";
+
+const WORKSPACE = `test-${Date.now()}`;
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+async function insertDrawer(workspace, user, thread) {
+  const id = randomUUID();
+  await sql(
+    `INSERT INTO nexaas_memory.events
+       (id, workspace, wing, hall, room, content, event_type, agent_id, normalize_version)
+     VALUES ($1, $2, 'notifications', 'pending', $3, '{}', 'drawer', 'test', 1)`,
+    [id, workspace, `pa-routed.${thread}`, ],
+  );
+  return id;
+}
+
+async function releaseAtOf(workspace, drawerId) {
+  const rows = await sql(
+    `SELECT release_at FROM nexaas_memory.pa_delivery_marker
+       WHERE workspace = $1 AND drawer_id = $2`,
+    [workspace, drawerId],
+  );
+  return rows[0]?.release_at ?? null;
+}
+
+// ── 1. computeReleaseAt — pure helper ──────────────────────────────
+console.log("\n1. computeReleaseAt picks the right wall clock per tier");
+{
+  const now = new Date("2026-05-15T10:00:00Z");
+  const immediate = computeReleaseAt("immediate", now);
+  assert(immediate.getTime() === now.getTime(), "immediate releases now");
+
+  const normal = computeReleaseAt("normal", now);
+  const expectedNormal = new Date("2026-05-15T10:15:00Z");
+  assert(normal.getTime() === expectedNormal.getTime(),
+    `normal releases now + 15min (got ${normal.toISOString()})`);
+
+  // For low: depends on local-time hour/minute, so just check that
+  // it's in the future and at the configured minute.
+  const low = computeReleaseAt("low", now);
+  assert(low.getTime() > now.getTime(), "low releases in the future");
+  assert(low.getMinutes() === 30, `low at minute 30 (got ${low.getMinutes()})`);
+  assert(low.getHours() === 7, `low at hour 7 (got ${low.getHours()})`);
+
+  // If we're already past today's release time, schedule for tomorrow.
+  const past = new Date();
+  past.setHours(8, 0, 0, 0);
+  const lowFromPast = computeReleaseAt("low", past);
+  assert(lowFromPast.getTime() > past.getTime(),
+    "past today's release → scheduled for tomorrow");
+  assert(lowFromPast.getDate() !== past.getDate() || lowFromPast.getMonth() !== past.getMonth(),
+    "next day's date (different day from input)");
+}
+
+// ── 2. enqueueDelivery sets release_at per tier ────────────────────
+console.log("\n2. enqueueDelivery stores the right release_at");
+{
+  const dImm = await insertDrawer(WORKSPACE, "alice", "inbox");
+  await enqueueDelivery(WORKSPACE, dImm, "alice", "inbox", "immediate");
+  const rImm = await releaseAtOf(WORKSPACE, dImm);
+  assert(rImm.getTime() <= Date.now(), "immediate release_at ≤ now");
+
+  const dNorm = await insertDrawer(WORKSPACE, "alice", "inbox");
+  await enqueueDelivery(WORKSPACE, dNorm, "alice", "inbox", "normal");
+  const rNorm = await releaseAtOf(WORKSPACE, dNorm);
+  const heldFor = rNorm.getTime() - Date.now();
+  // Allow ±2s margin for clock + insert latency.
+  assert(heldFor > 14 * 60_000 && heldFor < 16 * 60_000,
+    `normal held ~15min (got ${Math.round(heldFor / 1000)}s)`);
+
+  const dLow = await insertDrawer(WORKSPACE, "alice", "inbox");
+  await enqueueDelivery(WORKSPACE, dLow, "alice", "inbox", "low");
+  const rLow = await releaseAtOf(WORKSPACE, dLow);
+  assert(rLow.getTime() > Date.now(),
+    "low release_at is in the future");
+}
+
+// ── 3. claimNextDelivery refuses to surface held rows ──────────────
+console.log("\n3. Held rows are invisible to claimNextDelivery");
+{
+  // Clean slate for bob.
+  await sql(`DELETE FROM nexaas_memory.pa_delivery_marker WHERE workspace = $1 AND user_hall = 'bob'`, [WORKSPACE]);
+
+  const dNorm = await insertDrawer(WORKSPACE, "bob", "inbox");
+  await enqueueDelivery(WORKSPACE, dNorm, "bob", "inbox", "normal");
+  const claim1 = await claimNextDelivery(WORKSPACE, "bob", "inbox");
+  assert(claim1 === null, "normal-held row not claimable yet");
+
+  const dImm = await insertDrawer(WORKSPACE, "bob", "inbox");
+  await enqueueDelivery(WORKSPACE, dImm, "bob", "inbox", "immediate");
+  const claim2 = await claimNextDelivery(WORKSPACE, "bob", "inbox");
+  assert(claim2 !== null, "immediate row IS claimable");
+  assert(claim2.drawer_id === dImm, "claimed the immediate row, not the held normal");
+
+  // Second claim should return null — only one row was eligible.
+  const claim3 = await claimNextDelivery(WORKSPACE, "bob", "inbox");
+  assert(claim3 === null, "no more claimable rows (normal still held)");
+}
+
+// ── 4. Past-release row becomes claimable ──────────────────────────
+console.log("\n4. Row becomes claimable once release_at passes");
+{
+  await sql(`DELETE FROM nexaas_memory.pa_delivery_marker WHERE workspace = $1 AND user_hall = 'carol'`, [WORKSPACE]);
+
+  const dNorm = await insertDrawer(WORKSPACE, "carol", "inbox");
+  await enqueueDelivery(WORKSPACE, dNorm, "carol", "inbox", "normal");
+
+  const claimHeld = await claimNextDelivery(WORKSPACE, "carol", "inbox");
+  assert(claimHeld === null, "fresh normal is held");
+
+  // Backdate release_at to simulate time passing.
+  await sql(
+    `UPDATE nexaas_memory.pa_delivery_marker
+        SET release_at = now() - interval '1 minute'
+      WHERE workspace = $1 AND drawer_id = $2`,
+    [WORKSPACE, dNorm],
+  );
+  const claimReleased = await claimNextDelivery(WORKSPACE, "carol", "inbox");
+  assert(claimReleased?.drawer_id === dNorm, "row is claimable after release_at passes");
+}
+
+// ── 5. Default urgency parameter preserves backwards-compat ────────
+console.log("\n5. Default urgency = 'normal' keeps existing callers safe");
+{
+  await sql(`DELETE FROM nexaas_memory.pa_delivery_marker WHERE workspace = $1 AND user_hall = 'dave'`, [WORKSPACE]);
+
+  const drawer = await insertDrawer(WORKSPACE, "dave", "inbox");
+  // Old call shape (no urgency arg) → defaults to 'normal' → held.
+  await enqueueDelivery(WORKSPACE, drawer, "dave", "inbox");
+  const claim = await claimNextDelivery(WORKSPACE, "dave", "inbox");
+  assert(claim === null, "default-urgency caller gets normal-tier hold");
+}
+
+// Cleanup
+await sql(`DELETE FROM nexaas_memory.events WHERE workspace = $1`, [WORKSPACE]);
+await sql(`DELETE FROM nexaas_memory.pa_delivery_marker WHERE workspace = $1`, [WORKSPACE]);
+await getPool().end();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Part of #123 (Wave 2.4). Lands the framework primitive for urgency-tier scheduling so workspace delivery consumers see tier-aware drain for free — without the framework dictating render policy, digest assembly, or channel-specific buzz semantics.

Design hash-out preceded the PR: the smallest useful primitive is a single \`release_at\` column on \`pa_delivery_marker\`, gated by \`claimNextDelivery\`. Everything else (digests, backlog promotion, buzz/silent, per-user release times) stays workspace policy.

## Tier → release_at mapping

| Tier | release_at |
|---|---|
| \`immediate\` | \`now()\` — released right away |
| \`normal\` | \`now() + NEXAAS_PA_NORMAL_HOLD_MINUTES\` (default 15 min) |
| \`low\` | next \`NEXAAS_PA_LOW_RELEASE_HOUR:MINUTE\` wall-clock (default 07:30 local) |

Computed at enqueue time in \`computeReleaseAt(urgency, now)\`. Pure function, exported for tests, not part of the stable runtime API.

## Helper changes

- \`enqueueDelivery\` signature gains a trailing \`urgency: Urgency = \"normal\"\` parameter. Existing callers without the arg default to normal-tier (15-min hold), which is reasonable conservative behavior.
- \`claimNextDelivery\` adds \`AND release_at <= now()\` to its WHERE clause. Held rows become invisible to consumers; once the timestamp passes, the row surfaces naturally.
- \`ExecuteDeps.enqueueDeliveryMarker\` interface gains \`urgency\`; \`executePaNotify\` passes \`input.urgency\` through.

## Migration

\`database/migrations/023_pa_delivery_release_at.sql\` — adds \`release_at timestamptz NOT NULL DEFAULT now()\` and replaces \`ix_pa_delivery_marker_pending\` with one that includes the new column so claim queries stay index-only.

Existing rows from before the migration default to \"release immediately\" — backwards-compatible for any workspace consumer already draining the table.

## Env vars

Documented in CLAUDE.md:

- \`NEXAAS_PA_NORMAL_HOLD_MINUTES\` — default 15
- \`NEXAAS_PA_LOW_RELEASE_HOUR\` — default 7 (24-hour)
- \`NEXAAS_PA_LOW_RELEASE_MINUTE\` — default 30

## What this primitive deliberately does NOT do

| Concern | Why workspace, not framework |
|---|---|
| Digest assembly (combining N held notifications into one outbound) | Render is workspace's job; channel-specific |
| Backlog promotion (\"2+ normals → release both early\") | Policy depends on workspace traffic pattern |
| Phone-buzz vs silent | Channel-specific (e.g. Telegram \`disable_notification\`) |
| Per-user / per-thread release times | YAGNI for v1; deferred until measured need |
| \`urgency\` column denormalization on the marker | YAGNI for v1; \`claimNextDelivery\` hides the tier entirely |

Workspaces that want any of those query \`pa_delivery_marker\` directly with their own scheduling logic; the framework just enforces the release_at gate.

## Test

\`scripts/test-pa-urgency-release.mjs\` — 17 assertions, 5 groups against a real Postgres:

1. \`computeReleaseAt\` picks the right wall clock per tier, including the past-today-rolls-to-tomorrow boundary
2. \`enqueueDelivery\` stores the right \`release_at\` (within ±2s tolerance for clock + insert latency)
3. Held normal-tier row is invisible to \`claimNextDelivery\`; immediate row IS claimable; second claim returns null (only one was eligible)
4. Row becomes claimable once \`release_at\` passes (test backdates \`release_at\` to simulate time passing)
5. Default urgency = \"normal\" keeps existing callers (no urgency arg) on the conservative path

Run:
\`\`\`
DATABASE_URL=postgresql://nexaas_test:test@127.0.0.1/pa_delivery_test \\
  node --import tsx scripts/test-pa-urgency-release.mjs
\`\`\`

→ \`17 passed, 0 failed\`.

## Counter-argument considered

If a workspace wants event-based holding (\"release when N events accumulate\" or \"release when an admin acks\") then \`release_at\` doesn't help. But the RFC explicitly calls for time-based holds (low → 07:30, normal → 15 min). Time-based is what's documented; that's what we ship. Event-based primitives can be added later if the need shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)