### PR TITLE
fix(db): pa_delivery_marker.status accepts NULL (#206)

### DIFF
--- a/database/migrations/025_pa_delivery_marker_status_nullable.sql
+++ b/database/migrations/025_pa_delivery_marker_status_nullable.sql
@@ -1,0 +1,40 @@
+-- Migration 025: pa_delivery_marker.status accepts NULL (issue #206)
+-- Date: 2026-05-24
+--
+-- Follow-through for PR #191 / commit 6ecacee, which changed
+-- enqueueDelivery() in packages/runtime/src/pa/delivery.ts to insert
+-- status=NULL (instead of 'queued') so workspace consumers using the
+-- LEFT-JOIN-NULL eligibility pattern see freshly enqueued markers (see
+-- closed #182 for the original silent-drop root cause).
+--
+-- That code change shipped without the matching schema change:
+-- pa_delivery_marker.status was created in migration 021 as
+-- `text NOT NULL DEFAULT 'queued'`. Postgres only applies the DEFAULT
+-- when the column is omitted from INSERT — an explicit NULL is inserted
+-- as-is and trips the NOT NULL constraint (#206).
+--
+-- Phoenix Voyages observed this on every pa-notify dispatch:
+--   error: null value in column "status" of relation "pa_delivery_marker"
+--          violates not-null constraint
+-- Non-fatal because the upstream notification still delivers, but the
+-- delivery-marker row never lands, so per-message tracking is lost.
+--
+-- Fix:
+--   - DROP NOT NULL on status (allow explicit NULL).
+--   - DROP DEFAULT on status (omitted column also writes NULL — keeps
+--     storage behavior consistent regardless of how callers write).
+--
+-- The CHECK constraint
+--   CHECK (status IN ('queued','sent','failed','dead','skipped'))
+-- stays as-is. SQL CHECK passes on NULL by default (NULL IN (...) is
+-- NULL, treated as pass), so existing 'queued'/'sent'/etc rows and new
+-- explicit-value writes continue to be validated.
+--
+-- Existing data: rows inserted before PR #191 / commit 6ecacee have
+-- status='queued'. They remain valid and continue to be picked up by
+-- claimNextDelivery's widened filter (status IS NULL OR status IN
+-- ('queued','failed'), per PR #191).
+
+ALTER TABLE nexaas_memory.pa_delivery_marker
+  ALTER COLUMN status DROP NOT NULL,
+  ALTER COLUMN status DROP DEFAULT;


### PR DESCRIPTION
Migration 025 aligns the `pa_delivery_marker.status` column with the intentional code change shipped in PR #191. Closes #206.

## Root cause

PR #191 (commit 6ecacee, closing #182) changed `enqueueDelivery()` in `packages/runtime/src/pa/delivery.ts` to insert `status=NULL` instead of `'queued'` so workspace consumers using the LEFT-JOIN-NULL eligibility pattern see freshly enqueued markers.

That code change shipped **without the matching schema change**. Migration 021 created the column as:

```sql
status text NOT NULL DEFAULT 'queued'
```

Postgres only applies the DEFAULT when the column is **omitted** from INSERT. An explicit NULL goes in as-is and trips the NOT NULL constraint. Phoenix observed it on every pa-notify dispatch (#206):

```
error: null value in column "status" of relation "pa_delivery_marker"
       violates not-null constraint
  at async Object.enqueueDeliveryMarker (.../pa-notify.js:328:13)
```

Non-fatal — the upstream notification still delivers — but the delivery-marker row never lands, so per-message tracking and idempotency for pa-notify are silently lost on every send.

## What changes

```sql
ALTER TABLE nexaas_memory.pa_delivery_marker
  ALTER COLUMN status DROP NOT NULL,
  ALTER COLUMN status DROP DEFAULT;
```

- **DROP NOT NULL** allows explicit `NULL` (matches the code path in PR #191)
- **DROP DEFAULT** keeps storage behavior consistent: omitted column also writes NULL, not `'queued'`

## CHECK constraint stays

```sql
CHECK (status IN ('queued','sent','failed','dead','skipped'))
```

SQL CHECK passes NULL by default — `NULL IN (...)` evaluates to NULL, which CHECK treats as a pass. Existing rows with valid status values continue to validate; new explicit-value writes still validate; new explicit-NULL writes pass.

## Existing data

Rows inserted before PR #191 / commit 6ecacee have `status='queued'`. They remain valid and continue to be picked up by `claimNextDelivery`'s widened filter (`status IS NULL OR status IN ('queued','failed')`, per PR #191). No data migration required.

## Why not revert PR #191 instead?

That would re-introduce the original silent-drop bug #182. The schema needed to catch up to the deliberate code-side change; reverting code is the wrong direction. Phoenix's LEFT-JOIN-NULL consumer is the supported workspace pattern; we want freshly enqueued markers to be visible to it without the workspace having to widen the filter defensively.

## Test plan

- [ ] `nexaas upgrade --migrate` applies 025 cleanly on Phoenix (where pa_delivery_marker has NOT NULL today)
- [ ] First pa-notify dispatch after migration: marker row lands with `status=NULL` (no exception in worker logs)
- [ ] `claimNextDelivery` picks up the NULL-status marker
- [ ] Existing 'queued' rows from before PR #191: still pickable
- [ ] CHECK still rejects invalid status values (verify with `INSERT … status='bogus'` → fails as expected)
- [ ] Fresh `nexaas init` workspace: migration applies (021 → 025 sequence works in order)

## Related

- Closes #206
- Follows up PR #191 (#182 — the original state-machine fix that the schema didn't catch up with)

🤖 Generated with [Claude Code](https://claude.com/claude-code)