### PR TITLE
feat(chain-reliability): required outputs + chain_signal kind for multi-skill chains

### DIFF
--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -81,6 +81,13 @@ export interface AiSkillManifest {
     notify?: { channel_role: string; timeout?: string };
     verify?: OutputVerification;
     /**
+     * When true, the executor verifies the agent called
+     * `framework__produce_output(id, ...)` for this output before end_turn.
+     * If not, the run terminates with `terminal_reason: "required_output_missing"`
+     * — closes the silent-stall failure mode in multi-skill chains (#180).
+     */
+    required?: boolean;
+    /**
      * Per-output format hint for `kind: notification` outputs routed via
      * the primary_output auto-map (#61). Values: "plain" | "markdown"
      * | "html" — framework-canonical per messaging-outbound v0.2 (#38).
@@ -558,6 +565,46 @@ export async function runAiSkill(
     } catch { /* non-fatal — billing table may not exist on all installs */ }
 
     await runTracker.markStepCompleted(runId, stepId);
+
+    // Required-output check (#180) — multi-skill chains declare the
+    // next-stage signal as `outputs[].required: true` so a hallucinated
+    // success (agent says "signal emitted" but didn't call produce_output)
+    // surfaces as a structured failure instead of a silently-stalled chain.
+    // Runs only when the loop completed cleanly — aborts already block the
+    // chain via the existing terminal_reason discriminator.
+    const missingRequired: string[] = !result.aborted
+      ? (manifest.outputs ?? [])
+          .filter((o) => o.required === true)
+          .map((o) => o.id)
+          .filter((id) => !frameworkToolsState.producedOutputs.includes(id))
+      : [];
+    if (missingRequired.length > 0) {
+      const summary = `required output(s) not produced: ${missingRequired.join(", ")}`;
+      await session.writeDrawer(
+        primaryRoom,
+        JSON.stringify(buildTerminalDrawerPayload(
+          { skill: manifest.id, terminal_reason: "required_output_missing" },
+          {
+            missing_outputs: missingRequired,
+            produced_outputs: frameworkToolsState.producedOutputs,
+            turns: result.turns,
+          },
+        )),
+      );
+      await appendWal({
+        workspace,
+        op: "ai_skill_required_output_missing",
+        actor: `skill:${manifest.id}`,
+        payload: {
+          run_id: runId,
+          missing: missingRequired,
+          produced: frameworkToolsState.producedOutputs,
+        },
+      });
+      await runTracker.markStepFailed(runId, stepId, summary);
+      console.warn(`[nexaas] AI skill '${manifest.id}' ${summary}`);
+      return { success: false, turns: result.turns, toolCalls: result.toolCalls.length, content: result.content };
+    }
 
     // Output verification (#28) — only when the loop wasn't already aborted.
     // A skill that declares `outputs[].verify` gets checked here before the

--- a/packages/runtime/src/engine/apply.ts
+++ b/packages/runtime/src/engine/apply.ts
@@ -130,6 +130,35 @@ export async function apply(
         break;
       }
 
+      // Chain-signal kind (#180) — multi-skill chains use this to emit a
+      // next-stage trigger that an inbound-message-triggered skill picks up.
+      // The inbound-dispatcher polls `inbox.messaging.<channel_role>` and
+      // by convention `channel_role === output_id`, so we write to that
+      // exact room. The agent's payload becomes the drawer content; the
+      // downstream skill receives it via triggerPayload.
+      if (action.output_kind === "chain_signal") {
+        const channelRole = action.action.kind; // produce_output sets kind = output.id
+        await session.writeDrawer(
+          { wing: "inbox", hall: "messaging", room: channelRole },
+          JSON.stringify(action.action.payload ?? {}),
+          { run_id: runId, step_id: stepId },
+        );
+        await appendWal({
+          workspace,
+          op: "action_auto_executed",
+          actor: `skill:${session.ctx.skillId}`,
+          payload: {
+            run_id: runId,
+            step_id: stepId,
+            action_kind: action.action.kind,
+            output_kind: "chain_signal",
+            channel_role: channelRole,
+            source: action.source,
+          },
+        });
+        break;
+      }
+
       // Default path — non-notification kinds write to events.skill.executed
       // as before. Palace_write / external_send / mcp_tool_call / etc. go
       // through this branch; future stages add their own kind-specific

--- a/packages/runtime/src/skill-terminal.ts
+++ b/packages/runtime/src/skill-terminal.ts
@@ -36,7 +36,8 @@ export type TerminalReason =
   | "prompt_overflow"  // model rejected request as too long (#173)
   | "rate_limited"     // 429 from model provider
   | "manifest_missing" // scheduler fired but manifest file is gone (#172)
-  | "verification_failed"; // ai-skill output verification failed required checks
+  | "verification_failed" // ai-skill output verification failed required checks
+  | "required_output_missing"; // ai-skill ended without producing a required output (#180)
 
 export interface TerminalDrawerPayload {
   skill: string;

--- a/packages/runtime/src/tag/route.ts
+++ b/packages/runtime/src/tag/route.ts
@@ -29,6 +29,7 @@ export type OutputKind =
   | "palace_write"          // drawer write (committing a decision)
   | "subagent_invocation"   // spawning a sub-agent run
   | "mcp_tool_call"         // arbitrary MCP tool dispatch
+  | "chain_signal"          // emit the next-stage signal for a multi-skill chain (#180)
   | (string & {});           // allow custom kinds without narrowing
 
 export interface ManifestNotifyConfig {
@@ -76,6 +77,19 @@ export interface ManifestOutput {
   approval?: ManifestApproval;
   overridable?: boolean;
   overridable_to?: RoutingDecision[];
+  /**
+   * When true, the ai-skill executor verifies the agent called
+   * `framework__produce_output` for this output id before declaring
+   * end_turn. If not, the run terminates with
+   * `terminal_reason: "required_output_missing"` and a drawer naming the
+   * missing output (#180).
+   *
+   * Used by multi-skill chains: declare the next-stage signal as a
+   * required output of `kind: chain_signal` so a hallucinated success
+   * (agent says "signal emitted" but didn't actually call the tool)
+   * surfaces as a structured failure instead of a stalled chain.
+   */
+  required?: boolean;
   notify?: ManifestNotifyConfig;                     // legacy field; prefer `approval.channel_role` for approval flows
   conditions?: Array<{                               // reserved for future stages; evaluator stub
     if: string;

--- a/scripts/test-required-outputs-180.mjs
+++ b/scripts/test-required-outputs-180.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Regression test for #180 — required outputs + chain_signal kind.
+ *
+ * Verifies the contract pieces in isolation: the TerminalReason union
+ * includes the new value, the drawer payload shape is right, and the
+ * conceptual required-output computation matches what ai-skill.ts does.
+ * Runtime wiring (engine.apply routing + ai-skill catch) is covered by
+ * smoke tests against a real workspace.
+ *
+ * Run: node --import tsx scripts/test-required-outputs-180.mjs
+ */
+
+import { buildTerminalDrawerPayload } from "../packages/runtime/src/skill-terminal.ts";
+
+let pass = 0;
+let fail = 0;
+function assert(cond, msg) {
+  if (cond) { console.log(`  ✓ ${msg}`); pass++; }
+  else { console.log(`  ✗ ${msg}`); fail++; }
+}
+
+// ── 1. required_output_missing drawer shape ───────────────────────
+console.log("\n1. required_output_missing drawer carries missing+produced lists");
+{
+  const payload = buildTerminalDrawerPayload(
+    { skill: "promo/research", terminal_reason: "required_output_missing" },
+    {
+      missing_outputs: ["promo_draft_ready"],
+      produced_outputs: ["promo_research_done"],
+      turns: 8,
+    },
+  );
+  assert(payload.success === false, "required_output_missing is failure");
+  assert(payload.terminal_reason === "required_output_missing", "reason set");
+  assert(Array.isArray(payload.missing_outputs) && payload.missing_outputs[0] === "promo_draft_ready",
+    "missing_outputs list carried");
+  assert(Array.isArray(payload.produced_outputs) && payload.produced_outputs[0] === "promo_research_done",
+    "produced_outputs list carried (diagnostic: shows what DID happen)");
+  assert(payload.turns === 8, "turns preserved");
+}
+
+// ── 2. missingRequired computation matches ai-skill.ts logic ──────
+console.log("\n2. missing-required computation mirrors ai-skill.ts");
+function computeMissing(outputs, produced, aborted) {
+  if (aborted) return [];
+  return outputs
+    .filter((o) => o.required === true)
+    .map((o) => o.id)
+    .filter((id) => !produced.includes(id));
+}
+{
+  // Case A: all required outputs produced
+  const allOk = computeMissing(
+    [{ id: "a", required: true }, { id: "b", required: false }],
+    ["a", "b"],
+    false,
+  );
+  assert(allOk.length === 0, "all required produced → no missing");
+
+  // Case B: one required missing
+  const oneMissing = computeMissing(
+    [{ id: "stage_1_complete", required: true }],
+    [],
+    false,
+  );
+  assert(oneMissing.length === 1 && oneMissing[0] === "stage_1_complete",
+    "missing required surfaced");
+
+  // Case C: optional output not produced — no failure
+  const optionalOnly = computeMissing(
+    [{ id: "metrics_dump" }, { id: "audit_blob", required: false }],
+    [],
+    false,
+  );
+  assert(optionalOnly.length === 0, "optional outputs don't trigger failure");
+
+  // Case D: loop aborted → no check (abort already terminates with its
+  // own reason; we don't double-report)
+  const aborted = computeMissing(
+    [{ id: "stage_1_complete", required: true }],
+    [],
+    true,
+  );
+  assert(aborted.length === 0, "aborted loop skips required check");
+
+  // Case E: multiple missing reported together
+  const multi = computeMissing(
+    [
+      { id: "a", required: true },
+      { id: "b", required: true },
+      { id: "c", required: true },
+    ],
+    ["b"],
+    false,
+  );
+  assert(multi.length === 2 && multi.includes("a") && multi.includes("c"),
+    "multiple missing required reported");
+}
+
+// ── 3. chain_signal routing convention ────────────────────────────
+console.log("\n3. chain_signal routes to inbox.messaging.<output_id>");
+{
+  // engine.apply uses action.action.kind as the channel_role for chain_signal.
+  // produce_output sets kind = output.id, so output_id directly becomes the
+  // room name — matching the inbound-dispatcher convention (room === channel_role).
+  const outputId = "stage_1_complete";
+  const room = { wing: "inbox", hall: "messaging", room: outputId };
+  assert(room.wing === "inbox" && room.hall === "messaging" && room.room === "stage_1_complete",
+    "chain_signal target room: inbox.messaging.<output_id>");
+  // Verify the next step's trigger would match: an inbound-message trigger
+  // with channel_role: stage_1_complete polls exactly this room.
+  const trigger = { type: "inbound-message", channel_role: "stage_1_complete" };
+  assert(trigger.channel_role === room.room, "channel_role === room (dispatcher convention)");
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #180. Adopts the smallest framework primitive that solves Phoenix's silent chain-stall failure mode by extending two existing primitives instead of adding new infrastructure.

## The failure being closed

Multi-skill chains (cron → research → asset-find → ...) plumbed via `inbound-message` triggers have a silent-failure surface: each step is supposed to emit the next-stage signal via `framework__produce_output`, but the agent often hallucinates having made the call ("Perfect! Signal emitted") without actually calling the tool. The skill exits with `terminal_reason: ok`, no error, but no row landed at the trigger room — the chain stalls until an operator manually emits the missing signal. Phoenix has hit this every chain transition since the pattern was introduced.

## What's new

**1. `OutputKind: "chain_signal"`** — when `produce_output` is called for a kind: chain_signal output, `engine.apply` writes the drawer to `inbox.messaging.<output_id>`, matching the inbound-dispatcher's `channel_role === room` convention (`packages/runtime/src/tasks/inbound-dispatcher.ts:213`). The next step's `inbound-message` trigger with the same channel_role picks it up. Deterministic emit — agent reliability is irrelevant for the actual write.

**2. `outputs[].required: true`** — at end_turn (loop completed cleanly), the executor verifies the agent called `framework__produce_output` for every required output. If any are missing, the run terminates with `terminal_reason: "required_output_missing"` (extends the #175 union) and a drawer carrying `missing_outputs` + `produced_outputs` for diagnosis. The hallucinated-success failure mode becomes a structured failure that silent-failure-watchdog (#69) and dashboards can render.

## Why this is framework-shaped (and small)

The two pieces are minimal extensions to existing infrastructure:
- `produce_output` + TAG routing + `framework__produce_output` already exist (#45 Stage 1b, #60)
- `frameworkToolsState.producedOutputs` already tracks which outputs fired
- The new check is one filter against that list at end_turn
- The new routing is one branch in `engine.apply`'s auto_execute case

No new MCP tool, no new event dispatcher, no new staging-room pattern. Per pragmatic-primitives discipline: extend what's already in the system.

## Phoenix's manifest after this lands

Each chain step's manifest declares the next-stage signal as a required `chain_signal` output:

\`\`\`yaml
outputs:
  - id: stage_1_complete
    kind: chain_signal
    routing_default: auto_execute
    required: true
\`\`\`

Agent calling \`framework__produce_output('stage_1_complete', payload)\` → deterministic emit. Failing to call it → structured abort. Both behaviors are framework-shaped; no per-adopter staging-room reinvention.

## Why not the alternatives the issue listed

| Option | Why declined |
|---|---|
| A — verification turn (purely prompt) | Doesn't solve the problem, just adds another step the agent could skip |
| B — composite shell + ai skill staging | Pure workspace pattern; would force every adopter to reinvent the same staging-room pattern |
| C — alone (just verify the call happened) | Surfaces the failure but doesn't fix it — agent that ignored produce_output once will ignore it twice |
| D — alone (declarative emit) | Useful, but on its own can't catch "agent didn't call produce_output at all" |

This PR is **C + D combined into one extension**: the deterministic emit (D's value) lives in `chain_signal`'s engine routing; the required-call check (C's value) is the `required: true` field. Both are needed; the existing produce_output plumbing makes the combination cheap.

## Test plan
- [x] `node --import tsx scripts/test-required-outputs-180.mjs` — 12 assertions pass (drawer shape, missing-required computation including abort short-circuit + multi-missing, chain_signal routing convention)
- [x] All prior tests green (#171 19, #172 21, #173 21, #174 25 — total 86)
- [x] `npx tsc --noEmit` clean in `packages/runtime`
- [ ] Smoke: register a two-skill chain on Phoenix (step-1 with `chain_signal` required output, step-2 with matching `inbound-message` trigger); fire step-1 with an agent that calls produce_output → chain advances autonomously
- [ ] Smoke: fire step-1 with an agent that's prompted NOT to call produce_output → run terminates with `terminal_reason: required_output_missing`, no row at `inbox.messaging.stage_1_complete`, downstream step doesn't fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)