### PR TITLE
feat(cli): nexaas conformance — end-to-end install proof at $0 AI spend (#213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,13 @@ no client names, no specific data, no workspace-specific context]
 
 ## CLI Reference
 
-The `nexaas` CLI provides 15 commands for workspace management:
+The `nexaas` CLI provides these commands for workspace management:
 
 ```
 nexaas init --workspace <id>           Set up Nexaas on a VPS
 nexaas status                          Runtime health check
 nexaas health                          Detailed 10-point health report
+nexaas conformance [--json]            Prove the install works end-to-end ($0 AI spend)
 nexaas register-skill <skill.yaml>     Register skill with BullMQ scheduler
 nexaas trigger-skill <skill.yaml>      Fire a skill manually
 nexaas dry-run <skill.yaml> [--live]   Validate a skill manifest

--- a/packages/cli/src/conformance-mock-model.ts
+++ b/packages/cli/src/conformance-mock-model.ts
@@ -1,0 +1,148 @@
+/**
+ * Local mock of the Anthropic Messages API for conformance runs (#213).
+ *
+ * `nexaas conformance` points the Anthropic SDK at this server via
+ * ANTHROPIC_BASE_URL *inside the conformance process only* — the live
+ * worker's environment is never touched. Both runtime model paths work
+ * against it unmodified:
+ *   - the agentic loop's `client.messages.stream()` (SSE streaming)
+ *   - the gateway's anthropic provider (`messages.create`, JSON)
+ *
+ * Responses are deterministic and cost $0. The server binds 127.0.0.1 on
+ * an ephemeral port and lives only for the duration of the check.
+ */
+
+import { createServer, type Server } from "http";
+import type { AddressInfo } from "net";
+
+export const MOCK_REPLY_TEXT =
+  "CONFORMANCE_OK — deterministic reply from the Nexaas mock model server.";
+
+export interface MockModelServer {
+  /** Base URL to assign to ANTHROPIC_BASE_URL (no trailing slash). */
+  url: string;
+  /** Number of /v1/messages requests served so far. */
+  calls: () => number;
+  close: () => Promise<void>;
+}
+
+interface MessagesRequestBody {
+  model?: string;
+  stream?: boolean;
+}
+
+function sseEvent(type: string, data: Record<string, unknown>): string {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+}
+
+function buildFinalMessage(model: string) {
+  return {
+    id: "msg_conformance_mock",
+    type: "message",
+    role: "assistant",
+    model,
+    content: [{ type: "text", text: MOCK_REPLY_TEXT }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 12,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  };
+}
+
+export function startMockModelServer(): Promise<MockModelServer> {
+  let callCount = 0;
+
+  const server: Server = createServer((req, res) => {
+    if (req.method !== "POST" || !req.url?.endsWith("/v1/messages")) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { type: "not_found_error", message: "mock server only implements POST /v1/messages" } }));
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      callCount++;
+      let body: MessagesRequestBody = {};
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+      } catch {
+        /* tolerate — reply anyway, this is a probe */
+      }
+      const model = body.model ?? "mock-model";
+
+      if (!body.stream) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(buildFinalMessage(model)));
+        return;
+      }
+
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      res.write(
+        sseEvent("message_start", {
+          message: {
+            id: "msg_conformance_mock",
+            type: "message",
+            role: "assistant",
+            model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 1,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        }),
+      );
+      res.write(
+        sseEvent("content_block_start", {
+          index: 0,
+          content_block: { type: "text", text: "" },
+        }),
+      );
+      res.write(
+        sseEvent("content_block_delta", {
+          index: 0,
+          delta: { type: "text_delta", text: MOCK_REPLY_TEXT },
+        }),
+      );
+      res.write(sseEvent("content_block_stop", { index: 0 }));
+      res.write(
+        sseEvent("message_delta", {
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 12 },
+        }),
+      );
+      res.write(sseEvent("message_stop", {}));
+      res.end();
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        calls: () => callCount,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+            // Don't keep the CLI process alive on lingering keep-alive sockets.
+            server.closeAllConnections?.();
+          }),
+      });
+    });
+  });
+}

--- a/packages/cli/src/conformance.ts
+++ b/packages/cli/src/conformance.ts
@@ -1,0 +1,444 @@
+/**
+ * nexaas conformance — prove a VPS install works end-to-end at $0 AI spend (#213).
+ *
+ * `nexaas health` checks that components are up; this command checks that the
+ * framework *works*: pillar pipeline, queue→worker round-trip, waitpoint
+ * matching, WAL integrity, migration state. Designed to run on a live
+ * production VPS without side effects — every execution probe is namespaced
+ * under `conformance/` ids, writes only to `ops.conformance.*` rooms, and
+ * cleans up after itself. AI-skill execution is served by a local mock model
+ * server (ANTHROPIC_BASE_URL override inside this process only), so no API
+ * dollars are spent and the live worker's environment is never touched.
+ *
+ * Usage:
+ *   nexaas conformance                  Run infra + execution proofs
+ *   nexaas conformance --skip-execution Infra checks only (no skill runs)
+ *   nexaas conformance --with-backup    Also run a backup and verify history
+ *   nexaas conformance --json           Machine-readable output
+ *   nexaas conformance --keep-artifacts Leave temp manifests on disk for debugging
+ *
+ * Exit codes: 0 = all pass (skips allowed), 1 = at least one failure,
+ *             2 = cannot run (missing env / DB unreachable).
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { spawnSync } from "child_process";
+import pg from "pg";
+import { Queue } from "bullmq";
+import { Redis } from "ioredis";
+import { verifyWalChain } from "@nexaas/palace";
+import { startMockModelServer, MOCK_REPLY_TEXT } from "./conformance-mock-model.js";
+import { gatherState } from "./migration-state.js";
+
+interface CheckResult {
+  id: string;
+  status: "pass" | "fail" | "skip";
+  detail: string;
+  duration_ms: number;
+}
+
+const SHELL_ROUNDTRIP_TIMEOUT_MS = 60_000;
+const WAITPOINT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 1_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function workerBase(): string {
+  return `http://localhost:${process.env.NEXAAS_WORKER_PORT ?? "9090"}`;
+}
+
+function bearerHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  const token = process.env.NEXAAS_CROSS_VPS_BEARER_TOKEN;
+  if (token) headers["authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+export async function run(args: string[] = []) {
+  const json = args.includes("--json");
+  const skipExecution = args.includes("--skip-execution");
+  const withBackup = args.includes("--with-backup");
+  const keepArtifacts = args.includes("--keep-artifacts");
+
+  const workspace = process.env.NEXAAS_WORKSPACE;
+  const dbUrl = process.env.DATABASE_URL;
+  if (!workspace || !dbUrl) {
+    console.error("NEXAAS_WORKSPACE and DATABASE_URL are required");
+    process.exit(2);
+  }
+
+  const pool = new pg.Pool({ connectionString: dbUrl, max: 2 });
+  try {
+    await pool.query("SELECT 1");
+  } catch (err) {
+    console.error(`Cannot reach Postgres: ${(err as Error).message}`);
+    await pool.end();
+    process.exit(2);
+  }
+
+  const results: CheckResult[] = [];
+  let workerHealthy = false;
+  let redisHealthy = false;
+
+  async function check(id: string, fn: () => Promise<{ status: CheckResult["status"]; detail: string }>) {
+    const start = Date.now();
+    try {
+      const r = await fn();
+      results.push({ id, ...r, duration_ms: Date.now() - start });
+    } catch (err) {
+      results.push({
+        id,
+        status: "fail",
+        detail: (err as Error).message,
+        duration_ms: Date.now() - start,
+      });
+    }
+    if (!json) {
+      const r = results[results.length - 1];
+      const mark = r.status === "pass" ? "✓" : r.status === "skip" ? "–" : "✗";
+      console.log(`  ${mark} ${id.padEnd(20)} ${r.detail}`);
+    }
+  }
+
+  if (!json) console.log(`\n  Nexaas conformance — workspace '${workspace}'\n`);
+
+  // ── Infra proofs ────────────────────────────────────────────────────
+
+  await check("palace-schema", async () => {
+    const core = ["events", "wal", "skill_runs", "schema_migrations"];
+    const r = await pool.query(
+      `SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'nexaas_memory' AND table_name = ANY($1)`,
+      [core],
+    );
+    const present = r.rows.map((row) => row.table_name as string);
+    const missing = core.filter((t) => !present.includes(t));
+    if (missing.length > 0) {
+      return { status: "fail", detail: `nexaas_memory missing tables: ${missing.join(", ")}` };
+    }
+    return { status: "pass", detail: "nexaas_memory core tables present" };
+  });
+
+  await check("redis", async () => {
+    const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+      maxRetriesPerRequest: 1,
+      connectTimeout: 3000,
+      lazyConnect: true,
+    });
+    try {
+      await redis.connect();
+      const pong = await redis.ping();
+      redisHealthy = pong === "PONG";
+      return redisHealthy
+        ? { status: "pass", detail: "PONG" }
+        : { status: "fail", detail: `unexpected ping reply: ${pong}` };
+    } finally {
+      redis.disconnect();
+    }
+  });
+
+  await check("worker-health", async () => {
+    try {
+      const res = await fetch(`${workerBase()}/health`, { signal: AbortSignal.timeout(5000) });
+      const body = (await res.json()) as { status?: string; uptime?: number };
+      workerHealthy = res.ok && body.status === "healthy";
+      return workerHealthy
+        ? { status: "pass", detail: `healthy, uptime ${Math.round(body.uptime ?? 0)}s` }
+        : { status: "fail", detail: `worker reports status='${body.status}' (http ${res.status})` };
+    } catch (err) {
+      return { status: "fail", detail: `no response from ${workerBase()}/health — is nexaas-worker running? (${(err as Error).message})` };
+    }
+  });
+
+  await check("migration-state", async () => {
+    const state = await gatherState();
+    if (state.pending.length > 0) {
+      return { status: "fail", detail: `${state.pending.length} pending migration(s): ${state.pending.join(", ")}` };
+    }
+    const residual = state.residual_public.table_exists
+      ? ` (residual public.schema_migrations present — see nexaas migration-state)`
+      : "";
+    return { status: "pass", detail: `${state.applied_count} applied, 0 pending${residual}` };
+  });
+
+  await check("wal-chain", async () => {
+    const r = await verifyWalChain(workspace);
+    if (!r.valid) {
+      return { status: "fail", detail: `WAL chain broken at id ${r.brokenAt}: ${r.error}` };
+    }
+    return { status: "pass", detail: "hash chain valid" };
+  });
+
+  // ── Execution proofs ────────────────────────────────────────────────
+
+  const artifactsDir = mkdtempSync(join(tmpdir(), "nexaas-conformance-"));
+
+  await check("shell-roundtrip", async () => {
+    if (skipExecution) return { status: "skip", detail: "--skip-execution" };
+    if (!workerHealthy || !redisHealthy) {
+      return { status: "skip", detail: "requires live worker + redis" };
+    }
+    const manifestPath = join(artifactsDir, "shell-roundtrip.skill.yaml");
+    writeFileSync(manifestPath, [
+      `id: conformance/shell-roundtrip`,
+      `version: "0.0.1"`,
+      `description: Conformance probe — shell skill round-trip through the live worker`,
+      `execution:`,
+      `  type: shell`,
+      `  command: "echo conformance-shell-ok"`,
+      `  timeout: 30`,
+      `rooms:`,
+      `  primary: { wing: ops, hall: conformance, room: shell-roundtrip }`,
+      ``,
+    ].join("\n"));
+
+    const connection = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+    });
+    const queue = new Queue(`nexaas-skills-${workspace}`, { connection });
+    const runId = randomUUID();
+    const jobId = `conformance-shell-${Date.now()}`;
+    try {
+      await queue.add("skill-step", {
+        workspace,
+        runId,
+        skillId: "conformance/shell-roundtrip",
+        skillVersion: "0.0.1",
+        stepId: "shell-exec",
+        triggerType: "manual",
+        manifestPath,
+      }, { jobId });
+
+      const deadline = Date.now() + SHELL_ROUNDTRIP_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        const r = await pool.query(
+          `SELECT status FROM nexaas_memory.skill_runs WHERE run_id = $1`,
+          [runId],
+        );
+        const status = r.rows[0]?.status as string | undefined;
+        if (status === "completed") {
+          return { status: "pass", detail: `queue → worker → shell executor → skill_runs completed (run ${runId.slice(0, 8)})` };
+        }
+        if (status && status !== "running") {
+          return { status: "fail", detail: `run finished with status='${status}' (run ${runId})` };
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      // Leave nothing behind on timeout.
+      try { await (await queue.getJob(jobId))?.remove(); } catch { /* consumed or gone */ }
+      return {
+        status: "fail",
+        detail: `no terminal status within ${SHELL_ROUNDTRIP_TIMEOUT_MS / 1000}s — worker not consuming nexaas-skills-${workspace}?`,
+      };
+    } finally {
+      await queue.close();
+      await connection.quit();
+    }
+  });
+
+  await check("ai-pillar", async () => {
+    if (skipExecution) return { status: "skip", detail: "--skip-execution" };
+
+    const manifestPath = join(artifactsDir, "ai-pillar.skill.yaml");
+    writeFileSync(manifestPath, [
+      `id: conformance/ai-pillar`,
+      `version: "0.0.1"`,
+      `description: Conformance probe — ai-skill pillar pipeline against the mock model`,
+      `execution:`,
+      `  type: ai-skill`,
+      `  model_tier: cheap`,
+      `rooms:`,
+      `  primary: { wing: ops, hall: conformance, room: ai-pillar }`,
+      `limits:`,
+      `  max_turns: 2`,
+      `  max_spend_usd: 0.05`,
+      ``,
+    ].join("\n"));
+    writeFileSync(join(artifactsDir, "prompt.md"), [
+      `You are a conformance probe. Reply with a single short sentence and stop.`,
+      ``,
+    ].join("\n"));
+
+    const mock = await startMockModelServer();
+    const savedBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_BASE_URL = mock.url;
+    if (!process.env.ANTHROPIC_API_KEY) process.env.ANTHROPIC_API_KEY = "conformance-mock-key";
+
+    const runId = randomUUID();
+    try {
+      const { runAiSkill } = await import("@nexaas/runtime");
+      const result = await runAiSkill(
+        workspace,
+        {
+          id: "conformance/ai-pillar",
+          version: "0.0.1",
+          execution: { type: "ai-skill", model_tier: "cheap" },
+          rooms: { primary: { wing: "ops", hall: "conformance", room: "ai-pillar" } },
+          limits: { max_turns: 2, max_spend_usd: 0.05 },
+        },
+        manifestPath,
+        { runId, stepId: "ai-exec", triggerType: "manual" },
+      );
+
+      if (!result.success) {
+        return { status: "fail", detail: `runAiSkill returned success=false: ${result.content.slice(0, 200)}` };
+      }
+      if (mock.calls() === 0) {
+        return { status: "fail", detail: "model call did not reach the mock server — ANTHROPIC_BASE_URL override not honored" };
+      }
+      if (!result.content.includes(MOCK_REPLY_TEXT.slice(0, 14))) {
+        return { status: "fail", detail: `agentic loop returned unexpected content: ${result.content.slice(0, 120)}` };
+      }
+      const runRow = await pool.query(
+        `SELECT status FROM nexaas_memory.skill_runs WHERE run_id = $1`,
+        [runId],
+      );
+      if (runRow.rows[0]?.status !== "completed") {
+        return { status: "fail", detail: `skill_runs status='${runRow.rows[0]?.status}' after successful run` };
+      }
+      const walRow = await pool.query(
+        `SELECT count(*)::int AS n FROM nexaas_memory.wal
+          WHERE workspace = $1 AND op = 'ai_skill_completed' AND payload->>'run_id' = $2`,
+        [workspace, runId],
+      );
+      if ((walRow.rows[0]?.n ?? 0) < 1) {
+        return { status: "fail", detail: "no ai_skill_completed WAL entry for the run" };
+      }
+      return {
+        status: "pass",
+        detail: `pillar pipeline + agentic loop + WAL audit in ${result.turns} turn(s), ${mock.calls()} mock model call(s)`,
+      };
+    } finally {
+      if (savedBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+      else process.env.ANTHROPIC_BASE_URL = savedBaseUrl;
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+      await mock.close();
+    }
+  });
+
+  await check("waitpoint-roundtrip", async () => {
+    if (skipExecution) return { status: "skip", detail: "--skip-execution" };
+    if (!workerHealthy) return { status: "skip", detail: "requires live worker" };
+
+    const role = "conformance_probe";
+    const code = String(100000 + Math.floor(Math.random() * 900000));
+
+    const reg = await fetch(`${workerBase()}/api/waitpoints/inbound-match`, {
+      method: "POST",
+      headers: bearerHeaders(),
+      body: JSON.stringify({
+        workspace,
+        match: { room_pattern: role, content_pattern: "digit_code" },
+        timeout_seconds: 120,
+        tags: ["conformance"],
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (reg.status !== 201) {
+      return { status: "fail", detail: `waitpoint registration failed: http ${reg.status} ${(await reg.text()).slice(0, 150)}` };
+    }
+    const { waitpoint_id } = (await reg.json()) as { waitpoint_id: string };
+
+    try {
+      const post = await fetch(`${workerBase()}/api/drawers/inbound`, {
+        method: "POST",
+        headers: bearerHeaders(),
+        body: JSON.stringify({
+          workspace,
+          channel_role: role,
+          message: {
+            id: `conformance-${waitpoint_id}`,
+            from: "conformance",
+            content: `conformance probe code ${code}`,
+          },
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      if (post.status !== 201) {
+        return { status: "fail", detail: `inbound drawer write failed: http ${post.status} ${(await post.text()).slice(0, 150)}` };
+      }
+
+      const deadline = Date.now() + WAITPOINT_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        const res = await fetch(
+          `${workerBase()}/api/waitpoints/${waitpoint_id}?workspace=${encodeURIComponent(workspace)}`,
+          { headers: bearerHeaders(), signal: AbortSignal.timeout(5000) },
+        );
+        const status = (await res.json()) as {
+          status?: string;
+          resolved_with?: { content?: string };
+        };
+        if (status.status === "resolved") {
+          const got = status.resolved_with?.content ?? "";
+          return got.includes(code)
+            ? { status: "pass", detail: `inbound drawer matched + extracted '${code}' via live worker` }
+            : { status: "fail", detail: `resolved with unexpected content '${got}' (expected ${code})` };
+        }
+        if (status.status && status.status !== "pending") {
+          return { status: "fail", detail: `waitpoint ended '${status.status}' before resolution` };
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      return {
+        status: "fail",
+        detail: `not resolved within ${WAITPOINT_TIMEOUT_MS / 1000}s — inbound-match matcher not running in the worker?`,
+      };
+    } finally {
+      // Cancel if still pending so no waitpoint outlives the probe.
+      try {
+        await fetch(`${workerBase()}/api/waitpoints/${waitpoint_id}?workspace=${encodeURIComponent(workspace)}`, {
+          method: "DELETE",
+          headers: bearerHeaders(),
+          signal: AbortSignal.timeout(5000),
+        });
+      } catch { /* already resolved or worker gone */ }
+    }
+  });
+
+  await check("backup-run", async () => {
+    if (!withBackup) return { status: "skip", detail: "opt-in via --with-backup" };
+    const before = await pool.query(`SELECT count(*)::int AS n FROM nexaas_memory.backup_history`);
+    const r = spawnSync(process.execPath, [...process.execArgv, process.argv[1], "backup", "now"], {
+      encoding: "utf-8",
+      timeout: 300_000,
+      env: process.env,
+    });
+    if (r.status !== 0) {
+      return { status: "fail", detail: `nexaas backup now exited ${r.status}: ${(r.stderr || r.stdout || "").trim().slice(0, 200)}` };
+    }
+    const after = await pool.query(
+      `SELECT count(*)::int AS n FROM nexaas_memory.backup_history`,
+    );
+    if ((after.rows[0]?.n ?? 0) <= (before.rows[0]?.n ?? 0)) {
+      return { status: "fail", detail: "backup command succeeded but no backup_history row was recorded" };
+    }
+    return { status: "pass", detail: "backup ran and was recorded in backup_history (restore not exercised — see #213)" };
+  });
+
+  // ── Summary ─────────────────────────────────────────────────────────
+
+  if (!keepArtifacts) rmSync(artifactsDir, { recursive: true, force: true });
+  await pool.end();
+
+  const passed = results.filter((r) => r.status === "pass").length;
+  const failed = results.filter((r) => r.status === "fail").length;
+  const skipped = results.filter((r) => r.status === "skip").length;
+
+  if (json) {
+    console.log(JSON.stringify({ workspace, results, summary: { passed, failed, skipped } }, null, 2));
+  } else {
+    console.log(`\n  ${passed} passed, ${failed} failed, ${skipped} skipped`);
+    if (keepArtifacts) console.log(`  Artifacts kept at ${artifactsDir}`);
+    console.log("");
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,6 +76,9 @@ switch (command) {
   case "doctor":
     import("./doctor.js").then((m) => m.run(process.argv.slice(3)));
     break;
+  case "conformance":
+    import("./conformance.js").then((m) => m.run(process.argv.slice(3)));
+    break;
   default:
     console.log(`
 Nexaas CLI — framework for context-aware AI execution
@@ -95,6 +98,7 @@ Commands:
   gdpr export|delete|redact|subjects   PII management (GDPR compliance)
   doctor locks [--since 24h]           Concurrency-group lock contention report
   status                                Check runtime health
+  conformance [--json|--skip-execution] Prove the install works end-to-end ($0 AI spend)
   verify-wal [--full]                   Verify WAL chain integrity
   migration-state [--json]              Print applied/pending migrations from the canonical tracker
 

--- a/packages/cli/src/migration-state.ts
+++ b/packages/cli/src/migration-state.ts
@@ -54,7 +54,7 @@ function findMigrationsDir(): string | null {
   return null;
 }
 
-async function gatherState(): Promise<State> {
+export async function gatherState(): Promise<State> {
   const migrationsDir = findMigrationsDir();
   if (!migrationsDir) {
     throw new Error(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,16 @@
  */
 
 export { runSkillStep } from "./pipeline.js";
+export {
+  runAiSkill,
+  type AiSkillManifest,
+  type AiSkillExecutionContext,
+} from "./ai-skill.js";
+export {
+  runShellSkill,
+  type ShellSkillManifest,
+  type SkillExecutionContext,
+} from "./shell-skill.js";
 export { ModelGateway } from "./models/gateway.js";
 export { route as tagRoute } from "./tag/route.js";
 export { assemble as cagAssemble } from "./cag/assemble.js";


### PR DESCRIPTION
First slice of #213 (production hardening T1, umbrella #219).

## What

`nexaas conformance [--json] [--skip-execution] [--with-backup] [--keep-artifacts]` — proves a VPS install **works** end-to-end, where `nexaas health` proves it's **up**.

| Check | Proof |
|---|---|
| `palace-schema` | `nexaas_memory` core tables present |
| `redis` | live PING |
| `worker-health` | `:9090/health` reports healthy |
| `migration-state` | 0 pending vs canonical tracker (reuses `gatherState()`) |
| `wal-chain` | hash chain valid (`verifyWalChain`) |
| `shell-roundtrip` | one-off BullMQ job → live worker → shell executor → `skill_runs` completed |
| `ai-pillar` | `runAiSkill` in-process against a **local mock Anthropic server** — real agentic loop, real palace writes, real WAL audit, $0 spend |
| `waitpoint-roundtrip` | register inbound-match via the worker API → inject drawer via `/api/drawers/inbound` → assert live matching + extraction |
| `backup-run` | opt-in: `backup now` + `backup_history` assertion |

Exit codes: 0 pass / 1 failures / 2 cannot-run. `--json` for provisioning pipelines (#218).

## The mock-model approach (do-no-harm by construction)

Recon found AI skills don't go through the ModelGateway — the agentic loop calls the Anthropic SDK directly. Rather than adding a mock provider only the gateway would see, the suite starts a local HTTP server implementing `/v1/messages` (JSON + SSE streaming) and points the SDK at it via `ANTHROPIC_BASE_URL` **inside the conformance process only** (SDK ≥0.39 honors the env var). Both model paths covered, zero changes to production hot paths, the live worker's environment untouched.

## Residue discipline

Probes are namespaced `conformance/*`, write only `ops.conformance.*` rooms, temp manifests live in a `mkdtemp` dir removed afterwards, un-consumed queue jobs are removed on timeout, and pending waitpoints are cancelled in a `finally`. Verified post-run: zero `running` skill_runs, no artifact dirs.

## Supporting changes

- `@nexaas/runtime` exports `runAiSkill` / `runShellSkill` + manifest types (the worker imports them relatively; the package index never exposed them — additive)
- `migration-state.ts` exports `gatherState()`

## Validation (scratch DB + dev worker on the framework VPS)

- 9/9 pass with `--with-backup`, via both tsx and compiled `--conditions=production dist/` paths
- Worker unreachable → `worker-health` fails with actionable message, dependent execution checks skip, exit 1; `ai-pillar` still passes (in-process)
- Missing env → exit 2
- Scratch env fully torn down after

## Found along the way (commented on #218)

`nexaas init` applies migrations via a raw psql loop and never creates/populates `nexaas_memory.schema_migrations` — fresh installs have no canonical tracker until their first `nexaas upgrade`. The init last-mile work in #218 should adopt the upgrade-runner's tracked path.

## Remaining for #213 (follow-up slices)

Archetype scenarios (ingestion→triage, approval-gated publish, shadow financial, broadcast), mock-channel MCP, restore exercising, wiring into `nexaas init`/`upgrade` (#214/#218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nexaas conformance` command to validate VPS installation health and functionality, including infrastructure, execution, and data integrity checks.
  * Support for `--json` output format and optional `--keep-artifacts` and `--with-backup` flags.

* **Documentation**
  * Updated CLI reference to document the new `nexaas conformance` command alongside existing workspace-management utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->