### PR TITLE
feat(worker): refuse snap node + tsx wrapping at startup (#185)

### DIFF
--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -1,8 +1,12 @@
 /**
  * Nexaas worker entry point — starts BullMQ worker + outbox relay + Bull Board dashboard.
  *
- * This is what the nexaas-worker systemd service runs:
- *   ExecStart=/snap/bin/node /opt/nexaas/node_modules/.bin/tsx /opt/nexaas/packages/runtime/src/worker.ts
+ * This is what the nexaas-worker systemd service runs in production:
+ *   ExecStart=/usr/bin/node --conditions=production /opt/nexaas/packages/runtime/dist/worker.js
+ *
+ * Snap-installed node and tsx wrapping are both refused at startup — see PR
+ * #162 + #185. Dev/test runs that legitimately go through tsx can opt out
+ * with NEXAAS_ALLOW_DEV_LAUNCH=1.
  *
  * It starts:
  * 1. The BullMQ skill step worker (processes jobs through the pillar pipeline)
@@ -74,6 +78,41 @@ const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
 
 if (!WORKSPACE) {
   console.error("NEXAAS_WORKSPACE is required");
+  process.exit(1);
+}
+
+// Runtime self-checks — refuse to start on the launch patterns the framework
+// already rejects elsewhere (PR #162 covered nexaas init; this enforces at
+// worker boot so adopters can't silently regress).
+//
+// Snap-installed node is unconditional: it swallows journald stdout, escapes
+// cgroup cleanup, and rejects --conditions=production. There is no
+// legitimate reason for the worker to run under /snap/bin/node.
+if (process.execPath.startsWith("/snap/")) {
+  console.error(
+    `[nexaas] refusing to start: process.execPath=${process.execPath} (snap-installed node). ` +
+      `See PR #162. Install NodeSource node and run from /usr/bin/node.`,
+  );
+  process.exit(1);
+}
+
+// tsx-wrapped launches are refused in production but opt-outable for dev/test.
+// In production the unit MUST run the compiled dist/worker.js so Node's
+// --conditions=production routes cross-package imports through dist/ rather
+// than src/ via tsx transforms. NEXAAS_ALLOW_DEV_LAUNCH=1 bypasses for scripts
+// that knowingly invoke `node --import tsx packages/runtime/src/worker.ts`.
+const entryArg = process.argv[1] ?? "";
+const launchedViaTsx =
+  entryArg.endsWith("/tsx") ||
+  entryArg.includes("/tsx/") ||
+  entryArg.endsWith("worker.ts");
+if (launchedViaTsx && process.env.NEXAAS_ALLOW_DEV_LAUNCH !== "1") {
+  console.error(
+    `[nexaas] refusing to start: launched via tsx (argv[1]=${entryArg}). ` +
+      `Production must run compiled JS: ` +
+      `'node --conditions=production /opt/nexaas/packages/runtime/dist/worker.js'. ` +
+      `Set NEXAAS_ALLOW_DEV_LAUNCH=1 for dev/test runs that knowingly go through tsx.`,
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- Refuses to start when `process.execPath` is under `/snap/` (snap-installed node — see PR #162)
- Refuses to start when `argv[1]` resolves to `tsx` or `src/worker.ts` directly, unless `NEXAAS_ALLOW_DEV_LAUNCH=1` is set
- Updates the leading doc-block to reflect the production ExecStart line
- Closes #185

## Why

PR #162 established that `nexaas init` refuses snap-installed node, but the worker itself didn't check at startup. Phoenix Voyages ran on snap node + tsx for months without visible failure — until journald-swallowed stdout, cgroup-escape orphans, and stop-sigterm → SIGKILL events surfaced the misconfiguration. By the time it was detected there had been two SIGKILL events in a single day.

Without a startup check, the framework's own "refused configuration" doc was being silently violated by adopters who installed once and never re-audited.

## Behavior

| Launch | Behavior |
|---|---|
| `/usr/bin/node --conditions=production dist/worker.js` | Starts normally |
| `/snap/bin/node ...` | **Refuses, exits 1.** No bypass — snap node is broken for this workload. |
| `node --import tsx packages/runtime/src/worker.ts` | Refuses, exits 1. **Bypass: `NEXAAS_ALLOW_DEV_LAUNCH=1`** (dev/test runs). |
| `tsx packages/runtime/src/worker.ts` | Same as above. |

Error messages include the correct production launch command and the bypass env var name.

## Breaking impact

Adopters currently running on **snap node** must switch to NodeSource node before pulling this change. Adopters currently running the worker via **tsx in production** must either switch to compiled JS (`node --conditions=production dist/worker.js`) or set `NEXAAS_ALLOW_DEV_LAUNCH=1`.

Phoenix Voyages is one such adopter — they're already planning a Phase 0 fix to NodeSource + `dist/worker.js` as part of their migration. Other direct adopters should audit `cat /etc/systemd/system/nexaas-worker.service | grep ExecStart` before upgrading.

## Test plan

- [ ] On a clean NodeSource Node 20 install: worker starts normally
- [ ] On snap-installed node: worker refuses with the documented error message
- [ ] Launched via tsx without bypass: refuses
- [ ] Launched via tsx with `NEXAAS_ALLOW_DEV_LAUNCH=1`: starts (legitimate dev/test path)
- [ ] `npm run build` succeeds — TypeScript compilation passes

## Related

- Closes #185
- References PR #162 (snap node refusal in `nexaas init`)
- Phoenix Voyages migration coordination brief §6 item 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)