### PR TITLE
fix(scheduler): phantom-skill guards — ephemeral path refusal + manifest_missing drawer

### DIFF
--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -23,6 +23,7 @@ import {
   loadPersonaProfile,
   upsertPaThreads,
   detectPaReplyUser,
+  isEphemeralPath,
   type UpsertSummary,
 } from "@nexaas/runtime";
 
@@ -130,6 +131,19 @@ export interface RegisterContext {
   queue: Queue;
   workspace: string;
   workspaceTz: string;
+  /**
+   * Allow registering a manifest stored under an ephemeral filesystem path
+   * (`/tmp`, `/run`, `/var/tmp`, `/dev/shm`, `$XDG_RUNTIME_DIR`). Default
+   * `false` — those paths get garbage-collected by systemd-tmpfiles, the
+   * kernel on boot, or OOM-prompted /tmp sweeps, leaving the BullMQ
+   * scheduler ticking on a phantom skill (#172).
+   *
+   * The CLI exposes this as `--allow-ephemeral`. Library/programmatic
+   * callers can pass `true` when they explicitly know the storage layer
+   * (e.g. integration tests writing to a tmpdir they control for the
+   * duration of the run).
+   */
+  allowEphemeral?: boolean;
 }
 
 /**
@@ -160,12 +174,18 @@ export interface RegisterResult {
 }
 
 const USAGE = `\
-Usage: nexaas register-skill <path-to-skill.yaml>
+Usage: nexaas register-skill <path-to-skill.yaml> [--allow-ephemeral]
 
 Registers a skill manifest with the BullMQ scheduler. Reads the manifest,
 upserts every cron trigger as a repeatable BullMQ job, and prints a
 confirmation. Existing repeatables for the same skill ID are cleaned up
 before the new one is upserted.
+
+Flags:
+  --allow-ephemeral   Permit registering a manifest stored under /tmp,
+                      /run, /var/tmp, /dev/shm, or \$XDG_RUNTIME_DIR.
+                      Refused by default — those paths get cleaned and
+                      leave the scheduler firing on a phantom skill.
 
 Bulk equivalent:
   nexaas register-skills <dir>           Register every skill.yaml under <dir>
@@ -330,6 +350,23 @@ export async function registerOneSkill(
       cleaned: 0,
       status: "error",
       error: `manifest not found at '${manifestPath}' — pass an absolute path or run from $NEXAAS_WORKSPACE_ROOT`,
+    };
+  }
+
+  // Refuse manifests stored on ephemeral paths — they get cleaned up by
+  // systemd-tmpfiles or kernel /tmp sweeps, leaving the scheduler firing
+  // on a dead repeatable with no observable signal (#172). Operators with
+  // a legitimate use (integration tests, throwaway dry-runs) pass
+  // `--allow-ephemeral`.
+  const absolutePath = resolve(manifestPath);
+  if (!ctx.allowEphemeral && isEphemeralPath(absolutePath)) {
+    return {
+      skillId: manifestPath,
+      version: "?",
+      registered: 0,
+      cleaned: 0,
+      status: "error",
+      error: `manifest path '${absolutePath}' is ephemeral (under /tmp, /run, /var/tmp, /dev/shm, or $XDG_RUNTIME_DIR). The scheduler would tick forever on a vanishing file. Move it under $NEXAAS_WORKSPACE_ROOT/nexaas-skills/ or pass --allow-ephemeral if you know what you're doing.`,
     };
   }
 
@@ -533,7 +570,12 @@ export async function run(args: string[]) {
     return;
   }
 
-  const manifestPath = args[0];
+  // Strip flags so positional args[0] is the manifest path regardless of
+  // ordering. Currently we only support --allow-ephemeral (#172); add to
+  // the filter as more flags arrive.
+  const allowEphemeral = args.includes("--allow-ephemeral");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const manifestPath = positional[0];
   if (!manifestPath) {
     console.error(USAGE);
     process.exit(1);
@@ -561,7 +603,7 @@ export async function run(args: string[]) {
   const workspaceTz = resolveWorkspaceTimezone(workspace);
 
   try {
-    const result = await registerOneSkill(resolved, { queue, workspace, workspaceTz });
+    const result = await registerOneSkill(resolved, { queue, workspace, workspaceTz, allowEphemeral });
 
     if (result.status === "error") {
       console.error(`  ✗ ${result.error}`);

--- a/packages/runtime/src/bullmq/worker.ts
+++ b/packages/runtime/src/bullmq/worker.ts
@@ -12,15 +12,16 @@ import { runSkillStep } from "../pipeline.js";
 import { runShellSkill, type ShellSkillManifest } from "../shell-skill.js";
 import { runAiSkill, type AiSkillManifest } from "../ai-skill.js";
 import { runTracker } from "../run-tracker.js";
-import { appendWal, sql } from "@nexaas/palace";
+import { palace, appendWal, sql } from "@nexaas/palace";
 import type { SkillJobData } from "./queues.js";
 import { isRateLimitError, extractCooldownMs, pauseQueueFor } from "./rate-limit.js";
 import { startHeartbeatLoop, stopHeartbeatLoop } from "../fleet/heartbeat.js";
 import { shutdownMcpPool } from "../mcp/pool.js";
 import { withGroups, resolveConcurrencyGroups } from "../concurrency-groups.js";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import { load as yamlLoad } from "js-yaml";
 import { randomUUID } from "crypto";
+import { buildTerminalDrawerPayload, isEphemeralPath } from "../skill-terminal.js";
 
 let _worker: Worker | null = null;
 
@@ -52,6 +53,21 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
       // Shell/AI skill executors create their own run records
       const jobData = data as SkillJobData & { manifestPath?: string };
       if (jobData.manifestPath) {
+        // Phantom-skill guard (#172): the scheduler stored an absolute
+        // manifestPath at registration time, but the file may have been
+        // deleted, moved, or never persisted across a /tmp cleanup. Before
+        // this guard, `readFileSync` threw ENOENT, BullMQ failed the job,
+        // and no drawer / no skill_run row was ever produced — the
+        // canonical "scheduler fires forever into the void" failure.
+        // Now we synthesize a failed run + terminal drawer so dashboards
+        // and silent-failure-watchdog (#69) see the event.
+        if (!existsSync(jobData.manifestPath)) {
+          await handleManifestMissing(data, jobData.manifestPath);
+          // Throw so BullMQ marks the job failed and stops retrying the
+          // same vanishing path forever. The job_failed listener below
+          // will append its own WAL row.
+          throw new Error(`manifest_missing: ${jobData.manifestPath}`);
+        }
         const manifestContent = readFileSync(jobData.manifestPath, "utf-8");
         const manifest = yamlLoad(manifestContent) as Record<string, unknown>;
         const execType = (manifest.execution as Record<string, unknown>)?.type;
@@ -259,6 +275,103 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
 
 export function getWorker(): Worker | null {
   return _worker;
+}
+
+/**
+ * Phantom-skill terminal drawer (#172). Fired when a job arrives carrying
+ * a manifestPath that no longer exists on disk — register-skill may have
+ * persisted an ephemeral path that got cleaned up, or the workspace moved
+ * the file without re-registering.
+ *
+ * Synthesizes a complete failure trail so downstream watchers don't have
+ * to special-case "scheduler tick with no run":
+ *   1. skill_run row created + marked failed (silent-failure-watchdog #69
+ *      counts toward its streak)
+ *   2. Terminal drawer written to a sensible default room — operators
+ *      reading the dashboard see the failure with the missing path and
+ *      a hint when the path was ephemeral
+ *   3. WAL entry tagged `skill_manifest_missing`
+ *
+ * Each step is wrapped in its own try/catch — we want maximum signal even
+ * if one writer is broken (e.g. DB lost). The caller throws afterward so
+ * BullMQ marks the job failed and stops retrying.
+ */
+async function handleManifestMissing(
+  data: SkillJobData,
+  manifestPath: string,
+): Promise<void> {
+  const workspace = data.workspace;
+  const runId = data.runId ?? randomUUID();
+  const skillId = data.skillId ?? "unknown";
+  const stepId = data.stepId ?? "fire";
+  const ephemeral = isEphemeralPath(manifestPath);
+
+  // 1. Skill run row + marked failed. Wrapped because the workspace may
+  // have a stale schema or DB connection issue we don't want to mask
+  // the drawer write.
+  try {
+    await runTracker.createRun({
+      runId,
+      workspace,
+      skillId,
+      skillVersion: data.skillVersion,
+      triggerType: data.triggerType ?? "cron",
+      triggerPayload: data.triggerPayload as Record<string, unknown> | undefined,
+    });
+  } catch (err) {
+    const pgErr = err as { code?: string };
+    // 23505 duplicate PK is fine — another path created the row already.
+    if (pgErr.code !== "23505") {
+      console.warn(`[nexaas] manifest_missing: createRun failed for ${skillId}: ${(err as Error).message}`);
+    }
+  }
+  try {
+    await runTracker.markStepFailed(runId, stepId, `manifest_missing: ${manifestPath}`);
+  } catch (err) {
+    console.warn(`[nexaas] manifest_missing: markStepFailed failed for ${skillId}: ${(err as Error).message}`);
+  }
+
+  // 2. Terminal drawer. Default room is `ops.scheduler.<skillId>` — the
+  // skill's declared primary room is unknowable without the manifest, and
+  // ops.scheduler is where phantom-skill failures naturally belong.
+  try {
+    const session = palace.enter({ workspace, runId, skillId, stepId });
+    await session.writeDrawer(
+      { wing: "ops", hall: "scheduler", room: skillId.replace(/\//g, "-") },
+      JSON.stringify(buildTerminalDrawerPayload(
+        { skill: skillId, terminal_reason: "manifest_missing" },
+        {
+          manifest_path: manifestPath,
+          was_ephemeral_path: ephemeral,
+          trigger_type: data.triggerType ?? "cron",
+        },
+      )),
+    );
+  } catch (err) {
+    console.error(`[nexaas] manifest_missing: drawer write failed for ${skillId}: ${(err as Error).message}`);
+  }
+
+  // 3. WAL entry. Best-effort like everything in this handler.
+  try {
+    await appendWal({
+      workspace,
+      op: "skill_manifest_missing",
+      actor: "bullmq-worker",
+      payload: {
+        run_id: runId,
+        skill_id: skillId,
+        manifest_path: manifestPath,
+        was_ephemeral_path: ephemeral,
+      },
+    });
+  } catch (err) {
+    console.warn(`[nexaas] manifest_missing: WAL append failed for ${skillId}: ${(err as Error).message}`);
+  }
+
+  console.error(
+    `[nexaas] PHANTOM SKILL: '${skillId}' fired but manifest is gone at ${manifestPath}` +
+      (ephemeral ? " (ephemeral path — register without --allow-ephemeral)" : ""),
+  );
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -31,6 +31,19 @@ export {
 export { runCompaction } from "./tasks/closet-compaction.js";
 export { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-reaper.js";
 
+// Skill terminal-state primitives (#171–#174 silent-failure arc)
+export {
+  type TerminalReason,
+  type TerminalDrawerPayload,
+  buildTerminalDrawerPayload,
+  terminalReasonFromAgenticStopReason,
+  isPromptOverflowError,
+  extractPromptOverflowTokens,
+  isEphemeralPath,
+  EPHEMERAL_PATH_PREFIXES,
+  STREAM_PREVIEW_CAP_BYTES,
+} from "./skill-terminal.js";
+
 // PA-as-Router persona profile (RFC-0002 Wave 1, #122)
 export {
   PersonaProfileSchema,

--- a/packages/runtime/src/skill-terminal.ts
+++ b/packages/runtime/src/skill-terminal.ts
@@ -79,6 +79,41 @@ export function buildTerminalDrawerPayload(
 export const STREAM_PREVIEW_CAP_BYTES = 2048;
 
 /**
+ * Filesystem path prefixes that indicate ephemeral storage. Manifests stored
+ * under these are liable to vanish across reboots, systemd-tmpfiles cleanup,
+ * or OOM-prompted /tmp sweeps — leaving the BullMQ scheduler ticking on a
+ * dead repeatable that produces no run, no log, no drawer (#172).
+ *
+ * Trailing slash is intentional — without it `/tmpfoo` would falsely match.
+ */
+export const EPHEMERAL_PATH_PREFIXES = [
+  "/tmp/",
+  "/var/tmp/",
+  "/run/",
+  "/dev/shm/",
+] as const;
+
+/**
+ * Returns true when the absolute path lives under an ephemeral filesystem
+ * prefix. Also checks `$XDG_RUNTIME_DIR` at call time so container and
+ * desktop-session configurations with non-default runtime dirs are caught.
+ *
+ * Caller is responsible for resolving relative paths first — we compare
+ * against absolute prefixes, so passing `./tmp/foo` would not match.
+ */
+export function isEphemeralPath(absPath: string): boolean {
+  if (!absPath) return false;
+  for (const prefix of EPHEMERAL_PATH_PREFIXES) {
+    if (absPath.startsWith(prefix)) return true;
+  }
+  const xdgRuntime = process.env.XDG_RUNTIME_DIR;
+  if (xdgRuntime && absPath.startsWith(xdgRuntime.endsWith("/") ? xdgRuntime : xdgRuntime + "/")) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Detect whether a thrown error represents a prompt-overflow rejection from
  * the model provider (e.g. Anthropic returns 400 with a body that includes
  * "prompt is too long: <N> tokens > <M> maximum" when the assembled request

--- a/scripts/test-manifest-missing-172.mjs
+++ b/scripts/test-manifest-missing-172.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #172 — phantom-skill guards.
+ *
+ * Two halves:
+ *   - Pure: isEphemeralPath() classifier covers /tmp, /run, /var/tmp,
+ *     /dev/shm, $XDG_RUNTIME_DIR; rejects workspace paths.
+ *   - Pure: terminal-drawer shape for manifest_missing.
+ *   - Integration: register-skill's registerOneSkill() refuses an
+ *     ephemeral path and accepts the same manifest from a workspace path,
+ *     and respects --allow-ephemeral via allowEphemeral on the context.
+ *
+ * Run: node --import tsx scripts/test-manifest-missing-172.mjs
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir, homedir } from "os";
+import {
+  isEphemeralPath,
+  buildTerminalDrawerPayload,
+} from "../packages/runtime/src/skill-terminal.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. isEphemeralPath classifier ─────────────────────────────────
+console.log("\n1. isEphemeralPath() classifier");
+{
+  assert(isEphemeralPath("/tmp/skill.yaml") === true, "/tmp/ → ephemeral");
+  assert(isEphemeralPath("/tmp/foo/bar/skill.yaml") === true, "nested under /tmp → ephemeral");
+  assert(isEphemeralPath("/var/tmp/skill.yaml") === true, "/var/tmp → ephemeral");
+  assert(isEphemeralPath("/run/user/1000/skill.yaml") === true, "/run/ → ephemeral");
+  assert(isEphemeralPath("/dev/shm/skill.yaml") === true, "/dev/shm → ephemeral");
+
+  assert(isEphemeralPath("/home/ubuntu/workspace/nexaas-skills/x/skill.yaml") === false,
+    "workspace path → not ephemeral");
+  assert(isEphemeralPath("/opt/nexaas/nexaas-skills/x/skill.yaml") === false,
+    "/opt/ → not ephemeral");
+  assert(isEphemeralPath("/tmpfoo/skill.yaml") === false,
+    "/tmpfoo (not /tmp/) → not ephemeral (trailing-slash matters)");
+  assert(isEphemeralPath("") === false, "empty string → not ephemeral");
+
+  // $XDG_RUNTIME_DIR — set then verify
+  const prev = process.env.XDG_RUNTIME_DIR;
+  process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+  assert(isEphemeralPath("/run/user/1000/skill.yaml") === true,
+    "$XDG_RUNTIME_DIR → ephemeral");
+  // Custom XDG dir outside the canonical prefixes
+  process.env.XDG_RUNTIME_DIR = "/var/runtime/myuser";
+  assert(isEphemeralPath("/var/runtime/myuser/skill.yaml") === true,
+    "custom XDG_RUNTIME_DIR → ephemeral");
+  if (prev === undefined) delete process.env.XDG_RUNTIME_DIR;
+  else process.env.XDG_RUNTIME_DIR = prev;
+}
+
+// ── 2. manifest_missing drawer shape ──────────────────────────────
+console.log("\n2. manifest_missing drawer carries diagnostic hints");
+{
+  const payload = buildTerminalDrawerPayload(
+    { skill: "marketing/freshness-watchdog", terminal_reason: "manifest_missing" },
+    {
+      manifest_path: "/tmp/skill-test.yaml",
+      was_ephemeral_path: true,
+      trigger_type: "cron",
+    },
+  );
+  assert(payload.success === false, "manifest_missing is a failure");
+  assert(payload.terminal_reason === "manifest_missing", "terminal_reason set");
+  assert(payload.manifest_path === "/tmp/skill-test.yaml", "manifest_path carried");
+  assert(payload.was_ephemeral_path === true, "ephemeral hint carried");
+  assert(payload.trigger_type === "cron", "trigger_type carried");
+}
+
+// ── 3. registerOneSkill refuses ephemeral path without override ───
+console.log("\n3. registerOneSkill() refuses ephemeral path");
+{
+  // Lazy-import so the runtime tsx pipeline doesn't init BullMQ until we need it.
+  const { registerOneSkill } = await import("../packages/cli/src/register-skill.ts");
+
+  // Create a manifest at /tmp/ that's otherwise valid.
+  const dir = mkdtempSync(join(tmpdir(), "manifest-missing-test-"));
+  const manifestPath = join(dir, "skill.yaml");
+  writeFileSync(manifestPath, [
+    "id: ops/test-ephemeral",
+    "version: 1.0.0",
+    "triggers:",
+    "  - type: cron",
+    "    schedule: '0 * * * *'",
+    "execution:",
+    "  type: shell",
+    "  command: echo hi",
+  ].join("\n"));
+
+  // No Redis queue is needed — refusal happens before any queue use.
+  const fakeQueue = { upsertJobScheduler: async () => {}, getRepeatableJobs: async () => [], removeRepeatableByKey: async () => {} };
+  const ctx = { queue: fakeQueue, workspace: "test", workspaceTz: "UTC" };
+
+  const refused = await registerOneSkill(manifestPath, ctx);
+  assert(refused.status === "error", "ephemeral path → status=error");
+  assert(typeof refused.error === "string" && refused.error.includes("ephemeral"),
+    "error message mentions 'ephemeral'");
+  assert(typeof refused.error === "string" && refused.error.includes("--allow-ephemeral"),
+    "error message hints at the --allow-ephemeral override");
+
+  // With allowEphemeral true the path check is bypassed. The call will
+  // hit the fake queue (which accepts anything) and report success.
+  const accepted = await registerOneSkill(manifestPath, { ...ctx, allowEphemeral: true });
+  assert(accepted.status === "registered" || accepted.status === "no-triggers",
+    `--allow-ephemeral bypass works (status=${accepted.status})`);
+
+  // Cleanup
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 4. Non-ephemeral path is accepted ─────────────────────────────
+console.log("\n4. registerOneSkill() accepts workspace path");
+{
+  const { registerOneSkill } = await import("../packages/cli/src/register-skill.ts");
+
+  // Place the manifest under the user's home dir (definitely not ephemeral).
+  const dir = join(homedir(), `.nexaas-test-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  const manifestPath = join(dir, "skill.yaml");
+  writeFileSync(manifestPath, [
+    "id: ops/test-workspace",
+    "version: 1.0.0",
+    "triggers:",
+    "  - type: cron",
+    "    schedule: '*/5 * * * *'",
+    "execution:",
+    "  type: shell",
+    "  command: echo hi",
+  ].join("\n"));
+
+  const fakeQueue = { upsertJobScheduler: async () => {}, getRepeatableJobs: async () => [], removeRepeatableByKey: async () => {} };
+  const result = await registerOneSkill(manifestPath, { queue: fakeQueue, workspace: "test", workspaceTz: "UTC" });
+  assert(result.status !== "error" || !(result.error?.includes("ephemeral")),
+    `workspace path accepted (status=${result.status})`);
+
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #172. Final slice of the silent-failure arc (#171, #172, #173, #174). Two guards close the \"scheduler ticks forever on a vanished manifest\" failure class:

## Guard 1 — register-skill refuses ephemeral paths

\`/tmp\`, \`/var/tmp\`, \`/run\`, \`/dev/shm\`, and \`\$XDG_RUNTIME_DIR\` are refused by default. The CLI exposes \`--allow-ephemeral\` for operators with a legitimate need (integration tests, throwaway dry-runs); the library path takes \`allowEphemeral: true\` on \`RegisterContext\`. The error message names the override so the next attempt is informed:

\`\`\`
manifest path '/tmp/skill-test.yaml' is ephemeral (under /tmp, /run, /var/tmp,
/dev/shm, or \$XDG_RUNTIME_DIR). The scheduler would tick forever on a
vanishing file. Move it under \$NEXAAS_WORKSPACE_ROOT/nexaas-skills/ or
pass --allow-ephemeral if you know what you're doing.
\`\`\`

## Guard 2 — worker synthesizes a failure trail when manifest is gone at fire time

Previously \`readFileSync\` in \`bullmq/worker.ts\` threw ENOENT, BullMQ failed the job, and the workspace had no observable signal beyond a generic \`job_failed\` WAL row. No skill_run, no drawer, silent-failure-watchdog #69 never saw it. Now \`handleManifestMissing()\`:
- Creates a \`skill_run\` row + marks it failed (silent-failure-watchdog now counts the streak)
- Writes terminal drawer to \`ops.scheduler.<skillId>\` with \`terminal_reason: \"manifest_missing\"\`, carrying \`manifest_path\` and \`was_ephemeral_path\` for diagnosis
- Appends \`skill_manifest_missing\` WAL row
- Throws to BullMQ so the job is marked failed and retries stop

Each step is its own try/catch — maximum signal even when one writer is broken.

## New primitives in \`skill-terminal.ts\`
- \`EPHEMERAL_PATH_PREFIXES\` — canonical list, shared by both guards
- \`isEphemeralPath(absPath)\` — also honors \`\$XDG_RUNTIME_DIR\` at call time for container / desktop-session configs

Runtime \`index.ts\` now re-exports the full silent-failure-arc surface so other consumers (Nexmatic, library tools) can adopt the discriminator without re-implementing the heuristics.

## Arc summary
Every terminal state in a skill's lifecycle now produces a drawer with a canonical \`terminal_reason\`. The \"no drawer\" state has been eliminated as a representable outcome across:
- shell-skill (#175 → closes #171)
- ai-skill loop aborts + exceptions (#176 → closes #174)
- prompt-overflow classification (#177 → closes #173)
- scheduler fire path (this PR → closes #172)

## Test plan
- [x] \`node --import tsx scripts/test-manifest-missing-172.mjs\` — 21 new assertions pass (classifier coverage, drawer shape, register-skill refusal w/ + w/o override, workspace path acceptance)
- [x] All prior tests green: #171 (19), #174 (25), #173 (21)
- [x] \`npx tsc --noEmit\` clean in both \`packages/runtime\` and \`packages/cli\`
- [ ] Smoke: \`nexaas register-skill /tmp/foo.yaml\` returns the new error message naming \`--allow-ephemeral\`
- [ ] Smoke: \`nexaas register-skill /tmp/foo.yaml --allow-ephemeral\` succeeds
- [ ] Smoke: register a skill, delete the manifest file, wait for next cron tick — palace has a drawer at \`ops.scheduler.<skillId>\` with \`terminal_reason: \"manifest_missing\"\` and \`was_ephemeral_path: true/false\` correctly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)