### PR TITLE
fix(skills-trigger): accept contract.yaml alongside skill.yaml

### DIFF
--- a/packages/runtime/src/api/skills-trigger.ts
+++ b/packages/runtime/src/api/skills-trigger.ts
@@ -57,15 +57,21 @@ export interface ManifestSlim {
   execution?: { type?: string };
 }
 
+/** Canonical manifest filenames in resolution order. `skill.yaml` is the
+ *  legacy framework name; `contract.yaml` is the format register-skill
+ *  accepts natively as of #139/#141. Both are valid storage shapes — the
+ *  trigger lookup needs to find whichever one the skill author ships. */
+const MANIFEST_FILENAMES = ["skill.yaml", "contract.yaml"] as const;
+
 /**
  * Resolve a skill_id into an absolute manifest path under the workspace's
  * skills root, rejecting any input that would escape the root.
  *
- * Matches the convention used by `nexaas register-skill` and the worker's
- * scheduler self-heal: `<root>/nexaas-skills/<category>/<name>/skill.yaml`.
- *
- * Returns null for inputs that look like path-traversal attempts. The
- * caller surfaces a 400; we don't try to be clever about partial matches.
+ * Returns the first existing manifest file from MANIFEST_FILENAMES at
+ * `<root>/nexaas-skills/<category>/<name>/`. Falls back to the first
+ * candidate (skill.yaml) if neither exists so the caller's 404 message
+ * names a sensible path. Returns null only for path-traversal attempts
+ * (caller surfaces a 400).
  */
 export function resolveSkillManifestPath(
   skillId: string,
@@ -76,14 +82,20 @@ export function resolveSkillManifestPath(
   if (!/^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/.test(skillId)) return null;
 
   const skillsRoot = resolve(workspaceRoot, "nexaas-skills");
-  const candidate = resolve(skillsRoot, skillId, "skill.yaml");
+  const skillDir = resolve(skillsRoot, skillId);
 
   // Defense in depth — even though the regex above blocks `..`, verify
   // the resolved path is genuinely under the skills root before touching
   // the filesystem. Catches e.g. symlinked categories.
-  if (!candidate.startsWith(skillsRoot + sep)) return null;
+  if (!skillDir.startsWith(skillsRoot + sep)) return null;
 
-  return candidate;
+  for (const filename of MANIFEST_FILENAMES) {
+    const candidate = resolve(skillDir, filename);
+    if (existsSync(candidate)) return candidate;
+  }
+  // Neither variant exists — return the legacy name so the 404 message
+  // points operators at the conventional location.
+  return resolve(skillDir, MANIFEST_FILENAMES[0]);
 }
 
 export function loadSkillManifest(path: string): ManifestSlim | null {


### PR DESCRIPTION
## Summary
- `/api/skills/trigger` only looked for `skill.yaml`; manual triggers 404'd on skills shipped as `contract.yaml` even though `nexaas register-skill` accepts that format natively (#139/#141).
- Resolution now tries both filenames in order; the 404 message still names the legacy path so operators have an actionable hint.

## Context
This is part 2 of three small PRs fixing the cross-repo "skill trigger 404 on fresh workspace" symptom (Nexmatic #6):
1. ✅ Nexaas #169 — `init.ts` writes `NEXAAS_WORKSPACE_ROOT` to generated `.env`
2. 🟢 **This PR** — `skills-trigger.ts` accepts `contract.yaml`
3. ⏳ Nexmatic — `deploy-instance.sh` exports `NEXAAS_WORKSPACE_ROOT` before `nexaas init`

Both `skill.yaml` and `contract.yaml` are legitimate manifest shapes; this aligns the HTTP trigger lookup with the register-skill lookup behaviour.

## Test plan
- [ ] Typecheck clean (`npx tsc --noEmit` in `packages/runtime`) — verified locally
- [ ] Manual: workspace shipping `contract.yaml` returns 202 from `/api/skills/trigger` instead of 404
- [ ] Manual: workspace shipping `skill.yaml` still resolves (regression check)
- [ ] Manual: invalid `skillId` still returns 400 (path-traversal guard unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)