### PR TITLE
fix(db): migration 024 drops public.event_runs + public.job_queue first (#210)

### DIFF
--- a/database/migrations/024_drop_vestigial_public_tables.sql
+++ b/database/migrations/024_drop_vestigial_public_tables.sql
@@ -1,13 +1,13 @@
--- Migration 024: Drop vestigial public.* tables (issue #183)
--- Date: 2026-05-16
+-- Migration 024: Drop vestigial public.* tables (issue #183, expanded #210)
+-- Date: 2026-05-16 (expanded 2026-05-24)
 --
--- Three tables in the public schema are 0-row on every healthy worker and have
+-- Five tables in the public schema are 0-row on every healthy worker and have
 -- zero writers anywhere in the framework. Live data lives in nexaas_memory.*.
 -- They exist as residual from pre-palace deploys. Operators or LLM-assisted
 -- ops tooling defaulting to the public schema get a misleading
 -- "framework not writing" picture of substrate state.
 --
--- Audited 2026-05-16 against /opt/nexaas at HEAD d44f9c6:
+-- Original audit 2026-05-16 against /opt/nexaas at HEAD d44f9c6:
 --   grep -rn "public.workspace_skills|INSERT INTO workspace_skills|FROM workspace_skills"
 --        packages/ mcp/ integrations/ database/  → only this drop matches
 --   grep -rn "public.events|INSERT INTO events|FROM events\b"  (excluding nexaas_memory)
@@ -15,18 +15,55 @@
 --   grep -rn "public.agent_memory|agent_memory"
 --        → only the CREATE in 009_architecture_v4.sql and this drop
 --
--- The live equivalents are:
+-- Update 2026-05-24 (#210): the original drop set omitted public.event_runs
+-- and public.job_queue, which hold FKs to public.events:
+--
+--   conname                  | from_table
+--   -------------------------+------------
+--   event_runs_event_id_fkey | event_runs
+--   job_queue_event_id_fkey  | job_queue
+--
+-- Without CASCADE, the drop of public.events failed on every affected adopter
+-- ("cannot drop table events because other objects depend on it"). Phoenix
+-- Voyages hit this on their nexaas upgrade --migrate.
+--
+-- Both event_runs and job_queue are the same pre-palace residual family —
+-- 0 rows on healthy workers, no framework writers. Re-audited 2026-05-24:
+--   grep -rn "public.event_runs|FROM event_runs|INSERT INTO event_runs"
+--        packages/ mcp/ integrations/ database/  → 0 references
+--   grep -rn "public.job_queue|FROM job_queue|INSERT INTO job_queue"
+--        packages/ mcp/ integrations/ database/  → 0 references
+--
+-- Adding them to the drop set in dependency order. Still no CASCADE — the
+-- "fail loudly so the operator can investigate" stance is preserved for any
+-- FK we haven't enumerated.
+--
+-- The live equivalents for the original three (workspace_skills, events,
+-- agent_memory) and the two FK-holders (event_runs, job_queue):
 --   public.workspace_skills  → BullMQ repeat keys
 --                              (bull:nexaas-skills-<workspace>:repeat:*)
 --   public.events            → nexaas_memory.events
 --   public.agent_memory      → nexaas_memory.{closets, entities, facts}
+--   public.event_runs        → nexaas_memory.skill_runs
+--   public.job_queue         → BullMQ (Redis-backed)
 --
--- DROP TABLE removes attached indexes (idx_agent_memory_dept,
--- idx_agent_memory_type from 009) automatically. CASCADE is intentionally
--- omitted — these tables should have no dependents; if any exist on a given
--- deploy, the migration fails loudly so the operator can investigate rather
--- than silently dropping consumer state.
+-- Modification-in-place rationale (#210): the original 024 never successfully
+-- applied on any affected adopter — it failed on the FK violation and rolled
+-- back. The single deploy where 024 is recorded as applied (Phoenix Voyages)
+-- got there via manual out-of-band drops of event_runs + job_queue followed
+-- by re-running nexaas upgrade --migrate. The migration runner tracks
+-- schema_migrations by filename (no checksum), so the patched 024 is
+-- invisible to deploys where the filename is already recorded. For new
+-- affected adopters, the patched drop set applies cleanly in one pass.
+--
+-- DROP TABLE removes attached indexes automatically. CASCADE remains
+-- intentionally omitted.
 
+-- FK-holders drop first (they reference public.events):
+DROP TABLE IF EXISTS public.event_runs;
+DROP TABLE IF EXISTS public.job_queue;
+
+-- Original three (no remaining inbound FKs after the drops above):
 DROP TABLE IF EXISTS public.workspace_skills;
 DROP TABLE IF EXISTS public.events;
 DROP TABLE IF EXISTS public.agent_memory;


### PR DESCRIPTION
Migration 024 from #183 had an incomplete drop set. `public.event_runs` and `public.job_queue` hold FKs to `public.events`, blocking the drop without CASCADE. Phoenix Voyages hit this on `nexaas upgrade --migrate`:

```
✗ 024_drop_vestigial_public_tables.sql: cannot drop table events because other objects depend on it
```

Closes #210.

## What changes

Patches `024_drop_vestigial_public_tables.sql` in place to drop the FK-holders first:

```sql
-- FK-holders drop first (they reference public.events):
DROP TABLE IF EXISTS public.event_runs;
DROP TABLE IF EXISTS public.job_queue;

-- Original three (no remaining inbound FKs after the drops above):
DROP TABLE IF EXISTS public.workspace_skills;
DROP TABLE IF EXISTS public.events;
DROP TABLE IF EXISTS public.agent_memory;
```

CASCADE remains intentionally omitted. Comment block updated with the #210 rationale + re-audit results.

## Audit (2026-05-24, against current main)

```bash
grep -rn 'public.event_runs|FROM event_runs|INSERT INTO event_runs' \
  packages/ mcp/ integrations/ database/
# → 0 references

grep -rn 'public.job_queue|FROM job_queue|INSERT INTO job_queue' \
  packages/ mcp/ integrations/ database/
# → 0 references
```

Both are 0-row pre-palace residue. Live equivalents:
- `public.event_runs` → `nexaas_memory.skill_runs`
- `public.job_queue` → BullMQ (Redis-backed)

## Modification-in-place rationale

Migrations are normally immutable historical record. Editing 024 in place is the right call here because:

- **024 never successfully applied on any affected adopter** — it failed on the FK violation and rolled back. Every deploy that hit it is in the "024 not applied yet" state.
- **The single deploy where 024 IS recorded as applied** (Phoenix Voyages) got there via manual out-of-band drops of event_runs + job_queue followed by re-running `nexaas upgrade --migrate`. The patched 024 is invisible to Phoenix because the runner tracks `schema_migrations` by filename (no checksum), so it won't re-run.
- **No-migration adopters and adopters who haven't hit 024 yet** get the corrected version on their next `nexaas upgrade --migrate` and the drops apply cleanly in one pass.

Adding a migration 026 with the FK-holder drops wouldn't help — the runner stops at 024's failure and never reaches 026. Patching in place is the only solution that doesn't require every affected adopter to do Phoenix's manual workaround.

## Backwards compatibility

- **Phoenix (024 recorded applied):** patched 024 is invisible. No change to deploy state.
- **Fresh `nexaas init` adopters (no legacy public.* tables):** `IF EXISTS` makes all five drops no-ops. No change.
- **Affected adopter who hit the failure but didn't manually intervene:** corrected 024 applies cleanly on next migrate run. State arrives at "all five tables dropped" without operator intervention.
- **Affected adopter who manually dropped event_runs + job_queue then ran 024 successfully** (Phoenix's path): patched 024 still invisible (filename already in schema_migrations). State unchanged.

## Test plan

- [ ] Fresh `nexaas init` workspace: migrate runs 024 as no-op via `IF EXISTS`
- [ ] Legacy workspace with the FK-bearing tables: patched 024 drops in dependency order, succeeds
- [ ] Phoenix-style deploy (024 already recorded): re-running `nexaas upgrade --migrate` doesn't re-attempt 024
- [ ] CHECK constraint preservation: nothing in this migration touches CHECK constraints on the remaining `nexaas_memory.*` tables

## Related

- Closes #210
- Follows up #183 / PR #195 (original incomplete drop set)
- Same cleanup family as PR #207 (migration 025 — pa_delivery_marker.status nullable) — another schema/code reconciliation following a recent merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database migration to remove obsolete tables as part of ongoing maintenance and cleanup efforts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Systemsaholic/nexaas/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->