### PR TITLE
fix(ai-skill): switch to streaming with per-chunk idle timeout (#197)

### DIFF
--- a/packages/runtime/src/models/agentic-loop.ts
+++ b/packages/runtime/src/models/agentic-loop.ts
@@ -29,19 +29,97 @@ function getClient(): Anthropic {
     // queue-pause path (#27). Our own retryWithBackoff below handles the
     // retryable-but-not-429 cases; 429s propagate unretried so the worker
     // layer can pause the queue for the cooldown window.
-    // timeout: 60s — fail fast on network hangs; #32 showed the default
-    // 10min timeout leaves stalled requests hanging skill runs for minutes.
+    //
+    // No request-level `timeout` — we use streaming below and apply our
+    // own per-chunk idle timeout via `streamWithChunkIdleTimeout`. The
+    // SDK's timeout option would otherwise bound the ENTIRE stream
+    // (issue #197): a research-class skill whose first-turn output takes
+    // 2+ minutes to stream would always time out, even though chunks are
+    // flowing. Idle-timeout semantics catch real network hangs without
+    // killing legitimate long responses.
     _client = new Anthropic({
       apiKey: process.env.ANTHROPIC_API_KEY,
       maxRetries: 0,
-      timeout: 60_000,
     });
   }
   return _client;
 }
 
 /**
- * Retry wrapper for the single `client.messages.create` call.
+ * Default idle-timeout between streaming chunks. If no chunk arrives
+ * for this many milliseconds, the request is aborted as if the network
+ * had hung — re-raised as APIConnectionTimeoutError so
+ * `retryMessagesCreate` retries it. Override via NEXAAS_CHUNK_IDLE_MS.
+ */
+const DEFAULT_CHUNK_IDLE_MS = 60_000;
+
+function chunkIdleMs(): number {
+  const v = Number(process.env.NEXAAS_CHUNK_IDLE_MS ?? DEFAULT_CHUNK_IDLE_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_CHUNK_IDLE_MS;
+}
+
+/**
+ * Run a streaming `messages.stream` request with idle-timeout semantics.
+ *
+ * Replaces the non-streaming `messages.create` path that was causing
+ * #197 — when the model's response stream takes longer than the
+ * single-request timeout (e.g. 60s+ of complex tool_use planning), the
+ * non-streaming call times out even though chunks are flowing.
+ *
+ * Behaviour:
+ *  - Stream is consumed via `stream.finalMessage()`, returning the same
+ *    `Anthropic.Message` shape as `messages.create` (content, usage,
+ *    stop_reason).
+ *  - A timer resets on every `streamEvent`. If no event fires for
+ *    `idleMs` milliseconds, the stream's AbortController fires and the
+ *    awaiting `finalMessage()` rejects with `APIUserAbortError`. We
+ *    translate that into `APIConnectionTimeoutError` so the existing
+ *    `isRetryableAnthropicError` classifier (which already retries
+ *    timeout errors) handles it without code change.
+ *  - Legitimate `APIUserAbortError`s (caller-initiated, e.g. a future
+ *    cancellation pathway) keep propagating as user aborts.
+ */
+async function streamWithChunkIdleTimeout(
+  client: Anthropic,
+  params: Anthropic.MessageCreateParams,
+  idleMs: number,
+): Promise<Anthropic.Message> {
+  // `messages.stream()` returns a MessageStream synchronously; the
+  // request is dispatched on construction. Setting up the idle watcher
+  // before awaiting finalMessage() guarantees we don't miss the first
+  // chunk.
+  const stream = client.messages.stream(params);
+
+  let timedOutByIdle = false;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const resetIdle = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      timedOutByIdle = true;
+      stream.controller.abort();
+    }, idleMs);
+  };
+
+  // Reset on every streamed event (headers, content_block_*, message_*).
+  stream.on("streamEvent", resetIdle);
+  resetIdle();
+
+  try {
+    return await stream.finalMessage();
+  } catch (err) {
+    if (timedOutByIdle && err instanceof Anthropic.APIUserAbortError) {
+      throw new Anthropic.APIConnectionTimeoutError({
+        message: `Stream idle timeout (${idleMs}ms) — no chunks received within window. Aborted by Nexaas streaming watchdog.`,
+      });
+    }
+    throw err;
+  } finally {
+    if (idleTimer) clearTimeout(idleTimer);
+  }
+}
+
+/**
+ * Retry wrapper for the streaming-message call.
  *
  * Retries on connection errors and 5xx (incl. 529 overloaded) with
  * exponential backoff + jitter. 429s are NEVER retried here — they
@@ -50,6 +128,13 @@ function getClient(): Anthropic {
  *
  * Addresses #32: transient network blips (~1-3/hr at baseline) were
  * killing runs outright because the call wasn't wrapped.
+ *
+ * Note: as of #197, the underlying call is `streamWithChunkIdleTimeout`,
+ * not `client.messages.create`. The wrapper signature is unchanged
+ * because `finalMessage()` resolves to the same `Anthropic.Message`
+ * shape, and chunk-idle timeouts are translated to
+ * `APIConnectionTimeoutError` so they slot into the retryable-error
+ * classifier without surgery.
  */
 async function retryMessagesCreate(
   fn: () => Promise<Anthropic.Message>,
@@ -266,13 +351,19 @@ export async function runAgenticLoop(params: {
   while (turns < maxTurns) {
     turns++;
 
-    const response = await retryMessagesCreate(() => client.messages.create({
-      model,
-      max_tokens: maxTokensPerTurn,
-      system: systemParam,
-      messages,
-      tools: anthropicTools,
-    }));
+    const response = await retryMessagesCreate(() =>
+      streamWithChunkIdleTimeout(
+        client,
+        {
+          model,
+          max_tokens: maxTokensPerTurn,
+          system: systemParam,
+          messages,
+          tools: anthropicTools,
+        },
+        chunkIdleMs(),
+      ),
+    );
 
     totalInputTokens += response.usage.input_tokens;
     totalOutputTokens += response.usage.output_tokens;


### PR DESCRIPTION
Closes #197.

## Summary

The agentic loop's Anthropic client used non-streaming `messages.create()` with `timeout: 60_000`, which bounded the **entire response time** at 60 seconds. Skills whose first agentic turn legitimately takes longer to respond — research, multi-step planning, long-form drafting — always failed: the request timed out before the response finished, retried 5× with the same outcome, and surfaced as `error_summary: \"Request timed out\"` with `token_usage: NULL`.

This is the failure that took out Phoenix's `rfp/research` for its entire deployment lifetime (5/5 attempts failed at 332-699s, 0 properties in the research DB).

## Approach

Switch to `client.messages.stream(...).finalMessage()` and add a chunk-idle watchdog: if no `streamEvent` fires for `idleMs` ms, abort the stream via its `AbortController`. Translate that abort into `APIConnectionTimeoutError` so the existing `retryMessagesCreate` classifier picks it up — no other code path changes.

```ts
async function streamWithChunkIdleTimeout(
  client: Anthropic,
  params: Anthropic.MessageCreateParams,
  idleMs: number,
): Promise<Anthropic.Message> {
  const stream = client.messages.stream(params);
  let timedOutByIdle = false;
  let idleTimer: ReturnType<typeof setTimeout> | null = null;
  const resetIdle = () => {
    if (idleTimer) clearTimeout(idleTimer);
    idleTimer = setTimeout(() => {
      timedOutByIdle = true;
      stream.controller.abort();
    }, idleMs);
  };
  stream.on(\"streamEvent\", resetIdle);
  resetIdle();
  try {
    return await stream.finalMessage();
  } catch (err) {
    if (timedOutByIdle && err instanceof Anthropic.APIUserAbortError) {
      throw new Anthropic.APIConnectionTimeoutError({
        message: \`Stream idle timeout (\${idleMs}ms) — no chunks received within window. Aborted by Nexaas streaming watchdog.\`,
      });
    }
    throw err;
  } finally {
    if (idleTimer) clearTimeout(idleTimer);
  }
}
```

`stream.finalMessage()` resolves to the same `Anthropic.Message` shape as `messages.create()` (`content`, `usage`, `stop_reason`), so downstream code in the agentic loop didn't change.

## Defaults & tuning

- `DEFAULT_CHUNK_IDLE_MS = 60_000` — matches the prior request-level timeout, but applied per-chunk-idle. A 5-minute response with chunks flowing every <60s now succeeds; a real network hang still fails fast.
- Override via `NEXAAS_CHUNK_IDLE_MS` env var per-deployment.

Operators running Sonnet-with-many-tools skills (research-class) may want to raise this to 120000-300000ms. Phoenix's rfp/research with 47 tools needs ~180s of idle tolerance because Anthropic takes that long to emit the first content block when the available tool surface is large — that's a real backend behavior, not a Nexaas-side issue.

## Backwards compatibility

- **Wire behavior**: streaming responses use the same v1 messages API endpoint; Anthropic billing is identical to non-streaming for the same model+params.
- **Error semantics**: chunk-idle timeouts now masquerade as `APIConnectionTimeoutError`, which was already in `isRetryable()` — retry behavior unchanged for legitimate network hangs.
- **Caching**: `cache_control` breakpoints on tools and system still attach correctly; the streaming path returns `cache_read_input_tokens` / `cache_creation_input_tokens` in the same `usage` shape.
- **Tool-use blocks**: `block.type === \"tool_use\"` and `block.input` are populated in the final message exactly like non-streaming. The agentic loop's `toolUseBlocks` collection is unaffected.
- **No public API surface change**: every caller of `runAgenticLoop` gets the same `AgenticResult` it always did.

## What I tested

Built clean with the workspace `tsc -p tsconfig.json` chain. Deployed to a local worker, fired Phoenix's rfp/research skill which had a 100% failure rate pre-patch:

| Config | Default 60s idle | Result |
|---|---|---|
| 145 tools (original)            | ❌ failed 690s · `Stream idle timeout (60000ms) ... aborted by Nexaas streaming watchdog` |
| 47 tools (post-MCP-trim)        | ❌ failed 690s · same error (Anthropic time-to-first-byte exceeds 60s for this prompt size + Sonnet 4.6) |

The patched code path is exercised — the error message is from the new wrapper — but Anthropic's time-to-first-byte for this specific prompt is longer than the default 60s threshold. Raising `NEXAAS_CHUNK_IDLE_MS=180000` is expected to unblock; full run validation in progress and will be edited in here when complete.

The chunk-idle wrapper is the **necessary** part of the fix; raising the default-or-env idle to 120-180s would be a separate tuning decision. I went with 60s default to preserve the original \"fail fast on network hangs\" goal — operators can raise per-deployment.

## Phoenix-side companion

Phoenix's [research skill manifest comment](https://github.com/Systemsaholic/Phoenix-Voyages/commit/ecf3c61) and [memory entry](https://github.com/Systemsaholic/Phoenix-Voyages/blob/main/CLAUDE.md) reference this PR. Once it lands, I'll bump the env var on the production worker and re-fire the smoke test against MARKS-TML-2028.

## Adjacent observations (not in this PR)

From the issue body — worth picking up as separate PRs:

1. **Tool-count telemetry warning** — log `with N tools` more loudly (or just warn at >75) so context bloat doesn't go unnoticed.
2. **NULL token_usage on timeout** — even on a failed run, the SDK has request_id and approximate input size before the timeout fires. Capture it to skill_runs so post-mortems aren't blind.
3. **Per-skill tool allowlist** — orthogonal to this PR, filed as #196. Reduces context bloat at the manifest level rather than at the env-var level.

Happy to follow up on any of these.