### PR TITLE
fix(ai-skill): terminal drawer on spend_cap, exception, and preflight-fail

### DIFF
--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -31,6 +31,10 @@ import {
   isFrameworkTool,
   type FrameworkToolContext,
 } from "./ai-skill-framework-tools.js";
+import {
+  buildTerminalDrawerPayload,
+  terminalReasonFromAgenticStopReason,
+} from "./skill-terminal.js";
 
 export interface AiSkillManifest {
   id: string;
@@ -203,6 +207,14 @@ export async function runAiSkill(
       return { success: true, turns: 0, toolCalls: 0, content: `skipped: ${reason}` };
     } else {
       const errSummary = (stderr.trim() || stdout.trim() || `preflight exited ${exitCode}`).slice(0, 500);
+      // Terminal drawer for the preflight-failure surface — previously only
+      // the WAL got an entry, leaving palace empty and dashboards blind.
+      // Companion silent-failure fix to #174 in the same file.
+      const room = manifest.rooms?.primary ?? { wing: "operations", hall: "ai", room: manifest.id };
+      await session.writeDrawer(room, JSON.stringify(buildTerminalDrawerPayload(
+        { skill: manifest.id, terminal_reason: "failed", duration_ms: preflightMs },
+        { preflight_exit_code: exitCode, error: errSummary },
+      )));
       await appendWal({
         workspace,
         op: "ai_skill_preflight_failed",
@@ -389,20 +401,36 @@ export async function runAiSkill(
       modelPricing,
     });
 
-    // Record the result as a palace drawer
+    // Record the result as a palace drawer. Shape uses the framework-wide
+    // terminal_reason discriminator (#171 helper) so dashboards and
+    // watchdog skills can render any abort reason without ai-skill-specific
+    // knowledge. The `aborted` and `stop_reason` fields are kept as extras
+    // for backward compatibility with consumers built before #174.
     const primaryRoom = manifest.rooms?.primary ?? { wing: "operations", hall: "ai", room: manifest.id };
-    const primaryDrawerPayload = {
-      skill: manifest.id,
-      success: !result.aborted,
-      stop_reason: result.stopReason,
-      aborted: result.aborted,
-      turns: result.turns,
-      tool_calls: result.toolCalls.length,
-      content_preview: result.content.slice(0, 500),
-      input_tokens: result.inputTokens,
-      output_tokens: result.outputTokens,
-      cost_usd: result.costUsd,
-    };
+    const terminalReason = terminalReasonFromAgenticStopReason(result.stopReason);
+    const primaryDrawerPayload = buildTerminalDrawerPayload(
+      { skill: manifest.id, terminal_reason: terminalReason },
+      {
+        // Legacy fields retained for existing consumers.
+        stop_reason: result.stopReason,
+        aborted: result.aborted,
+        turns: result.turns,
+        tool_calls: result.toolCalls.length,
+        content_preview: result.content.slice(0, 500),
+        input_tokens: result.inputTokens,
+        output_tokens: result.outputTokens,
+        cost_usd: result.costUsd,
+        // Surface the configured cap alongside the actual cost when the
+        // run aborted on spend — dashboards can render an "actual vs cap"
+        // delta without re-reading the manifest (#174 repro).
+        ...(terminalReason === "spend_cap" && agenticLimits.maxSpendUsd !== undefined
+          ? { spend_cap_usd: agenticLimits.maxSpendUsd, spend_actual_usd: result.costUsd }
+          : {}),
+        ...(terminalReason === "max_turns" && agenticLimits.maxTurns !== undefined
+          ? { max_turns: agenticLimits.maxTurns }
+          : {}),
+      },
+    );
 
     // #45 Stage 1b — TAG bridge. If the manifest declares a
     // primary_output pointing at an outputs[] entry, route the agentic
@@ -604,12 +632,30 @@ export async function runAiSkill(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const status = (err as { status?: number }).status;
+    const terminalReason = status === 429 ? "rate_limited" : "failed";
+
+    // Terminal drawer for the exception path — previously only the WAL
+    // got an entry, so a 429 / model-API error / MCP transport error
+    // produced a "phantom run" (job completes, palace empty). #174 closes
+    // the spend_cap variant of this surface; the same fix applies to every
+    // exception terminating ai-skill execution.
+    try {
+      const room = manifest.rooms?.primary ?? { wing: "operations", hall: "ai", room: manifest.id };
+      await session.writeDrawer(room, JSON.stringify(buildTerminalDrawerPayload(
+        { skill: manifest.id, terminal_reason: terminalReason },
+        { error: message.slice(0, 2048), status: status ?? null },
+      )));
+    } catch (drawerErr) {
+      // If the drawer write itself fails (e.g. DB connection lost) we
+      // still want the rethrow / return path below to run. Log and move on.
+      console.error(`[nexaas] AI skill '${manifest.id}' terminal-drawer write failed:`, drawerErr);
+    }
 
     await appendWal({
       workspace,
       op: status === 429 ? "ai_skill_rate_limited" : "ai_skill_failed",
       actor: `skill:${manifest.id}`,
-      payload: { run_id: runId, error: message, status },
+      payload: { run_id: runId, error: message, status, terminal_reason: terminalReason },
     });
 
     await runTracker.markStepFailed(runId, stepId, err);

--- a/packages/runtime/src/skill-terminal.ts
+++ b/packages/runtime/src/skill-terminal.ts
@@ -77,3 +77,34 @@ export function buildTerminalDrawerPayload(
  *  big enough for a typical traceback or warning paragraph and still small
  *  enough that drawer payloads stay rendering-friendly. */
 export const STREAM_PREVIEW_CAP_BYTES = 2048;
+
+/**
+ * Map the agentic loop's stop reason (defined in models/agentic-loop.ts as
+ * a deliberately narrow union) to the framework-wide TerminalReason.
+ *
+ * `end_turn` is the only stop reason that indicates a successful completion;
+ * every other value is an abort. The narrow loop union is intentional — the
+ * loop only knows about its own limits — so this adapter sits at the
+ * ai-skill executor boundary where loop-internal reasons become framework
+ * terminal states.
+ */
+export function terminalReasonFromAgenticStopReason(
+  stopReason:
+    | "end_turn"
+    | "max_turns"
+    | "spend_cap"
+    | "input_token_cap"
+    | "output_token_cap"
+    | "repetition"
+    | "error_streak",
+): TerminalReason {
+  switch (stopReason) {
+    case "end_turn":         return "ok";
+    case "max_turns":        return "max_turns";
+    case "spend_cap":        return "spend_cap";
+    case "input_token_cap":  return "input_token_cap";
+    case "output_token_cap": return "output_token_cap";
+    case "repetition":       return "repetition";
+    case "error_streak":     return "error_streak";
+  }
+}

--- a/scripts/test-ai-skill-terminal-174.mjs
+++ b/scripts/test-ai-skill-terminal-174.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #174 — ai-skill aborts (spend_cap, etc.) and
+ * exceptions must produce a terminal drawer with the canonical shape.
+ *
+ * Pure tests of:
+ *   - terminalReasonFromAgenticStopReason() — covers all 7 stop reasons
+ *   - buildTerminalDrawerPayload() shape for the three ai-skill exit paths
+ *     (loop abort with spend_cap, preflight-failed, generic exception)
+ *
+ * Behavioural assertion (the drawer is actually written) is covered by
+ * runtime smoke tests — these tests just verify the shape contract holds
+ * for the payload data each call site assembles.
+ *
+ * Run: node --import tsx scripts/test-ai-skill-terminal-174.mjs
+ */
+
+import {
+  buildTerminalDrawerPayload,
+  terminalReasonFromAgenticStopReason,
+} from "../packages/runtime/src/skill-terminal.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. AgenticStopReason → TerminalReason mapping ─────────────────
+console.log("\n1. terminalReasonFromAgenticStopReason — all 7 stop reasons map");
+{
+  assert(terminalReasonFromAgenticStopReason("end_turn") === "ok",
+    "end_turn → ok (only success value)");
+  assert(terminalReasonFromAgenticStopReason("max_turns") === "max_turns",
+    "max_turns passes through");
+  assert(terminalReasonFromAgenticStopReason("spend_cap") === "spend_cap",
+    "spend_cap passes through");
+  assert(terminalReasonFromAgenticStopReason("input_token_cap") === "input_token_cap",
+    "input_token_cap passes through");
+  assert(terminalReasonFromAgenticStopReason("output_token_cap") === "output_token_cap",
+    "output_token_cap passes through");
+  assert(terminalReasonFromAgenticStopReason("repetition") === "repetition",
+    "repetition passes through");
+  assert(terminalReasonFromAgenticStopReason("error_streak") === "error_streak",
+    "error_streak passes through");
+}
+
+// ── 2. spend_cap drawer carries the cap vs actual delta ────────────
+console.log("\n2. spend_cap drawer carries cap_usd + actual_usd (regression: #174)");
+{
+  // Simulate the payload assembly path in ai-skill.ts when the loop
+  // aborts on spend_cap. Includes the extras the executor adds only
+  // when terminal_reason === 'spend_cap'.
+  const stopReason = "spend_cap";
+  const terminalReason = terminalReasonFromAgenticStopReason(stopReason);
+  const limits = { maxSpendUsd: 1.45 };
+  const result = { costUsd: 1.46, inputTokens: 12345, outputTokens: 678, turns: 7, toolCalls: { length: 12 } };
+
+  const payload = buildTerminalDrawerPayload(
+    { skill: "marketing/freshness-watchdog", terminal_reason: terminalReason },
+    {
+      stop_reason: stopReason,
+      aborted: true,
+      turns: result.turns,
+      tool_calls: result.toolCalls.length,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+      cost_usd: result.costUsd,
+      ...(terminalReason === "spend_cap" && limits.maxSpendUsd !== undefined
+        ? { spend_cap_usd: limits.maxSpendUsd, spend_actual_usd: result.costUsd }
+        : {}),
+    },
+  );
+
+  assert(payload.success === false, "spend_cap drawer is success=false");
+  assert(payload.terminal_reason === "spend_cap", "terminal_reason='spend_cap'");
+  assert(payload.spend_cap_usd === 1.45, "spend_cap_usd carries manifest limit");
+  assert(payload.spend_actual_usd === 1.46, "spend_actual_usd carries result cost");
+  assert(payload.cost_usd === 1.46, "legacy cost_usd retained for backward compat");
+  assert(payload.aborted === true, "legacy aborted field retained");
+  assert(payload.stop_reason === "spend_cap", "legacy stop_reason retained");
+}
+
+// ── 3. max_turns drawer carries the configured cap ─────────────────
+console.log("\n3. max_turns drawer carries max_turns extra");
+{
+  const stopReason = "max_turns";
+  const terminalReason = terminalReasonFromAgenticStopReason(stopReason);
+  const limits = { maxTurns: 10 };
+
+  const payload = buildTerminalDrawerPayload(
+    { skill: "ops/long-task", terminal_reason: terminalReason },
+    {
+      ...(terminalReason === "max_turns" && limits.maxTurns !== undefined
+        ? { max_turns: limits.maxTurns }
+        : {}),
+    },
+  );
+  assert(payload.max_turns === 10, "max_turns carries the configured cap");
+  assert(payload.success === false, "max_turns is a failure");
+}
+
+// ── 4. preflight-failed drawer shape ───────────────────────────────
+console.log("\n4. preflight-failed exit ≥ 2 drawer shape");
+{
+  const payload = buildTerminalDrawerPayload(
+    { skill: "ops/example", terminal_reason: "failed", duration_ms: 250 },
+    { preflight_exit_code: 2, error: "preflight: db unreachable" },
+  );
+  assert(payload.success === false, "preflight-failed is success=false");
+  assert(payload.terminal_reason === "failed", "terminal_reason='failed'");
+  assert(payload.preflight_exit_code === 2, "preflight_exit_code carried");
+  assert(payload.duration_ms === 250, "duration_ms preserved");
+}
+
+// ── 5. catch-block exception drawer (rate_limited vs failed) ───────
+console.log("\n5. catch-block exception → rate_limited or failed");
+{
+  // 429 from Anthropic
+  const rateLimited = buildTerminalDrawerPayload(
+    { skill: "ops/api-skill", terminal_reason: "rate_limited" },
+    { error: "rate_limit_exceeded", status: 429 },
+  );
+  assert(rateLimited.terminal_reason === "rate_limited", "429 → rate_limited");
+  assert(rateLimited.success === false, "rate_limited is failure");
+  assert(rateLimited.status === 429, "status preserved");
+
+  // Generic exception (e.g. prompt-too-long, MCP transport error)
+  const generic = buildTerminalDrawerPayload(
+    { skill: "ops/big-skill", terminal_reason: "failed" },
+    { error: "prompt is too long: 220148 tokens > 200000 maximum", status: null },
+  );
+  assert(generic.terminal_reason === "failed", "generic exception → failed");
+  assert(generic.status === null, "status is null for non-HTTP errors");
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #174. Second slice of the silent-failure arc (#171, #172, #173, #174). Adopts the terminal-drawer contract from #175 across the three silent surfaces in `ai-skill.ts`.

## Three surfaces fixed

**1. Primary drawer (loop result)** — already written for aborted runs but used ad-hoc `aborted` + `stop_reason` fields. Now built via `buildTerminalDrawerPayload()` using canonical `terminal_reason` mapped from `AgenticStopReason`. Legacy fields kept as extras for backward compat. For `spend_cap` aborts the drawer carries `spend_cap_usd` + `spend_actual_usd` so dashboards can render the cap-vs-actual delta without re-reading the manifest (per #174 repro). For `max_turns` aborts it carries `max_turns`.

**2. Preflight failed (exit ≥ 2)** — previously WAL-only, palace empty. Now writes a terminal drawer with `terminal_reason: "failed"` and `preflight_exit_code` extra before returning.

**3. Catch block** — previously WAL-only. This is where prompt-too-long, 429 rate limits, MCP transport errors, and every other exception land. Now writes a terminal drawer: `terminal_reason: "rate_limited"` for 429s, `"failed"` otherwise. The drawer write is itself wrapped in try/catch so a DB hiccup doesn't swallow the rethrow path.

## New in `skill-terminal.ts`
- `terminalReasonFromAgenticStopReason()` — narrow adapter from loop-internal stop reasons to the framework-wide `TerminalReason` union. Loop union stays intentionally narrow; this adapter sits at the executor boundary.

## Arc context
This gets ai-skill to parity with shell-skill (#175). Sets up #173 — the catch block now writes a `"failed"` drawer when a prompt-overflow error bubbles up; the next PR will classify those specifically as `terminal_reason: "prompt_overflow"` and add register-time pre-flight tool-count checks.

## Test plan
- [x] `node --import tsx scripts/test-ai-skill-terminal-174.mjs` — 25 assertions pass
- [x] `node --import tsx scripts/test-terminal-drawer-171.mjs` — regression OK (19 assertions)
- [x] `npx tsc --noEmit` clean in `packages/runtime`
- [ ] Smoke: ai-skill with `max_spend_usd: 0.10` against an expensive prompt — drawer carries `terminal_reason: "spend_cap"`, `spend_cap_usd: 0.10`, `spend_actual_usd > 0.10`
- [ ] Smoke: ai-skill with preflight returning exit 2 — drawer carries `terminal_reason: "failed"`, `preflight_exit_code: 2`
- [ ] Smoke: ai-skill against an offline MCP server — catch-block drawer carries `terminal_reason: "failed"`, status: null

🤖 Generated with [Claude Code](https://claude.com/claude-code)