### PR TITLE
feat(cli): add 'nexaas migration-state' subcommand (#184)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,9 @@ switch (command) {
   case "verify-wal":
     import("./verify-wal.js").then((m) => m.run(process.argv.slice(3)));
     break;
+  case "migration-state":
+    import("./migration-state.js").then((m) => m.run(process.argv.slice(3)));
+    break;
   case "onboard":
     import("./onboard.js").then((m) => m.run(process.argv.slice(3)));
     break;
@@ -93,6 +96,7 @@ Commands:
   doctor locks [--since 24h]           Concurrency-group lock contention report
   status                                Check runtime health
   verify-wal [--full]                   Verify WAL chain integrity
+  migration-state [--json]              Print applied/pending migrations from the canonical tracker
 
 Usage:
   nexaas <command> [options]

--- a/packages/cli/src/migration-state.ts
+++ b/packages/cli/src/migration-state.ts
@@ -1,0 +1,180 @@
+/**
+ * nexaas migration-state — print canonical migration tracker state.
+ *
+ * Direct-adopter workspaces can end up with two `schema_migrations` tables —
+ * one in `public` (residual from a pre-palace migration runner), one in
+ * `nexaas_memory` (the framework's real tracker). Operators or tooling that
+ * default to `\dt` or query the wrong one get a misleading answer. See #184.
+ *
+ * This command always reads from `nexaas_memory.schema_migrations`, compares
+ * to the migration files on disk, and warns about residual `public` state.
+ *
+ * Usage:
+ *   nexaas migration-state           Human-readable summary
+ *   nexaas migration-state --json    Machine-readable output
+ */
+
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { createPool, sql, sqlOne } from "@nexaas/palace";
+
+interface AppliedRow {
+  filename: string;
+  applied_at: string;
+}
+
+interface ResidualRow {
+  filename: string;
+}
+
+interface State {
+  canonical_schema: "nexaas_memory";
+  canonical_table: "nexaas_memory.schema_migrations";
+  applied_count: number;
+  applied: AppliedRow[];
+  pending: string[];
+  migrations_dir: string;
+  residual_public: {
+    table_exists: boolean;
+    row_count: number;
+    rows: ResidualRow[];
+  };
+}
+
+function findMigrationsDir(): string | null {
+  const fromEnv = process.env.NEXAAS_ROOT;
+  const candidates = [
+    fromEnv ? join(fromEnv, "database", "migrations") : null,
+    "/opt/nexaas/database/migrations",
+    join(process.cwd(), "database", "migrations"),
+  ].filter(Boolean) as string[];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+async function gatherState(): Promise<State> {
+  const migrationsDir = findMigrationsDir();
+  if (!migrationsDir) {
+    throw new Error(
+      "Could not locate database/migrations directory. " +
+        "Set NEXAAS_ROOT or run from within the framework checkout.",
+    );
+  }
+
+  const onDisk = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  const applied = await sql<AppliedRow>(
+    `SELECT filename, applied_at::text AS applied_at
+       FROM nexaas_memory.schema_migrations
+      ORDER BY applied_at, filename`,
+  );
+
+  const appliedSet = new Set(applied.map((r) => r.filename));
+  const pending = onDisk.filter((f) => !appliedSet.has(f));
+
+  // Detect residual public.schema_migrations — common foot-gun on
+  // pre-palace deploys.
+  const publicTableCheck = await sqlOne<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'schema_migrations'
+     ) AS exists`,
+  );
+  const publicTableExists = publicTableCheck?.exists ?? false;
+
+  let residualRows: ResidualRow[] = [];
+  if (publicTableExists) {
+    try {
+      residualRows = await sql<ResidualRow>(
+        `SELECT filename FROM public.schema_migrations ORDER BY filename`,
+      );
+    } catch {
+      // Column name differs in some legacy installs; best-effort.
+      residualRows = [];
+    }
+  }
+
+  return {
+    canonical_schema: "nexaas_memory",
+    canonical_table: "nexaas_memory.schema_migrations",
+    applied_count: applied.length,
+    applied,
+    pending,
+    migrations_dir: migrationsDir,
+    residual_public: {
+      table_exists: publicTableExists,
+      row_count: residualRows.length,
+      rows: residualRows,
+    },
+  };
+}
+
+function printHuman(state: State): void {
+  console.log(`\n  Nexaas Migration State`);
+  console.log(`  ────────────────────────────────────────────────────`);
+  console.log(`  Canonical tracker:  ${state.canonical_table}`);
+  console.log(`  Migrations dir:     ${state.migrations_dir}`);
+  console.log(`  Applied:            ${state.applied_count}`);
+  console.log(`  Pending:            ${state.pending.length}`);
+
+  if (state.applied_count > 0) {
+    const latest = state.applied[state.applied.length - 1]!;
+    console.log(`  Latest applied:     ${latest.filename} (${latest.applied_at})`);
+  }
+
+  if (state.pending.length > 0) {
+    console.log(`\n  Pending migrations (newest last):`);
+    for (const f of state.pending) {
+      console.log(`    • ${f}`);
+    }
+    console.log(`\n  Run 'nexaas upgrade --migrate' to apply.`);
+  } else {
+    console.log(`\n  ✓ All migration files on disk are applied.`);
+  }
+
+  if (state.residual_public.table_exists) {
+    console.log(`\n  ⚠ Residual public.schema_migrations table detected (${state.residual_public.row_count} rows).`);
+    console.log(`    This is leftover from a pre-palace migration runner — the framework`);
+    console.log(`    no longer reads it. It can be confused with the real tracker by`);
+    console.log(`    operators or tooling that default to the public schema.`);
+    if (state.residual_public.row_count > 0) {
+      console.log(`    Rows:`);
+      for (const r of state.residual_public.rows) {
+        console.log(`      • ${r.filename}`);
+      }
+    }
+    console.log(`    See #184. Safe to drop after verifying no local tooling reads it.`);
+  }
+  console.log();
+}
+
+export async function run(args: string[] = []) {
+  const wantJson = args.includes("--json");
+
+  createPool();
+
+  let state: State;
+  try {
+    state = await gatherState();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (wantJson) {
+      console.log(JSON.stringify({ error: msg }));
+    } else {
+      console.error(`\n  ✗ ${msg}\n`);
+    }
+    process.exit(1);
+  }
+
+  if (wantJson) {
+    console.log(JSON.stringify(state, null, 2));
+  } else {
+    printHuman(state);
+  }
+
+  process.exit(state.pending.length === 0 ? 0 : 2);
+}


### PR DESCRIPTION
## Summary

New CLI subcommand: `nexaas migration-state` (with `--json` flag). Reads from `nexaas_memory.schema_migrations` (canonical), compares to migration files on disk, lists pending, and warns about residual `public.schema_migrations`.

Closes #184.

## Why

Direct-adopter workspaces can end up with two `schema_migrations` tables:

- `public.schema_migrations` — residual from a pre-palace migration runner. Empty or stale on every recent deploy.
- `nexaas_memory.schema_migrations` — the framework's real tracker.

Operators or LLM-assisted tooling that default to `\dt` (public-only) or query the wrong table get a misleading answer. Phoenix Voyages almost prescribed a `dropdb nexaas_palace` rollback off the wrong tracker — would have destroyed 1.34M wal rows.

This subcommand makes the right answer easy to get without needing to know the schema layout.

## Sample output

```
  Nexaas Migration State
  ────────────────────────────────────────────────────
  Canonical tracker:  nexaas_memory.schema_migrations
  Migrations dir:     /opt/nexaas/database/migrations
  Applied:            21
  Pending:            0
  Latest applied:     023_pa_delivery_release_at.sql (2026-04-22 14:33:12)

  ✓ All migration files on disk are applied.

  ⚠ Residual public.schema_migrations table detected (1 row).
    This is leftover from a pre-palace migration runner — the framework
    no longer reads it. It can be confused with the real tracker by
    operators or tooling that default to the public schema.
    Rows:
      • 014_workspace_kv.sql
    See #184. Safe to drop after verifying no local tooling reads it.
```

`--json` flag produces machine-readable output suitable for `jq` pipelines and CI gates.

## Exit codes

| Code | Meaning |
|---|---|
| 0 | All migrations applied, no pending |
| 1 | Error (DB unreachable, migrations dir missing) |
| 2 | Pending migrations exist (lets cron/CI gate on it) |

## Files

- **New:** `packages/cli/src/migration-state.ts` (~180 lines, framework integrity: no workspace-specific assumptions)
- **Edited:** `packages/cli/src/index.ts` (subcommand dispatch + help text entry)

## Test plan

- [ ] `nexaas migration-state` on Phoenix → expect 21 applied, 0 pending, residual public warning
- [ ] `nexaas migration-state --json` → valid JSON output, can be parsed by `jq`
- [ ] `nexaas migration-state` on a fresh `nexaas init` workspace → expect 23 applied, 0 pending, no residual warning
- [ ] DB unreachable → exit 1 with error
- [ ] `NEXAAS_ROOT` unset and not in framework checkout → exit 1 with clear error
- [ ] `npm run build` in `packages/cli/` succeeds — TypeScript check passed locally (`tsc --noEmit`)

## Related

- Closes #184
- Phoenix Voyages migration coordination brief §3.2 and §6 items 1–3
- Companion docs change: `CLAUDE.md` env vars section could reference this subcommand (defer to a docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)