### PR TITLE
fix(scheduler): vary cron jobName per trigger for multi-cron manifests (#193)

### DIFF
--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -463,10 +463,30 @@ export async function registerOneSkill(
     triggers: cronTriggers,
   });
 
-  for (const trigger of manifest.triggers) {
-    if (trigger.type !== "cron" || !trigger.schedule) continue;
+  const cronTriggerEntries = manifest.triggers.filter(
+    (t) => t.type === "cron" && t.schedule,
+  );
+  const baseJobName = `cron-${manifest.id.replace(/\//g, "-")}`;
+  const multiCron = cronTriggerEntries.length > 1;
 
-    const jobName = `cron-${manifest.id.replace(/\//g, "-")}`;
+  // Remove any legacy repeatable entries for this skill before re-upserting
+  // (#22 + #193). Single-cron manifests keep `baseJobName`; multi-cron
+  // manifests use `${baseJobName}-${idx}`. The prefix match catches both
+  // shapes so a manifest changing trigger count between calls doesn't leave
+  // orphans.
+  try {
+    const existing = await ctx.queue.getRepeatableJobs();
+    const stale = existing.filter(
+      (j) => j.name === baseJobName || j.name.startsWith(`${baseJobName}-`),
+    );
+    for (const j of stale) {
+      await ctx.queue.removeRepeatableByKey(j.key);
+    }
+    cleaned += stale.length;
+  } catch { /* non-fatal */ }
+
+  for (const [idx, trigger] of cronTriggerEntries.entries()) {
+    const jobName = multiCron ? `${baseJobName}-${idx}` : baseJobName;
     const tz =
       trigger.timezone ??
       manifest.timezone ??
@@ -474,19 +494,9 @@ export async function registerOneSkill(
       process.env.NEXAAS_TIMEZONE ??
       "UTC";
 
-    // Remove any legacy repeatable entries for this skill (#22).
-    try {
-      const existing = await ctx.queue.getRepeatableJobs();
-      const stale = existing.filter((j) => j.name === jobName);
-      for (const j of stale) {
-        await ctx.queue.removeRepeatableByKey(j.key);
-      }
-      cleaned += stale.length;
-    } catch { /* non-fatal */ }
-
     await ctx.queue.upsertJobScheduler(
       jobName,
-      { pattern: trigger.schedule, tz },
+      { pattern: trigger.schedule!, tz },
       {
         name: "skill-step",
         data: {

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -244,8 +244,26 @@ async function reconcileSkillSchedulers(workspace: string): Promise<{
       const cronTriggers = (manifest.triggers ?? []).filter((t) => t.type === "cron" && t.schedule);
       if (cronTriggers.length === 0) { skipped++; continue; }
 
-      for (const trigger of cronTriggers) {
-        const jobName = `cron-${manifest.id.replace(/\//g, "-")}`;
+      const baseJobName = `cron-${manifest.id.replace(/\//g, "-")}`;
+      const multiCron = cronTriggers.length > 1;
+
+      // #193: when a manifest has multiple cron triggers, each registers as
+      // `${baseJobName}-${idx}` so they don't collapse onto the same key.
+      // Migrating a previously-buggy registration (single `baseJobName` key
+      // carrying the last cron's pattern) requires explicitly removing the
+      // legacy single-key entry; the new idx-suffixed upserts wouldn't replace
+      // it. Single-cron manifests keep `baseJobName` as before — no migration.
+      if (multiCron) {
+        try {
+          const existing = await queue.getRepeatableJobs();
+          for (const r of existing.filter((j) => j.name === baseJobName)) {
+            await queue.removeRepeatableByKey(r.key);
+          }
+        } catch { /* non-fatal — cleanup is opportunistic */ }
+      }
+
+      for (const [idx, trigger] of cronTriggers.entries()) {
+        const jobName = multiCron ? `${baseJobName}-${idx}` : baseJobName;
         const tz = trigger.timezone ?? manifest.timezone ?? workspaceTz;
         const stepId = manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec";
 
@@ -267,7 +285,7 @@ async function reconcileSkillSchedulers(workspace: string): Promise<{
           );
           registered++;
         } catch (err) {
-          console.warn(`[nexaas] failed to upsert scheduler for ${manifest.id}: ${(err as Error).message}`);
+          console.warn(`[nexaas] failed to upsert scheduler for ${manifest.id} (trigger ${idx}): ${(err as Error).message}`);
           errors++;
         }
       }
@@ -965,13 +983,17 @@ async function main() {
           }
         }
       } else {
-        // Disable: remove scheduler entries (keep files for now)
+        // Disable: remove scheduler entries (keep files for now). Prefix
+        // match handles multi-cron manifests where each trigger registers
+        // as `${baseJobName}-${idx}` (#193).
         for (const skillId of skills) {
           try {
-            const jobName = `cron-${skillId.replace(/\//g, "-")}`;
+            const baseJobName = `cron-${skillId.replace(/\//g, "-")}`;
             const q = new Queue(`nexaas-skills-${WORKSPACE}`, getRedisConnectionOpts());
             const repeatables = await q.getRepeatableJobs();
-            for (const r of repeatables.filter(j => j.name === jobName)) {
+            for (const r of repeatables.filter(j =>
+              j.name === baseJobName || j.name.startsWith(`${baseJobName}-`)
+            )) {
               await q.removeRepeatableByKey(r.key);
             }
             await q.close();


### PR DESCRIPTION
## Summary

Multi-cron skill manifests had **all but the last trigger silently dropped** at scheduler self-heal AND at `nexaas register-skill`. Both sites computed `jobName = cron-${manifest.id}` once per iteration — same value every time — and `upsertJobScheduler(jobName, …)` overwrote the prior. The startup log claimed success.

Closes #193.

## What changes

Three call sites, same fix:

| File | Lines | Change |
|---|---|---|
| `packages/runtime/src/worker.ts` | 244-292 | Self-heal: idx-suffix jobName when `cronTriggers.length > 1`; remove legacy single-key entry first to migrate pre-fix state cleanly |
| `packages/runtime/src/worker.ts` | 969-988 | Addon disable: filter uses prefix match so all `${baseJobName}-N` keys are removed |
| `packages/cli/src/register-skill.ts` | 466-525 | Move stale-cleanup outside the loop, use prefix-match filter, idx-suffix jobName |

```ts
// New pattern (worker.ts:266 and register-skill.ts:493)
const baseJobName = `cron-${manifest.id.replace(/\//g, "-")}`;
const multiCron = cronTriggers.length > 1;

for (const [idx, trigger] of cronTriggers.entries()) {
  const jobName = multiCron ? `${baseJobName}-${idx}` : baseJobName;
  ...
}
```

## Backwards compatibility

- **Single-cron manifests** (the common case): `jobName` stays `${baseJobName}` — no Redis key change, no migration needed.
- **Multi-cron manifests with the bug applied** (e.g. Phoenix's `tln/pending-approvals-sync` pre-workaround): on next worker startup, self-heal removes the legacy single-key entry and registers `${baseJobName}-0/1/2/…` — clean migration in one bounce. No operator action required.
- **Multi-cron manifests where Phoenix-style workaround was applied** (collapsed to single trigger): treated as single-cron, no change.

## Why both sites need the fix

`nexaas register-skill` was buggy the same way. Even after fixing `worker.ts`, a fresh registration via the CLI (e.g. `nexaas register-skills`) would re-create the collapsed state. The two paths must agree on jobName shape.

## Diagnostic-window concern (from #193 comment)

Phoenix's issue notes that the bug surfaced as "phantom-skill watchdog alert → operator reads worker.ts" — misclassifies as a generic phantom. A `console.warn` when multi-cron is detected would close that gap, but this PR keeps the behavior change to just the bug fix; better visibility belongs in a separate logging-improvement PR if wanted.

## Test plan

- [ ] Single-cron skill: registers identically before and after this change. Redis key shape unchanged.
- [ ] Multi-cron skill (Phoenix's 3-trigger pattern): all three triggers register as `${baseJobName}-0/1/2`. Skill fires on every pattern.
- [ ] Upgrade from buggy state: existing single `${baseJobName}` key (with the last cron's pattern) is removed during self-heal; replaced with three `-N` keys.
- [ ] Addon disable on multi-cron: all `${baseJobName}-N` keys are removed; no orphans left.
- [ ] `npm run build` succeeds in both `packages/runtime/` and `packages/cli/` — TypeScript check passes locally (`tsc --noEmit` both exit 0).

## Related

- Closes #193
- References #22 (the prior stale-cleanup fix in register-skill)
- Phoenix Voyages migration coordination context — surfaced today by their phantom-skill-watchdog catching the silent drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)