### PR TITLE
fix(pa-delivery): enqueueDelivery writes status=NULL, claim accepts NULL too (#182)

### DIFF
--- a/packages/runtime/src/pa/delivery.ts
+++ b/packages/runtime/src/pa/delivery.ts
@@ -19,8 +19,18 @@
  *
  * Workspace consumers written before these helpers can migrate at
  * their own cadence — helpers are opt-in and operate against the same
- * table schema. The framework writes 'queued' rows; consumers using
- * the old query patterns continue to work.
+ * table schema. enqueueDelivery writes status=NULL (not 'queued') so
+ * both consumer patterns work against the same row:
+ *
+ *   - Framework consumers using claimNextDelivery() see NULL and 'failed'
+ *     rows as eligible and transition them to 'claimed' → 'sent'.
+ *   - Pre-helper workspace consumers using the LEFT-JOIN-NULL pattern
+ *     (`WHERE m.status IS NULL OR m.status='failed'`) see the same row
+ *     and can deliver via their own upsert path.
+ *
+ * The earlier behavior — enqueueDelivery writing status='queued' — was
+ * incompatible with LEFT-JOIN-NULL consumers (the 'queued' filter
+ * silently excluded pre-seeded rows). See #182.
  */
 
 import { sql, sqlOne, appendWal } from "@nexaas/palace";
@@ -94,6 +104,12 @@ export interface DeliveryClaim {
  * with the same drawer_id is a no-op (allows the caller to safely
  * retry after a transient db failure).
  *
+ * The marker is inserted with status=NULL so both framework consumers
+ * (claimNextDelivery, which treats NULL/queued/failed as eligible) and
+ * pre-helper workspace consumers (LEFT-JOIN-NULL pattern) see it. See
+ * #182 for the previous 'queued'-write bug that silently dropped
+ * drawers for LEFT-JOIN-NULL consumers.
+ *
  * The marker's release_at is computed from the urgency tier so
  * claimNextDelivery can gate dispatch without the consumer having to
  * implement tier-aware scheduling itself. `immediate` releases now;
@@ -111,7 +127,7 @@ export async function enqueueDelivery(
   await sql(
     `INSERT INTO nexaas_memory.pa_delivery_marker
        (workspace, drawer_id, user_hall, thread_id, status, release_at)
-     VALUES ($1, $2, $3, $4, 'queued', $5)
+     VALUES ($1, $2, $3, $4, NULL, $5)
      ON CONFLICT (workspace, drawer_id) DO NOTHING`,
     [workspace, drawer_id, user_hall, thread_id, releaseAt],
   );
@@ -122,9 +138,11 @@ export async function enqueueDelivery(
  * if no eligible row exists. Concurrent callers for the same thread
  * serialize via SKIP LOCKED; different threads can claim in parallel.
  *
- * Eligible = status in ('queued', 'failed') AND retries < MAX_RETRIES.
- * Rows above MAX_RETRIES are moved to 'dead' by markDeliveryFailed and
- * stop being eligible.
+ * Eligible = status IS NULL OR status IN ('queued', 'failed') AND
+ * retries < MAX_RETRIES. NULL is the post-#182 default for freshly
+ * enqueued markers; 'queued' is preserved for legacy rows. Rows above
+ * MAX_RETRIES are moved to 'dead' by markDeliveryFailed and stop being
+ * eligible.
  */
 export async function claimNextDelivery(
   workspace: string,
@@ -142,7 +160,7 @@ export async function claimNextDelivery(
         WHERE workspace = $1
           AND user_hall = $2
           AND thread_id = $3
-          AND status IN ('queued', 'failed')
+          AND (status IS NULL OR status IN ('queued', 'failed'))
           AND retries < $4
           AND release_at <= now()
         ORDER BY claimed_at ASC


### PR DESCRIPTION
## Summary

Resolves the silent-drop bug in `nexaas_memory.pa_delivery_marker`. Two consumer patterns now both work against the same row:

| Consumer pattern | Eligibility filter | Works before this PR? | After |
|---|---|---|---|
| Framework (`claimNextDelivery`) | `status IN ('queued', 'failed')` | ✅ (but zero call sites) | ✅ (filter widened to include NULL) |
| LEFT-JOIN-NULL workspace (Phoenix's `pa/routed-deliver`) | `status IS NULL OR status='failed'` | ❌ (queued rows invisible) | ✅ (writes are NULL) |

Closes #182.

## Root cause

The framework had two incompatible state machines on the same table:

- `packages/runtime/src/pa/delivery.ts::enqueueDelivery` pre-inserted `status='queued'` with a `release_at` hold window.
- `packages/runtime/src/pa/delivery.ts::claimNextDelivery` expected to atomically transition `queued → claimed → sent` via `FOR UPDATE SKIP LOCKED`.
- Workspace adopters that wrote against the same table BEFORE these helpers existed (Phoenix's `pa/routed-deliver` skill) used a different pattern: `WHERE m.status IS NULL OR m.status='failed'` and `INSERT … ON CONFLICT DO UPDATE` straight to `status='sent'`. The `'queued'` filter silently excluded framework-seeded rows.
- `claimNextDelivery` has **zero production call sites** in the framework — so the framework path was shipping an unimplementable contract while the framework writer was poisoning the workspace path.

Phoenix Voyages observed **6 silently-dropped PA drawers** from a single afternoon (Ken Canning insurance reminder, broadcast #185 alert, Samantha Burton First Flight, Princess Cruises ×2). All recoverable via SQL but the underlying bug needed the upstream fix.

## What changes

```diff
-  VALUES ($1, $2, $3, $4, 'queued', $5)
+  VALUES ($1, $2, $3, $4, NULL, $5)
```

```diff
-  AND status IN ('queued', 'failed')
+  AND (status IS NULL OR status IN ('queued', 'failed'))
```

Plus two doc-block updates describing the dual-consumer contract correctly. The earlier "framework writes 'queued' rows; consumers using the old query patterns continue to work" comment was demonstrably false — workspace evidence proved it.

## Why not Option B (ship a canonical consumer skill)?

Option B (ship a default `pa/routed-deliver` skill in the framework using `claimNextDelivery()`) is still the right long-term direction — see issue #182. But:

- This PR is workspace-agnostic and unblocks every direct adopter today
- Option B is a larger change (new skill, registration semantics, deprecation of workspace-side consumers)
- The two paths are compatible after this change — Option B can land later without conflict

Recommend treating this as the short-term fix and tracking Option B separately.

## Backwards compatibility

- Workspaces using the LEFT-JOIN-NULL pattern: **fixed silently** — markers that would previously drop now deliver.
- Workspaces that DID implement `claimNextDelivery()`-style consumers: still work — eligibility filter now accepts NULL in addition to the original states. Existing 'queued' rows from before this PR still match.
- Schemas: no migration required. `pa_delivery_marker.status` is already nullable (the column has no NOT NULL constraint based on schema definition in migration 021).

## Test plan

- [ ] `enqueueDelivery` followed by `claimNextDelivery` on the same thread: claim succeeds (regression test for the framework path)
- [ ] `enqueueDelivery` followed by a LEFT-JOIN-NULL query against `events ⨝ pa_delivery_marker`: drawer is visible
- [ ] Phoenix's `pa/routed-deliver` skill running against a deployment with this fix: 6 currently-stuck drawers deliver on next tick (per Phoenix's recovery SQL in #182 comment)
- [ ] Existing 'queued' rows in production databases (legacy) are still eligible to claim after upgrade

## Related

- Closes #182 (with comment thread for Phoenix's defensive patch + recovery SQL)
- Phoenix Voyages migration coordination brief §3.1
- Followup: ship a canonical `pa/routed-deliver` framework skill (Option B in #182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)