### PR TITLE
fix(init): persist NEXAAS_WORKSPACE_ROOT to generated .env

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -216,12 +216,24 @@ export async function run(args: string[]) {
     if (voyageKey === "skip") voyageKey = "";
   }
 
+  // Workspace files (skills, MCP configs, manifests) live separately from
+  // the framework install. Default the workspace root to NEXAAS_ROOT for
+  // direct-adopter deployments where they're co-located; operator-managed
+  // deployments (Nexmatic) pre-export NEXAAS_WORKSPACE_ROOT to /home/<user>/
+  // <workspace>/ or similar before invoking init, and we persist whatever's
+  // in the process env. Critical for the worker's skill-trigger lookup at
+  // ${NEXAAS_WORKSPACE_ROOT}/nexaas-skills/<id>/skill.yaml — without this
+  // write, the env var is undefined at systemd-launch time and the worker
+  // falls back to /opt/nexaas, missing operator-placed skills.
+  const workspaceRoot = process.env.NEXAAS_WORKSPACE_ROOT ?? NEXAAS_ROOT;
+
   const envContent = `# Nexaas Framework Configuration
 # Generated: ${new Date().toISOString()}
 # Workspace: ${workspaceId}
 
 NEXAAS_WORKSPACE=${workspaceId}
 NEXAAS_ROOT=${NEXAAS_ROOT}
+NEXAAS_WORKSPACE_ROOT=${workspaceRoot}
 DATABASE_URL=${databaseUrl}
 REDIS_URL=redis://localhost:6379
 


### PR DESCRIPTION
Surfaced while investigating Nexmatic#6 (fresh-workspace skills 404 from \`/api/skills/trigger\`).

## The bug

The worker resolves skill manifests at \`\${NEXAAS_WORKSPACE_ROOT}/nexaas-skills/<id>/skill.yaml\` (see \`packages/runtime/src/api/skills-trigger.ts:79\` and the worker's scheduler self-heal in \`worker.ts:208-210\`). When the env var is unset, both fall back to \`/opt/nexaas\`.

\`nexaas init\` generates \`.env\` without that var — only \`NEXAAS_ROOT\`, \`NEXAAS_WORKSPACE\`, \`DATABASE_URL\`, \`REDIS_URL\`, model API keys, and the worker port. So on a systemd-launched worker, \`NEXAAS_WORKSPACE_ROOT\` is undefined and the worker looks at \`/opt/nexaas/nexaas-skills/\`.

Operator-managed deployments (Nexmatic) place skills under \`/home/<user>/<workspace>/nexaas-skills/\` (the separation between workspace files and framework install that the env-var docs in CLAUDE.md call for). The two paths never meet — every skill trigger returns 404.

## Fix

Read \`process.env.NEXAAS_WORKSPACE_ROOT\` at init time, default to \`NEXAAS_ROOT\` if unset, persist into the generated \`.env\`:

\`\`\`ts
const workspaceRoot = process.env.NEXAAS_WORKSPACE_ROOT ?? NEXAAS_ROOT;
\`\`\`

\`\`\`env
NEXAAS_WORKSPACE_ROOT=\${workspaceRoot}
\`\`\`

## Two deployment shapes this covers

- **Direct-adopter** (workspace co-located with framework install): \`NEXAAS_WORKSPACE_ROOT\` not pre-exported → defaults to \`/opt/nexaas\` → matches existing behavior on Phoenix and other direct-adopters. No change for them.
- **Operator-managed** (Nexmatic): \`deploy-instance.sh\` pre-exports \`NEXAAS_WORKSPACE_ROOT=\${WORKSPACE_ROOT}\` before invoking init → that value gets persisted → systemd-launched worker sees it → skill triggers resolve to the right path. Nexmatic-side companion change tracked in their repo.

## Test plan

- [x] \`npx tsc --noEmit\` in \`packages/cli\` — clean
- [ ] Direct-adopter: run \`nexaas init\` on a fresh box with no \`NEXAAS_WORKSPACE_ROOT\` pre-set → \`.env\` contains \`NEXAAS_WORKSPACE_ROOT=/opt/nexaas\` (preserving current behavior)
- [ ] Operator-managed: \`NEXAAS_WORKSPACE_ROOT=/home/ubuntu/foo nexaas init\` → \`.env\` contains \`NEXAAS_WORKSPACE_ROOT=/home/ubuntu/foo\`
- [ ] Worker restart picks up the new value from systemd's \`EnvironmentFile\` directive

## Out of scope

There's a parallel bug in the trigger resolver itself — it hardcodes \`skill.yaml\` while \`register-skill\` accepts \`contract.yaml\` natively (PR #141). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)