### PR TITLE
chore(db): drop vestigial public.{workspace_skills,events,agent_memory} (#183)

### DIFF
--- a/database/migrations/024_drop_vestigial_public_tables.sql
+++ b/database/migrations/024_drop_vestigial_public_tables.sql
@@ -1,0 +1,32 @@
+-- Migration 024: Drop vestigial public.* tables (issue #183)
+-- Date: 2026-05-16
+--
+-- Three tables in the public schema are 0-row on every healthy worker and have
+-- zero writers anywhere in the framework. Live data lives in nexaas_memory.*.
+-- They exist as residual from pre-palace deploys. Operators or LLM-assisted
+-- ops tooling defaulting to the public schema get a misleading
+-- "framework not writing" picture of substrate state.
+--
+-- Audited 2026-05-16 against /opt/nexaas at HEAD d44f9c6:
+--   grep -rn "public.workspace_skills|INSERT INTO workspace_skills|FROM workspace_skills"
+--        packages/ mcp/ integrations/ database/  → only this drop matches
+--   grep -rn "public.events|INSERT INTO events|FROM events\b"  (excluding nexaas_memory)
+--        → no writers
+--   grep -rn "public.agent_memory|agent_memory"
+--        → only the CREATE in 009_architecture_v4.sql and this drop
+--
+-- The live equivalents are:
+--   public.workspace_skills  → BullMQ repeat keys
+--                              (bull:nexaas-skills-<workspace>:repeat:*)
+--   public.events            → nexaas_memory.events
+--   public.agent_memory      → nexaas_memory.{closets, entities, facts}
+--
+-- DROP TABLE removes attached indexes (idx_agent_memory_dept,
+-- idx_agent_memory_type from 009) automatically. CASCADE is intentionally
+-- omitted — these tables should have no dependents; if any exist on a given
+-- deploy, the migration fails loudly so the operator can investigate rather
+-- than silently dropping consumer state.
+
+DROP TABLE IF EXISTS public.workspace_skills;
+DROP TABLE IF EXISTS public.events;
+DROP TABLE IF EXISTS public.agent_memory;


### PR DESCRIPTION
## Summary

Migration 024 drops three vestigial `public.*` tables that are 0-row on every healthy worker and have zero writers anywhere in the framework. Closes #183.

## Why

`public.workspace_skills`, `public.events`, `public.agent_memory` exist as residual from pre-palace deploys. Live data lives in `nexaas_memory.*`:

| Table | Status on healthy worker | Live equivalent |
|---|---|---|
| `public.workspace_skills` | 0 rows | BullMQ repeat keys (`bull:nexaas-skills-<workspace>:repeat:*`) |
| `public.events` | 0 rows / 24h | `nexaas_memory.events` (4,481 / 24h on Phoenix today) |
| `public.agent_memory` | 0 rows | `nexaas_memory.{closets, entities, facts}` (61k closets on Phoenix) |

Operators or LLM-assisted ops tooling that defaults to `\dt` (public-only) or queries the wrong table gets a plausible-looking but completely wrong picture of substrate state. Phoenix Voyages almost prescribed a `dropdb nexaas_palace` rollback off this confusion.

## Audit (2026-05-16, against HEAD `d44f9c6`)

```bash
grep -rn 'public.workspace_skills|INSERT INTO workspace_skills|FROM workspace_skills' \
  packages/ mcp/ integrations/ database/
# → only this PR's migration matches

grep -rn 'public.events|INSERT INTO events|FROM events\b' \
  packages/ mcp/ integrations/ database/ | grep -v nexaas_memory
# → no writers

grep -rn 'public.agent_memory|agent_memory' \
  packages/ mcp/ integrations/ database/
# → only the CREATE in 009_architecture_v4.sql + this PR's drop
```

No writers, no readers, no consumers. Safe to drop.

## What the migration does

```sql
DROP TABLE IF EXISTS public.workspace_skills;
DROP TABLE IF EXISTS public.events;
DROP TABLE IF EXISTS public.agent_memory;
```

- `IF EXISTS` makes it safe to apply on deploys where these tables were never created (e.g. fresh `nexaas init` post-palace-substrate)
- `DROP TABLE` removes attached indexes (`idx_agent_memory_dept`, `idx_agent_memory_type` from migration 009) automatically
- `CASCADE` intentionally omitted — these tables should have no dependents; if any exist on a given deploy, the migration fails loudly so the operator can investigate rather than silently dropping consumer state

## What's NOT in this PR

Issue #184 (filed yesterday) covers the related `public.schema_migrations` residual table and proposed a `nexaas migration-state` CLI subcommand (PR #192). That's a separate, larger conversation about the tracker location itself. This PR addresses only the three tables Phoenix explicitly inventoried in #183.

Other tables from migration 009 (`feedback_events`, `channel_registry`, `user_channel_preferences`, `heartbeat_schedules`) are NOT touched here — they're not in #183's scope and would need their own audit before similar treatment.

## Test plan

- [ ] Migration runs cleanly on Phoenix (all three tables exist there per #183)
- [ ] Migration runs cleanly on a fresh `nexaas init` workspace (none of these tables exist) — `IF EXISTS` makes it a no-op
- [ ] Worker startup after migration: no regressions, `nexaas health` returns green
- [ ] `nexaas register-skill` after migration: succeeds (it doesn't write to `public.workspace_skills`)

## Related

- Closes #183
- Companion: #184 / PR #192 (`nexaas migration-state` CLI surfaces the `schema_migrations` dual location)
- Phoenix Voyages migration coordination brief §6 items 2–3

🤖 Generated with [Claude Code](https://claude.com/claude-code)