### PR TITLE
fix(shell-skill): capture both streams + terminal_reason on every drawer

### DIFF
--- a/packages/runtime/src/shell-skill.ts
+++ b/packages/runtime/src/shell-skill.ts
@@ -14,6 +14,10 @@ import { spawn } from "child_process";
 import { palace, appendWal } from "@nexaas/palace";
 import { runTracker } from "./run-tracker.js";
 import { randomUUID } from "crypto";
+import {
+  buildTerminalDrawerPayload,
+  STREAM_PREVIEW_CAP_BYTES,
+} from "./skill-terminal.js";
 
 interface ShellRunResult {
   stdout: string;
@@ -181,7 +185,7 @@ export async function runShellSkill(
   try {
     const timeoutMs = (manifest.execution.timeout ?? 120) * 1000;
 
-    const { stdout } = await runShellWithGroupTimeout(
+    const { stdout, stderr } = await runShellWithGroupTimeout(
       manifest.execution.command,
       {
         cwd: manifest.execution.working_directory,
@@ -214,16 +218,20 @@ export async function runShellSkill(
 
     const durationMs = Date.now() - startTime;
 
-    // Write result drawer
+    // Capture BOTH streams on success too — scripts often emit non-fatal
+    // diagnostics (rate-limit retries, degraded-mode warnings) on stdout or
+    // stderr before exiting 0. Without symmetry the drawer hides whichever
+    // stream the script used (#171).
     const room = manifest.rooms?.primary ?? { wing: "operations", hall: "shell", room: manifest.id };
-    await session.writeDrawer(room, JSON.stringify({
-      skill: manifest.id,
-      command: manifest.execution.command,
-      success: true,
-      exit_code: 0,
-      duration_ms: durationMs,
-      stdout_preview: stdout.slice(0, 500),
-    }));
+    await session.writeDrawer(room, JSON.stringify(buildTerminalDrawerPayload(
+      { skill: manifest.id, terminal_reason: "ok", duration_ms: durationMs },
+      {
+        command: manifest.execution.command,
+        exit_code: 0,
+        stdout_preview: stdout.slice(0, STREAM_PREVIEW_CAP_BYTES),
+        stderr_preview: stderr.slice(0, STREAM_PREVIEW_CAP_BYTES),
+      },
+    )));
 
     await appendWal({
       workspace,
@@ -240,7 +248,7 @@ export async function runShellSkill(
     await runTracker.markStepCompleted(runId, stepId);
     await runTracker.markCompleted(runId);
 
-    return { success: true, exitCode: 0, stdout, stderr: "", durationMs };
+    return { success: true, exitCode: 0, stdout, stderr, durationMs };
   } catch (err: unknown) {
     const durationMs = Date.now() - startTime;
     // Promisified `exec` throws an error with `code` (exit code), `signal`,
@@ -258,15 +266,22 @@ export async function runShellSkill(
       ? execErr.code
       : (execErr.status ?? 1);
 
+    // `killed` is set by runShellWithGroupTimeout when the group-SIGKILL
+    // path fires. Treat that as a distinct terminal reason so the dashboard
+    // can render a "timed out" badge instead of a generic non-zero exit.
+    const killed = (execErr as { killed?: boolean }).killed === true;
+    const terminalReason = killed ? "timeout" : "failed";
+
     const room = manifest.rooms?.primary ?? { wing: "operations", hall: "shell", room: manifest.id };
-    await session.writeDrawer(room, JSON.stringify({
-      skill: manifest.id,
-      command: manifest.execution.command,
-      success: false,
-      exit_code: exitCode,
-      duration_ms: durationMs,
-      stderr_preview: (execErr.stderr ?? execErr.message ?? "").slice(0, 500),
-    }));
+    await session.writeDrawer(room, JSON.stringify(buildTerminalDrawerPayload(
+      { skill: manifest.id, terminal_reason: terminalReason, duration_ms: durationMs },
+      {
+        command: manifest.execution.command,
+        exit_code: exitCode,
+        stdout_preview: (execErr.stdout ?? "").slice(0, STREAM_PREVIEW_CAP_BYTES),
+        stderr_preview: (execErr.stderr ?? execErr.message ?? "").slice(0, STREAM_PREVIEW_CAP_BYTES),
+      },
+    )));
 
     await appendWal({
       workspace,
@@ -277,7 +292,8 @@ export async function runShellSkill(
         command: manifest.execution.command,
         exit_code: exitCode,
         duration_ms: durationMs,
-        error: (execErr.stderr ?? execErr.message ?? "").slice(0, 500),
+        terminal_reason: terminalReason,
+        error: (execErr.stderr ?? execErr.message ?? "").slice(0, STREAM_PREVIEW_CAP_BYTES),
       },
     });
 

--- a/packages/runtime/src/skill-terminal.ts
+++ b/packages/runtime/src/skill-terminal.ts
@@ -1,0 +1,79 @@
+/**
+ * Terminal-drawer contract — every skill run, whatever its outcome, MUST
+ * produce a drawer that names *why* it ended. This file owns the discriminator
+ * values and a builder that keeps the payload shape consistent across the
+ * shell and ai-skill executors plus the scheduler fire path.
+ *
+ * Filed in response to a cluster of silent-failure reports (#171, #172, #173,
+ * #174): scheduler ticks, BullMQ job completes, palace is empty. The fix is
+ * structural — "no drawer" must stop being a representable terminal state.
+ *
+ * Call sites still own their own writeDrawer + appendWal + runTracker calls
+ * because the surrounding context (room resolution, WAL op name, run-tracker
+ * state transition) differs per executor. This module only standardizes the
+ * payload shape so the dashboard and watchdog skills can render any terminal
+ * state without per-executor knowledge.
+ */
+
+/**
+ * The reason a skill run reached its terminal state. `ok` is the only success
+ * value; everything else is a failure mode the caller is expected to surface.
+ *
+ * Discriminator values are kebab-case for legibility in the dashboard and
+ * stable as a contract — dashboards and watchdog skills should be able to
+ * key off these names.
+ */
+export type TerminalReason =
+  | "ok"               // shell exit 0, agentic loop end_turn
+  | "failed"           // shell non-zero exit, generic ai-skill error
+  | "timeout"          // shell command exceeded its timeout
+  | "spend_cap"        // agentic loop exceeded maxSpendUsd
+  | "input_token_cap"  // agentic loop exceeded maxInputTokens
+  | "output_token_cap" // agentic loop exceeded maxOutputTokens
+  | "repetition"       // agentic loop detected identical-tool-call streak
+  | "error_streak"     // agentic loop hit max consecutive tool errors
+  | "max_turns"        // agentic loop hit maxTurns
+  | "prompt_overflow"  // model rejected request as too long (#173)
+  | "rate_limited"     // 429 from model provider
+  | "manifest_missing" // scheduler fired but manifest file is gone (#172)
+  | "verification_failed"; // ai-skill output verification failed required checks
+
+export interface TerminalDrawerPayload {
+  skill: string;
+  success: boolean;
+  terminal_reason: TerminalReason;
+  duration_ms?: number;
+  /** Reason-specific extras — kept as a flat record so the dashboard can render
+   *  per-reason fields without a deep schema. Callers are responsible for any
+   *  truncation (e.g. stdout/stderr previews capped at 2KB). */
+  [extra: string]: unknown;
+}
+
+/**
+ * Build a terminal-drawer payload with the canonical shape. Pass extras as the
+ * second arg; the helper enforces `success` matches `terminal_reason === 'ok'`
+ * so call sites can't accidentally write `success: true` with a failure reason.
+ */
+export function buildTerminalDrawerPayload(
+  base: { skill: string; terminal_reason: TerminalReason; duration_ms?: number },
+  extras: Record<string, unknown> = {},
+): TerminalDrawerPayload {
+  // Spread extras FIRST so canonical fields win the merge — callers can't
+  // pass `success: true` alongside `terminal_reason: "spend_cap"` and lie
+  // about outcome. The shell-skill drawer is the only audit signal for a
+  // failed run; an extras-clobber would silently flip a failure to success.
+  return {
+    ...extras,
+    skill: base.skill,
+    terminal_reason: base.terminal_reason,
+    success: base.terminal_reason === "ok",
+    ...(base.duration_ms !== undefined ? { duration_ms: base.duration_ms } : {}),
+  };
+}
+
+/** Default cap (bytes) for stdout/stderr previews on shell-skill drawers.
+ *  Up from the original 500B — operators reported losing diagnostic context
+ *  when scripts emitted multi-line warnings before exiting (#171). 2KB is
+ *  big enough for a typical traceback or warning paragraph and still small
+ *  enough that drawer payloads stay rendering-friendly. */
+export const STREAM_PREVIEW_CAP_BYTES = 2048;

--- a/scripts/test-terminal-drawer-171.mjs
+++ b/scripts/test-terminal-drawer-171.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #171 — shell-skill drawer must always include BOTH
+ * stdout_preview and stderr_preview, plus a terminal_reason discriminator.
+ *
+ * Pure test of `buildTerminalDrawerPayload` — covers the canonical shape
+ * for the four reasons shell-skill produces today (ok, failed, timeout)
+ * plus a sanity case for the success/terminal_reason invariant.
+ *
+ * Run: node --import tsx scripts/test-terminal-drawer-171.mjs
+ */
+
+import {
+  buildTerminalDrawerPayload,
+  STREAM_PREVIEW_CAP_BYTES,
+} from "../packages/runtime/src/skill-terminal.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. ok payload ────────────────────────────────────────────────
+console.log("\n1. terminal_reason: 'ok' produces success=true");
+{
+  const p = buildTerminalDrawerPayload(
+    { skill: "ops/example", terminal_reason: "ok", duration_ms: 42 },
+    {
+      command: "scripts/example.py",
+      exit_code: 0,
+      stdout_preview: "ran ok\n",
+      stderr_preview: "WARNING: degraded\n",
+    },
+  );
+  assert(p.skill === "ops/example", "skill set");
+  assert(p.success === true, "success=true for ok");
+  assert(p.terminal_reason === "ok", "terminal_reason='ok'");
+  assert(p.duration_ms === 42, "duration_ms preserved");
+  assert(p.stdout_preview === "ran ok\n", "stdout_preview captured");
+  assert(p.stderr_preview === "WARNING: degraded\n", "stderr_preview captured");
+  assert(p.exit_code === 0, "exit_code in extras");
+}
+
+// ── 2. failed payload ────────────────────────────────────────────
+console.log("\n2. terminal_reason: 'failed' produces success=false");
+{
+  const p = buildTerminalDrawerPayload(
+    { skill: "ops/example", terminal_reason: "failed", duration_ms: 100 },
+    {
+      command: "boom.sh",
+      exit_code: 2,
+      stdout_preview: "partial output before failure",
+      stderr_preview: "Traceback ...\nValueError",
+    },
+  );
+  assert(p.success === false, "success=false for failed");
+  assert(p.terminal_reason === "failed", "terminal_reason='failed'");
+  // The fix for #171: failure path MUST surface stdout too. Previously the
+  // drawer dropped stdout entirely on failure.
+  assert(typeof p.stdout_preview === "string" && p.stdout_preview.length > 0,
+    "failure drawer includes stdout_preview (regression: #171)");
+  assert(typeof p.stderr_preview === "string" && p.stderr_preview.length > 0,
+    "failure drawer includes stderr_preview");
+}
+
+// ── 3. timeout discriminator ─────────────────────────────────────
+console.log("\n3. terminal_reason: 'timeout' distinguishable from 'failed'");
+{
+  const p = buildTerminalDrawerPayload(
+    { skill: "ops/wedged", terminal_reason: "timeout", duration_ms: 120000 },
+    { command: "sleep 9999", exit_code: 137 },
+  );
+  assert(p.terminal_reason === "timeout", "timeout reason preserved");
+  assert(p.success === false, "timeout is a failure");
+}
+
+// ── 4. success/reason invariant ──────────────────────────────────
+console.log("\n4. canonical fields cannot be clobbered by extras");
+{
+  const p = buildTerminalDrawerPayload(
+    { skill: "ops/x", terminal_reason: "spend_cap" },
+    // Hostile extras trying to lie about the outcome.
+    { success: true, terminal_reason: "ok", skill: "tampered" },
+  );
+  assert(p.success === false, "spend_cap → success=false even with extras.success=true");
+  assert(p.terminal_reason === "spend_cap", "terminal_reason wins the merge");
+  assert(p.skill === "ops/x", "skill wins the merge");
+}
+
+// ── 5. duration_ms is optional ───────────────────────────────────
+console.log("\n5. duration_ms is omitted when not provided");
+{
+  const p = buildTerminalDrawerPayload(
+    { skill: "ops/x", terminal_reason: "manifest_missing" },
+  );
+  assert(!("duration_ms" in p), "no duration_ms when caller omits it");
+  assert(p.terminal_reason === "manifest_missing", "reason preserved");
+}
+
+// ── 6. preview cap exported ──────────────────────────────────────
+console.log("\n6. STREAM_PREVIEW_CAP_BYTES exported and sane");
+{
+  assert(STREAM_PREVIEW_CAP_BYTES === 2048, "cap is 2KB (up from 500B legacy)");
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #171. First slice of the silent-failure arc (#171, #172, #173, #174) — every terminal state in a skill's lifecycle must produce a drawer with a consistent discriminator. This PR establishes the contract and adopts it at the easiest call site (shell-skill).

## Summary
- New `skill-terminal.ts` defines `TerminalReason` (13 values) and `buildTerminalDrawerPayload()`. Canonical fields (`skill`, `terminal_reason`, `success`) win the spread so extras can't lie about outcome.
- Shell-skill success drawer now captures **both** `stdout_preview` and `stderr_preview` — previously dropped stderr, so a script could `print("WARNING")` to stderr and exit 0 with no audit trail.
- Shell-skill failure drawer now captures **both** streams — previously dropped stdout, hiding diagnostics emitted before the traceback.
- Timeout terminations carry `terminal_reason: "timeout"` (distinct from generic `failed`).
- Preview cap raised to 2KB (`STREAM_PREVIEW_CAP_BYTES`) — 500B was truncating typical Python tracebacks per the issue's repro.

## Arc context
`TerminalReason` already includes the discriminator values the remaining three issues need: `spend_cap`, `prompt_overflow`, `manifest_missing`, etc. Subsequent PRs adopt the helper at:
- ai-skill abort path → #174 (`spend_cap`)
- register-skill pre-flight + ai-skill catch → #173 (`prompt_overflow`)
- scheduler fire path → #172 (`manifest_missing`)

## Test plan
- [x] `node --import tsx scripts/test-terminal-drawer-171.mjs` — 19 assertions pass
- [x] `npx tsc --noEmit` clean in `packages/runtime`
- [ ] Smoke: run a shell skill that prints to stderr then exits 0 — drawer payload contains both `stdout_preview` and `stderr_preview`
- [ ] Smoke: run a shell skill that exits non-zero with stdout output before crashing — drawer payload contains both streams
- [ ] Smoke: run a shell skill with `timeout: 1` that sleeps longer — drawer has `terminal_reason: "timeout"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)