### PR TITLE
fix(ai-skill): heartbeat last_activity during long streaming turns (#199)

### DIFF
--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -397,18 +397,37 @@ export async function runAiSkill(
     // Run the agentic loop
     console.log(`[nexaas] Running AI skill '${manifest.id}' with ${allTools.length} tools, model: ${model}`);
 
-    const result = await runAgenticLoop({
-      model,
-      system: systemPrompt,
-      messages: [{ role: "user", content: userMessage }],
-      tools: allTools,
-      executeTool,
-      workspace,
-      runId,
-      skillId: manifest.id,
-      limits: agenticLimits,
-      modelPricing,
-    });
+    // Heartbeat: keep last_activity fresh while a long-running stream
+    // is in flight. Without this, multi-turn skills whose individual
+    // turns legitimately take 5-15 min each (research-class with the
+    // post-#197 streaming path) accumulate idle time at the DB level
+    // because last_activity only bumps at step boundaries —
+    // the 20-min orphan-run reaper kills them mid-stream. Heartbeat
+    // every 30 s is well under the reaper threshold + cheap (one
+    // single-row UPDATE).
+    const heartbeat = setInterval(() => {
+      runTracker.heartbeat(runId).catch(() => {
+        // Best-effort — never fail the run on a heartbeat DB blip.
+      });
+    }, 30_000);
+
+    let result: Awaited<ReturnType<typeof runAgenticLoop>>;
+    try {
+      result = await runAgenticLoop({
+        model,
+        system: systemPrompt,
+        messages: [{ role: "user", content: userMessage }],
+        tools: allTools,
+        executeTool,
+        workspace,
+        runId,
+        skillId: manifest.id,
+        limits: agenticLimits,
+        modelPricing,
+      });
+    } finally {
+      clearInterval(heartbeat);
+    }
 
     // Record the result as a palace drawer. Shape uses the framework-wide
     // terminal_reason discriminator (#171 helper) so dashboards and

--- a/packages/runtime/src/run-tracker.ts
+++ b/packages/runtime/src/run-tracker.ts
@@ -91,6 +91,23 @@ export const runTracker = {
     );
   },
 
+  /**
+   * Bump `last_activity` to NOW without changing status/step. Called
+   * from long-running streams (see ai-skill.ts heartbeat) so the
+   * orphan-run reaper doesn't kill runs that are legitimately busy
+   * but haven't crossed a step boundary in 20 minutes.
+   *
+   * Idempotent on missing/completed rows (UPDATE matches 0).
+   */
+  async heartbeat(runId: string): Promise<void> {
+    await sql(
+      `UPDATE nexaas_memory.skill_runs
+       SET last_activity = now()
+       WHERE run_id = $1 AND status = 'running'`,
+      [runId],
+    );
+  },
+
   async markStepFailed(runId: string, stepId: string, error: unknown): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     const rows = await sql<{ workspace: string; skill_id: string }>(


### PR DESCRIPTION
Closes #199. Pairs with #197 / #198.

## Summary

After the streaming switch landed, the 20-min orphan-run reaper started killing legitimate long research-class runs. Streaming turns can take 5-15 min each, and \`last_activity\` only updates at step boundaries. A multi-turn skill making real progress can have \`last_activity\` stale for >20 min and get reaped mid-stream.

This adds a 30 s heartbeat during \`runAgenticLoop\`.

## Diff shape

\`packages/runtime/src/run-tracker.ts\` — new \`heartbeat(runId)\` method:

\`\`\`ts
async heartbeat(runId: string): Promise<void> {
  await sql(
    \`UPDATE nexaas_memory.skill_runs
     SET last_activity = now()
     WHERE run_id = $1 AND status = 'running'\`,
    [runId],
  );
}
\`\`\`

Gated on \`status='running'\` so a heartbeat after manual cancel doesn't resurrect the row.

\`packages/runtime/src/ai-skill.ts\` — wraps the agentic loop:

\`\`\`ts
const heartbeat = setInterval(() => {
  runTracker.heartbeat(runId).catch(() => {
    // Best-effort — never fail the run on a heartbeat DB blip.
  });
}, 30_000);

let result;
try {
  result = await runAgenticLoop({ ... });
} finally {
  clearInterval(heartbeat);
}
\`\`\`

30 s × 1 single-row UPDATE = negligible DB cost. Reaper continues to catch genuinely orphaned runs (worker crash, OOM kill) because their heartbeat stops too.

## What I tested

- Built clean (\`npm run build\` exit 0).
- Smoke-tested on Phoenix's \`rfp/proposal-writer\` against MARKS-TML-2028, the same prompt that hit the 25 min reap pre-patch. The current run is in flight as I type this; I'll edit results into the PR description when it lands.
- Verified \`runTracker.heartbeat\` correctly no-ops on \`status='cancelled'\` rows so a delayed callback after a manual cancel can't flip status back to running.

## Backwards compatibility

- New runTracker method is additive — no callers change.
- ai-skill.ts wrap is internal — \`AgenticResult\` shape unchanged.
- No new env vars, no schema changes.
- The reaper itself is unchanged — same 20 min threshold continues to catch truly orphaned runs (worker died, process killed, OOM).

## Adjacent observations (parking-lot)

Filed in #199 — worth follow-up PRs:
1. Update the reaper's now-stale comment (references the pre-#197 60s timeout assumption).
2. Capture partial token_usage on reap, so reaped runs aren't misleadingly NULL.
3. \`NEXAAS_REAPER_MINUTES\` env override for deployment safety knob.

Happy to take any of those as a follow-up PR.