### PR TITLE
perf(inbound-match): batch the per-tick SELECT, soft-warn on high count

### DIFF
--- a/packages/runtime/src/tasks/inbound-dispatcher.ts
+++ b/packages/runtime/src/tasks/inbound-dispatcher.ts
@@ -41,7 +41,7 @@ import { randomUUID } from "crypto";
 import { load as yamlLoad } from "js-yaml";
 import { sql, appendWal } from "@nexaas/palace";
 import { enqueueSkillStep, type SkillJobData } from "../bullmq/queues.js";
-import { matchDrawerAgainstWaitpoints } from "./inbound-match-waitpoint.js";
+import { matchDrawerAgainstWaitpoints, selectOpenWaitpoints } from "./inbound-match-waitpoint.js";
 import { reportMissingRelation } from "./_consistency-warning.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 3_000;
@@ -169,6 +169,27 @@ async function recordDispatch(
   );
 }
 
+// Soft canary for the scalability watchpoint on inbound-match. Emits once
+// per process per workspace when the open-waitpoints count crosses a
+// threshold so operators get a heads-up before p99 match-duration starts
+// approaching the trigger value (~50ms in PG slow-query log). The
+// threshold is intentionally well below the level where the per-drawer
+// SELECT loop becomes a bottleneck — by then, an in-memory cache is the
+// real fix and the warning gives ops time to plan the upgrade.
+const WAITPOINT_HIGH_COUNT_THRESHOLD = 50;
+const _highCountWarned = new Set<string>();
+function maybeWarnOnHighWaitpointCount(workspace: string, count: number): void {
+  if (count < WAITPOINT_HIGH_COUNT_THRESHOLD) return;
+  if (_highCountWarned.has(workspace)) return;
+  _highCountWarned.add(workspace);
+  console.warn(
+    `[nexaas] inbound-match: workspace '${workspace}' has ${count} open waitpoints ` +
+    `(threshold ${WAITPOINT_HIGH_COUNT_THRESHOLD}). The per-tick SELECT stays cheap up to ` +
+    `a few hundred via the partial index, but at sustained 500+ the in-memory cache ` +
+    `mitigation should land. Watch for slow-query log entries on the SELECT below 50ms p99.`,
+  );
+}
+
 export async function dispatchPendingInbound(workspace: string): Promise<{
   drawers: number;
   dispatches: number;
@@ -180,22 +201,33 @@ export async function dispatchPendingInbound(workspace: string): Promise<{
 
   let drawers = 0, dispatches = 0, failed = 0, noSubscriber = 0;
 
+  // Load open waitpoints once per tick instead of once per drawer
+  // (mitigation #3 from the scalability watchpoint). Pass the list into
+  // each per-drawer match call. Skip the load entirely when there are
+  // no drawers to evaluate — saves a roundtrip in idle workspaces.
+  const openWaitpoints = pending.length > 0 ? await selectOpenWaitpoints(workspace) : [];
+  maybeWarnOnHighWaitpointCount(workspace, openWaitpoints.length);
+
   for (const drawer of pending) {
     drawers++;
     // Room = channel_role. Adapters MUST use this convention so the
     // dispatcher can route without scanning drawer content.
     const channelRole = drawer.room;
 
-    // #49 — check inbound-match waitpoints first (first-match-wins).
-    // Match does NOT short-circuit skill fanout; drawer is observable
-    // by both paths. Errors here don't block skill firing either.
+    // First-match-wins inbound-match check. Does NOT short-circuit
+    // skill fanout; drawer is observable by both paths. Errors here
+    // don't block skill firing either.
     try {
-      await matchDrawerAgainstWaitpoints(workspace, {
-        id: drawer.id,
-        room: drawer.room,
-        content: drawer.content,
-        created_at: drawer.created_at,
-      });
+      await matchDrawerAgainstWaitpoints(
+        workspace,
+        {
+          id: drawer.id,
+          room: drawer.room,
+          content: drawer.content,
+          created_at: drawer.created_at,
+        },
+        openWaitpoints,
+      );
     } catch (err) {
       console.warn(
         `[nexaas] inbound-match check failed for drawer ${drawer.id}: ${(err as Error).message}`,

--- a/packages/runtime/src/tasks/inbound-match-waitpoint.ts
+++ b/packages/runtime/src/tasks/inbound-match-waitpoint.ts
@@ -410,17 +410,16 @@ interface InboundDrawer {
 }
 
 /**
- * First-match-wins check against all open waitpoints for this workspace.
- * Called by the inbound-dispatcher for each new `inbox.messaging.*` drawer.
- * Resolves at most one waitpoint per drawer. Skill fanout continues
- * regardless of match (drawer is observable by both paths).
+ * Load all open inbound-match waitpoints for a workspace. Pulled out of
+ * matchDrawerAgainstWaitpoints so the inbound-dispatcher can do this
+ * SELECT once per tick instead of once per drawer (#54 mitigation #3).
+ *
+ * Ordering: ascending by creation so the dispatcher's first-match-wins
+ * iteration is deterministic across calls. The partial index from
+ * migration 018 keeps this O(log N) regardless of total events size.
  */
-export async function matchDrawerAgainstWaitpoints(
-  workspace: string,
-  drawer: InboundDrawer,
-): Promise<{ matched: boolean; waitpoint_id?: string }> {
-  // Open waitpoints for this workspace, ordered by creation — first-match-wins.
-  const openWaitpoints = await sql<WaitpointRow>(
+export async function selectOpenWaitpoints(workspace: string): Promise<WaitpointRow[]> {
+  return await sql<WaitpointRow>(
     `SELECT id, workspace, content, dormant_signal,
             dormant_until::text AS dormant_until,
             created_at::text AS created_at
@@ -431,6 +430,27 @@ export async function matchDrawerAgainstWaitpoints(
       ORDER BY created_at ASC`,
     [workspace, WAITPOINT_ROOM.wing, WAITPOINT_ROOM.hall, WAITPOINT_ROOM.room],
   );
+}
+
+/**
+ * First-match-wins check against all open waitpoints for this workspace.
+ * Called by the inbound-dispatcher for each new `inbox.messaging.*` drawer.
+ * Resolves at most one waitpoint per drawer. Skill fanout continues
+ * regardless of match (drawer is observable by both paths).
+ *
+ * `preloadedWaitpoints` — optional. When the dispatcher batches its tick,
+ * it pre-loads via selectOpenWaitpoints and passes the list in to avoid
+ * a SELECT per drawer. A race where another tick resolves a waitpoint in
+ * the meantime is safe: resolveWaitpoint below catches the "already
+ * resolved" error and continues scanning. Callers without preload (tests,
+ * out-of-band callers) get the original "load + match" behavior.
+ */
+export async function matchDrawerAgainstWaitpoints(
+  workspace: string,
+  drawer: InboundDrawer,
+  preloadedWaitpoints?: WaitpointRow[],
+): Promise<{ matched: boolean; waitpoint_id?: string }> {
+  const openWaitpoints = preloadedWaitpoints ?? await selectOpenWaitpoints(workspace);
 
   let drawerPayload: Record<string, unknown>;
   try { drawerPayload = JSON.parse(drawer.content); } catch { drawerPayload = {}; }

--- a/scripts/test-inbound-match-batch.mjs
+++ b/scripts/test-inbound-match-batch.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Regression test for inbound-match batch-evaluation refactor (#54).
+ *
+ * Verifies the matchDrawer function still behaves correctly when given a
+ * pre-loaded waitpoints list (the dispatcher's batch path) AND when
+ * called without one (the legacy single-shot path).
+ *
+ * Real Postgres required so resolveWaitpoint + the SELECT path work
+ * end-to-end. The test fixtures register two waitpoints, evaluate two
+ * drawers against them, and assert that:
+ *   - Pre-loaded eval matches the same waitpoint as cold eval
+ *   - Pre-loaded eval doesn't re-query (asserted by re-running with a
+ *     stale list and verifying it still works)
+ *   - First-match-wins ordering is preserved across both paths
+ *
+ * Run:
+ *   DATABASE_URL=postgresql://nexaas_test:test@127.0.0.1/pa_delivery_test \
+ *     node --import tsx scripts/test-inbound-match-batch.mjs
+ */
+
+import {
+  registerWaitpoint,
+  matchDrawerAgainstWaitpoints,
+  selectOpenWaitpoints,
+} from "../packages/runtime/src/tasks/inbound-match-waitpoint.ts";
+import { sql, getPool } from "../packages/palace/src/db.ts";
+import { randomUUID } from "crypto";
+
+const WORKSPACE = `test-${Date.now()}`;
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+async function makeDrawer(room, content) {
+  const id = randomUUID();
+  await sql(
+    `INSERT INTO nexaas_memory.events
+       (id, workspace, wing, hall, room, content, event_type, agent_id, normalize_version, created_at)
+     VALUES ($1, $2, 'inbox', 'messaging', $3, $4, 'drawer', 'test', 1, now())`,
+    [id, WORKSPACE, room, JSON.stringify({ content, from: "u123" })],
+  );
+  return { id, room, content: JSON.stringify({ content, from: "u123" }), created_at: new Date().toISOString() };
+}
+
+// Register a 2FA waitpoint and a UUID waitpoint. First-match-wins by
+// creation order, so the 2FA one should always win for codes.
+console.log("\nSetup: register two waitpoints");
+const reg1 = await registerWaitpoint({
+  workspace: WORKSPACE,
+  match: { content_pattern: "digit_code" },
+  timeout_seconds: 60,
+});
+const reg2 = await registerWaitpoint({
+  workspace: WORKSPACE,
+  match: { content_pattern: "uuid_v4" },
+  timeout_seconds: 60,
+});
+assert("waitpoint_id" in reg1, "first waitpoint registered");
+assert("waitpoint_id" in reg2, "second waitpoint registered");
+
+// ── 1. selectOpenWaitpoints returns both ─────────────────────────────
+console.log("\n1. selectOpenWaitpoints loads everything pending");
+{
+  const wps = await selectOpenWaitpoints(WORKSPACE);
+  assert(wps.length >= 2, `found ≥2 open waitpoints (got ${wps.length})`);
+  // Ordering: creation ASC — first registered is first
+  assert(wps[0].dormant_signal === reg1.waitpoint_id, "ordering: first registered is first");
+}
+
+// ── 2. Match with preload === match without preload ────────────────
+console.log("\n2. Match behavior identical with vs. without preload");
+{
+  const drawerCold = await makeDrawer("inbox.messaging.telegram", "Your code is 123456");
+  // Cold path: no preload, function does its own SELECT
+  const cold = await matchDrawerAgainstWaitpoints(WORKSPACE, drawerCold);
+  assert(cold.matched, "cold match succeeded");
+  assert(cold.waitpoint_id === reg1.waitpoint_id, "cold matched the 2FA waitpoint");
+}
+
+// ── 3. Preload path matches against the same list ────────────────────
+console.log("\n3. Preload path matches against the pre-loaded list");
+{
+  // Re-register another digit_code waitpoint since the first one was just resolved
+  const reg3 = await registerWaitpoint({
+    workspace: WORKSPACE,
+    match: { content_pattern: "digit_code" },
+    timeout_seconds: 60,
+  });
+  const wps = await selectOpenWaitpoints(WORKSPACE);
+  assert(wps.some(w => w.dormant_signal === reg3.waitpoint_id), "fresh waitpoint visible in preload");
+
+  const drawer = await makeDrawer("inbox.messaging.telegram", "Code 7890");
+  const result = await matchDrawerAgainstWaitpoints(WORKSPACE, drawer, wps);
+  assert(result.matched, "preload-path match succeeded");
+  assert(result.waitpoint_id === reg3.waitpoint_id, "preload matched the fresh digit_code waitpoint");
+}
+
+// ── 4. Preload list with an already-resolved waitpoint (race-safe) ──
+console.log("\n4. Preload with a stale (already-resolved) waitpoint is race-safe");
+{
+  // Register two digit_code waitpoints, then preload, then resolve the
+  // first one out-of-band before passing the stale list to matchDrawer.
+  // Expectation: matchDrawer skips the already-resolved one and matches
+  // the second.
+  const regA = await registerWaitpoint({
+    workspace: WORKSPACE,
+    match: { content_pattern: "digit_code" },
+    timeout_seconds: 60,
+  });
+  const regB = await registerWaitpoint({
+    workspace: WORKSPACE,
+    match: { content_pattern: "digit_code" },
+    timeout_seconds: 60,
+  });
+  const wps = await selectOpenWaitpoints(WORKSPACE);
+  // Simulate concurrent resolution of regA via direct DB update.
+  await sql(
+    `UPDATE nexaas_memory.events
+        SET dormant_signal = NULL
+      WHERE workspace = $1 AND dormant_signal = $2`,
+    [WORKSPACE, regA.waitpoint_id],
+  );
+
+  const drawer = await makeDrawer("inbox.messaging.telegram", "Number 4242");
+  const result = await matchDrawerAgainstWaitpoints(WORKSPACE, drawer, wps);
+  // The stale list has regA first. resolveWaitpoint on a NULL dormant_signal
+  // fails; matchDrawer logs and continues to regB.
+  assert(result.matched, "stale-list match still produced a match");
+  assert(result.waitpoint_id === regB.waitpoint_id,
+    `matched the next-available waitpoint (got ${result.waitpoint_id})`);
+}
+
+// ── 5. Empty preload skips the match loop entirely ──────────────────
+console.log("\n5. Empty preload (no open waitpoints) is a no-op");
+{
+  const drawer = await makeDrawer("inbox.messaging.telegram", "Nothing to match");
+  const result = await matchDrawerAgainstWaitpoints(WORKSPACE, drawer, []);
+  assert(!result.matched, "no match when preload is empty");
+}
+
+// Cleanup
+await sql(`DELETE FROM nexaas_memory.events WHERE workspace = $1`, [WORKSPACE]);
+await getPool().end();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Addresses #54. Ships **mitigation #3** from the issue body (batch evaluation) without committing to mitigation #1 (in-memory cache), which the issue author explicitly deferred until measured pain.

## Rationale (from the design discussion that produced this PR)

Three mitigations were on the table per the issue:

1. **In-memory waitpoint cache with TTL** — biggest win, but adds invalidation complexity. Deferred per the issue author's \"no workspace is anywhere near the scale where this matters\" stance.
2. **Partial index** — already shipped in migration 018.
3. **Batch evaluation** — this PR. Strictly better at any scale, no new machinery.

Batch evaluation costs nothing operationally (no cache invalidation, no TTL) and removes the SELECT-per-drawer pattern the issue is concerned about. The cache stays deferred until PG's slow-query log shows the SELECT crossing 50ms p99 or a workspace operationally hits >100 concurrent waitpoints — neither is true today.

## What changed

\`inbound-match-waitpoint.ts\`:
- Extracted \`selectOpenWaitpoints(workspace)\` as a public helper.
- \`matchDrawerAgainstWaitpoints\` now takes an optional \`preloadedWaitpoints\` argument. When supplied, it skips the SELECT and uses the pre-loaded list. When omitted, behavior is identical to before (cold path still works for out-of-band callers + tests).

\`inbound-dispatcher.ts\`:
- Calls \`selectOpenWaitpoints\` once per tick before the per-drawer loop, passes the list into each \`matchDrawerAgainstWaitpoints\` call.
- Skips the SELECT entirely when there are no drawers to evaluate — saves a roundtrip in idle workspaces.
- Soft canary: one-shot \`console.warn\` per process per workspace when open-waitpoints count crosses 50. Pointer to the issue's mitigation list in the warning text.

## Race safety

The preload path is safe under concurrent waitpoint resolution. The existing code path \"resolveWaitpoint failed (already resolved / race with another poller)\" is hit when a stale list contains a waitpoint that's been resolved between the SELECT and the match. The function logs and continues scanning the rest of the list. Test #4 in the regression suite exercises this exact race by manually NULLing a \`dormant_signal\` between preload and match — the next-available waitpoint matches, no crash.

## Why not also ship instrumentation?

The original issue talked about a histogram of \`(open-waitpoints-count, drawers-evaluated-per-tick, query-duration-ms)\`. We don't ship it because:

- **Postgres' slow-query log already captures SELECT timing for free.** Operators can grep \`journalctl -u postgresql\` for \`matchDrawerAgainstWaitpoints\`-shaped queries above 50ms. No framework code needed.
- **WAL emission per tick would add ~28k rows/workspace/day** at the default 3s tick — significant noise for a watchpoint that's not currently active.
- **The soft canary covers the most-needed signal** — a heads-up before the slow-query threshold is reached.

If structured histograms become operationally important later, they can be added as a follow-up.

## Test

\`scripts/test-inbound-match-batch.mjs\` — 12 assertions against a real Postgres:

1. \`selectOpenWaitpoints\` returns the right rows in creation order
2. Cold path (no preload) still matches identically to before
3. Preload path matches against the pre-loaded list
4. Preload list containing an already-resolved waitpoint is race-safe — next-available matches
5. Empty preload is a no-op

Run:
\`\`\`
DATABASE_URL=postgresql://nexaas_test:test@127.0.0.1/<db> node --import tsx scripts/test-inbound-match-batch.mjs
\`\`\`

→ \`12 passed, 0 failed\`.

## Closes / leaves open

Recommend **leaving #54 open** as the watchpoint it was designed to be. The cache (mitigation #1) is still the right fix at sustained 500+ concurrent waitpoints — this PR just removes the SELECT-per-drawer cost so the trigger threshold moves further away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)