### PR TITLE
fix(ai-skill): classify prompt-overflow exceptions with tool-count diagnostics

### DIFF
--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -34,6 +34,8 @@ import {
 import {
   buildTerminalDrawerPayload,
   terminalReasonFromAgenticStopReason,
+  isPromptOverflowError,
+  extractPromptOverflowTokens,
 } from "./skill-terminal.js";
 
 export interface AiSkillManifest {
@@ -632,7 +634,28 @@ export async function runAiSkill(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const status = (err as { status?: number }).status;
-    const terminalReason = status === 429 ? "rate_limited" : "failed";
+    // Classify the failure: 429 → rate_limited; "prompt is too long" 400 →
+    // prompt_overflow (#173); everything else → failed. Order matters —
+    // prompt_overflow check runs before the generic 'failed' fallthrough.
+    const promptOverflow = isPromptOverflowError(err);
+    const terminalReason = status === 429
+      ? "rate_limited"
+      : promptOverflow
+        ? "prompt_overflow"
+        : "failed";
+
+    // Tool-def overflow diagnostics — when the model rejected the request
+    // as too long, surface the tool count and (when parseable) the
+    // estimated-vs-max token numbers from the provider's error message.
+    // Helps operators correlate the failure with which MCP servers a
+    // skill declared, without re-running with verbose logging.
+    const promptOverflowExtras = promptOverflow
+      ? {
+          tool_count: allTools.length,
+          mcp_servers: manifest.mcp_servers ?? [],
+          ...(extractPromptOverflowTokens(message) ?? {}),
+        }
+      : {};
 
     // Terminal drawer for the exception path — previously only the WAL
     // got an entry, so a 429 / model-API error / MCP transport error
@@ -643,7 +666,11 @@ export async function runAiSkill(
       const room = manifest.rooms?.primary ?? { wing: "operations", hall: "ai", room: manifest.id };
       await session.writeDrawer(room, JSON.stringify(buildTerminalDrawerPayload(
         { skill: manifest.id, terminal_reason: terminalReason },
-        { error: message.slice(0, 2048), status: status ?? null },
+        {
+          error: message.slice(0, 2048),
+          status: status ?? null,
+          ...promptOverflowExtras,
+        },
       )));
     } catch (drawerErr) {
       // If the drawer write itself fails (e.g. DB connection lost) we
@@ -653,9 +680,13 @@ export async function runAiSkill(
 
     await appendWal({
       workspace,
-      op: status === 429 ? "ai_skill_rate_limited" : "ai_skill_failed",
+      op: status === 429
+        ? "ai_skill_rate_limited"
+        : promptOverflow
+          ? "ai_skill_prompt_overflow"
+          : "ai_skill_failed",
       actor: `skill:${manifest.id}`,
-      payload: { run_id: runId, error: message, status, terminal_reason: terminalReason },
+      payload: { run_id: runId, error: message, status, terminal_reason: terminalReason, ...promptOverflowExtras },
     });
 
     await runTracker.markStepFailed(runId, stepId, err);

--- a/packages/runtime/src/skill-terminal.ts
+++ b/packages/runtime/src/skill-terminal.ts
@@ -79,6 +79,54 @@ export function buildTerminalDrawerPayload(
 export const STREAM_PREVIEW_CAP_BYTES = 2048;
 
 /**
+ * Detect whether a thrown error represents a prompt-overflow rejection from
+ * the model provider (e.g. Anthropic returns 400 with a body that includes
+ * "prompt is too long: <N> tokens > <M> maximum" when the assembled request
+ * exceeds the context window).
+ *
+ * Used by the ai-skill catch block to classify the terminal_reason as
+ * `prompt_overflow` rather than the generic `failed`, so dashboards and
+ * watchdog skills can render this distinct failure mode (#173).
+ *
+ * Heuristic — Anthropic doesn't ship a typed error class for context
+ * overflow, just a 400 with the message above. We match the message
+ * pattern conservatively: must be a 400 AND mention "prompt is too long"
+ * OR the broader "context length"/"context window" phrasing. False
+ * positives are preferable to false negatives here — the worst case is
+ * a non-overflow 400 mislabeled as overflow on the drawer, which still
+ * surfaces as a failure (terminal_reason will be `prompt_overflow`
+ * instead of `failed`, but `success` is false either way).
+ */
+export function isPromptOverflowError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const status = (err as { status?: number }).status;
+  const message = (err as { message?: string }).message ?? "";
+  if (status !== 400) return false;
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("prompt is too long") ||
+    lower.includes("context length") ||
+    lower.includes("context window") ||
+    lower.includes("maximum context")
+  );
+}
+
+/**
+ * Parse the token-count numbers out of Anthropic's prompt-overflow message
+ * shape ("prompt is too long: 220148 tokens > 200000 maximum"). Returns
+ * undefined when the message doesn't carry the pattern — the caller should
+ * fall back to the plain error message in that case.
+ */
+export function extractPromptOverflowTokens(message: string): { estimated: number; maximum: number } | undefined {
+  const match = message.match(/(\d{4,})\s*tokens?\s*>\s*(\d{4,})/i);
+  if (!match || !match[1] || !match[2]) return undefined;
+  const estimated = Number.parseInt(match[1], 10);
+  const maximum = Number.parseInt(match[2], 10);
+  if (Number.isNaN(estimated) || Number.isNaN(maximum)) return undefined;
+  return { estimated, maximum };
+}
+
+/**
  * Map the agentic loop's stop reason (defined in models/agentic-loop.ts as
  * a deliberately narrow union) to the framework-wide TerminalReason.
  *

--- a/scripts/test-prompt-overflow-173.mjs
+++ b/scripts/test-prompt-overflow-173.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #173 — ai-skill prompt-overflow classifier.
+ *
+ * Pure tests of `isPromptOverflowError()` and `extractPromptOverflowTokens()`.
+ * The wiring inside ai-skill.ts's catch block is covered by smoke tests.
+ *
+ * Run: node --import tsx scripts/test-prompt-overflow-173.mjs
+ */
+
+import {
+  isPromptOverflowError,
+  extractPromptOverflowTokens,
+  buildTerminalDrawerPayload,
+} from "../packages/runtime/src/skill-terminal.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. classifier matches known Anthropic shapes ──────────────────
+console.log("\n1. isPromptOverflowError() matches Anthropic 400 overflow shapes");
+{
+  const real = Object.assign(new Error("prompt is too long: 220148 tokens > 200000 maximum"), { status: 400 });
+  assert(isPromptOverflowError(real) === true,
+    "exact Anthropic 'prompt is too long' phrasing → true");
+
+  const ctxLen = Object.assign(new Error("Bad Request: context length exceeded"), { status: 400 });
+  assert(isPromptOverflowError(ctxLen) === true,
+    "alternate phrasing 'context length' → true");
+
+  const ctxWin = Object.assign(new Error("Request exceeds the context window for this model"), { status: 400 });
+  assert(isPromptOverflowError(ctxWin) === true,
+    "'context window' phrasing → true");
+
+  const maxCtx = Object.assign(new Error("payload exceeds maximum context length of 200000"), { status: 400 });
+  assert(isPromptOverflowError(maxCtx) === true,
+    "'maximum context' phrasing → true");
+}
+
+// ── 2. classifier rejects non-overflow errors ─────────────────────
+console.log("\n2. isPromptOverflowError() does NOT match unrelated failures");
+{
+  const rateLimit = Object.assign(new Error("rate_limit_exceeded"), { status: 429 });
+  assert(isPromptOverflowError(rateLimit) === false,
+    "429 rate limit → false (not 400)");
+
+  const auth = Object.assign(new Error("authentication failed"), { status: 401 });
+  assert(isPromptOverflowError(auth) === false,
+    "401 auth failure → false");
+
+  const generic400 = Object.assign(new Error("invalid_request_error: missing field"), { status: 400 });
+  assert(isPromptOverflowError(generic400) === false,
+    "400 without prompt-too-long phrasing → false");
+
+  const stringErr = "plain string error";
+  assert(isPromptOverflowError(stringErr) === false,
+    "non-object error → false");
+
+  assert(isPromptOverflowError(null) === false, "null → false");
+  assert(isPromptOverflowError(undefined) === false, "undefined → false");
+}
+
+// ── 3. token-count parser ─────────────────────────────────────────
+console.log("\n3. extractPromptOverflowTokens() parses Anthropic message shape");
+{
+  const m = extractPromptOverflowTokens("prompt is too long: 220148 tokens > 200000 maximum");
+  assert(m?.estimated === 220148, "parsed estimated token count");
+  assert(m?.maximum === 200000, "parsed maximum token count");
+
+  const lowerCase = extractPromptOverflowTokens("prompt is too long: 12345 TOKENS > 8192 maximum");
+  assert(lowerCase?.estimated === 12345, "case-insensitive match");
+
+  const noNumbers = extractPromptOverflowTokens("prompt is too long");
+  assert(noNumbers === undefined, "no numbers → undefined");
+
+  const wrongShape = extractPromptOverflowTokens("something completely unrelated");
+  assert(wrongShape === undefined, "unrelated message → undefined");
+}
+
+// ── 4. integration: catch-block payload assembly ──────────────────
+console.log("\n4. catch-block payload uses prompt_overflow with diagnostics");
+{
+  // Simulate the assembly path in ai-skill.ts catch block when the
+  // model API returns the prompt-too-long 400.
+  const err = Object.assign(new Error("prompt is too long: 220148 tokens > 200000 maximum"), { status: 400 });
+  const isOverflow = isPromptOverflowError(err);
+  const tokens = extractPromptOverflowTokens(err.message);
+  const allToolsLength = 105; // groundhogg(52) + promotions(53) per #173 repro
+  const mcpServers = ["groundhogg", "promotions"];
+
+  const payload = buildTerminalDrawerPayload(
+    { skill: "marketing/lead-sync-with-promos", terminal_reason: "prompt_overflow" },
+    {
+      error: err.message.slice(0, 2048),
+      status: 400,
+      ...(isOverflow ? { tool_count: allToolsLength, mcp_servers: mcpServers, ...(tokens ?? {}) } : {}),
+    },
+  );
+
+  assert(payload.terminal_reason === "prompt_overflow",
+    "terminal_reason classified as prompt_overflow");
+  assert(payload.success === false, "prompt_overflow is failure");
+  assert(payload.tool_count === 105, "tool_count carried (regression: #173 repro)");
+  assert(Array.isArray(payload.mcp_servers) && payload.mcp_servers.length === 2,
+    "mcp_servers list carried for correlation");
+  assert(payload.estimated === 220148, "parsed estimated tokens on drawer");
+  assert(payload.maximum === 200000, "parsed maximum tokens on drawer");
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #173 (runtime-detection half). Third slice of the silent-failure arc (#171, #172, #173, #174).

When the model provider rejects a request as too long for its context window, the ai-skill catch block now classifies the failure as `terminal_reason: "prompt_overflow"` instead of the generic `failed`, and surfaces diagnostics on the drawer so operators can correlate the failure with which MCP servers the skill declared.

## Drawer extras for prompt_overflow

- `tool_count` — total MCP + framework tools the loop received
- `mcp_servers` — the declared `mcp_servers[]` list (so the operator can spot \"oh, I combined groundhogg + promotions again\")
- `estimated` / `maximum` — parsed from the provider's error message when available (\"prompt is too long: 220148 tokens > 200000 maximum\")

## New helpers in `skill-terminal.ts`

- `isPromptOverflowError(err)` — classifies a thrown error as overflow. Match is conservative: HTTP 400 **and** one of `\"prompt is too long\" | \"context length\" | \"context window\" | \"maximum context\"` in the message. False positives preferable to false negatives — worst case a non-overflow 400 gets a more specific label, but `success` is still `false` either way.
- `extractPromptOverflowTokens(message)` — parses the `N tokens > M` numbers out of Anthropic's message shape. Returns `undefined` when not parseable so the drawer falls back to the plain error string.

## Scope note: register-time pre-flight deferred

The issue's other suggested fix — \"pre-flight on skill registration: sum the tool-def token cost across declared MCP servers, warn @ 100K, refuse @ 180K\" — is intentionally out of scope here. It requires spawning each declared MCP server at registration time to enumerate tools and estimate token costs, which is heavy enough to warrant its own PR. It naturally clusters with #172's manifestPath pre-flight as **\"register-skill guards\"** — I'll file that as a follow-up after #172 lands so the guards share a single pre-flight surface.

## Test plan
- [x] `node --import tsx scripts/test-prompt-overflow-173.mjs` — 21 assertions pass
- [x] `npx tsc --noEmit` clean in `packages/runtime`
- [x] `node --import tsx scripts/test-ai-skill-terminal-174.mjs` — regression OK (25 assertions)
- [x] `node --import tsx scripts/test-terminal-drawer-171.mjs` — regression OK (19 assertions)
- [ ] Smoke: ai-skill declaring two large MCP servers (>200K total tool-def tokens) — drawer carries `terminal_reason: \"prompt_overflow\"`, `tool_count`, `mcp_servers`, and parsed token numbers
- [ ] Smoke: ai-skill hitting a non-overflow 400 (e.g. malformed tool schema) — drawer carries `terminal_reason: \"failed\"` (NOT `prompt_overflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling and diagnostics for scenarios where prompts exceed token limits. The system now distinguishes prompt overflow errors from other failure types and provides diagnostic details including token count information.

* **Tests**
  * Added regression tests to verify prompt overflow error detection and token extraction functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/177)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->