### PR TITLE
feat(runtime): per-workspace daily AI spend budget — hard stop with queue pause (#215)

### DIFF
--- a/database/migrations/026_spend_governance.sql
+++ b/database/migrations/026_spend_governance.sql
@@ -1,0 +1,29 @@
+-- Migration 026: Spend governance — per-workspace daily AI budget (issue #215)
+-- Date: 2026-06-10
+--
+-- Nexmatic provisions the model keys for most client workspaces, so a
+-- runaway agentic loop burns the operator's margin directly. Per-run
+-- guardrails (#25) bound a single run; nothing bounds a workspace's *day*.
+--
+-- Two pieces:
+--   1. workspace_config.spend_daily_budget_usd — the budget. NULL (default)
+--      means unlimited: existing workspaces see zero behavior change.
+--   2. spend_daily — one row per workspace per local day, incremented by
+--      the agentic loop and the model gateway after each completed call.
+--      `day` is computed in the workspace's configured timezone so the
+--      budget window matches the operator's mental model of "today".
+--
+-- Both changes are additive and nullable/defaulted — backward-compatible
+-- one release per the migration policy (#214).
+
+ALTER TABLE nexaas_memory.workspace_config
+  ADD COLUMN IF NOT EXISTS spend_daily_budget_usd NUMERIC;
+
+CREATE TABLE IF NOT EXISTS nexaas_memory.spend_daily (
+  workspace   TEXT NOT NULL,
+  day         DATE NOT NULL,
+  usd         NUMERIC NOT NULL DEFAULT 0,
+  model_calls INTEGER NOT NULL DEFAULT 0,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (workspace, day)
+);

--- a/docs/spend-governance.md
+++ b/docs/spend-governance.md
@@ -1,0 +1,84 @@
+# Spend Governance — per-workspace daily AI budget
+
+*Shipped for #215 (production hardening T3, umbrella #219).*
+
+Per-run guardrails (#25: `max_spend_usd`, token caps, turn caps) bound a single
+run. Nothing bounded a workspace's *day* — 500 cheap runs at $0.40 each are
+invisible to per-run caps. In operator-managed deployments the model keys
+belong to the operator, so a runaway day burns the operator's margin directly.
+
+The daily budget is a **hard stop**: when a workspace crosses it, the skill
+queue pauses until local midnight. Not an advisory alert.
+
+## Configuration
+
+```
+nexaas config set spend-budget 25        # $25/day hard budget
+nexaas config set spend-budget off       # back to unlimited (the default)
+nexaas config set spend-override today   # disable enforcement for today only
+```
+
+- Budget lives in `nexaas_memory.workspace_config.spend_daily_budget_usd`
+  (NULL = unlimited — every existing workspace is unaffected until opted in).
+- The budget day is the **workspace-local day** (`workspace_config.timezone`),
+  so "resumes at midnight" matches the operator's clock.
+- The override is a one-day escape hatch stored in `workspace_kv`
+  (`spend_budget_override_date`); it expires naturally at day rollover.
+
+## How it works
+
+**Recording.** The agentic loop (every ai-skill and PA conversation) and the
+model gateway (pillar-pipeline path) upsert completed-call cost into
+`nexaas_memory.spend_daily (workspace, day)`. Recording never throws — an
+accounting failure must not fail a run that already happened.
+
+**Enforcement** is deliberately *not* per-turn. Spec'd behavior: in-flight
+runs finish their current step and park. Overshoot is bounded by
+`worker concurrency × max_spend_usd`.
+
+| Surface | Behavior on breach |
+|---|---|
+| ai-skill (pre-run, after preflight) | Run is **skipped** (not failed — no silent-failure counter pollution), terminal drawer written, queue paused immediately |
+| Model gateway (pre-call) | Throws `SpendBudgetExceededError` **before** resolving providers — the fallback chain can never route around the budget onto a still-billable fallback key |
+| PA service (pre-conversation) | Returns a clear refusal message naming the override command — PA arrives over HTTP, so the queue pause alone wouldn't stop it |
+| Worker monitor (60s tick + at startup) | Pauses/resumes the queue persistently |
+
+**Pause/resume is monitor-driven, not timer-driven.** The 429 backoff (#27)
+uses in-memory `setTimeout` resumes — fine for 5-minute cooldowns, wrong for
+an overnight pause: BullMQ pause state persists in Redis across worker
+restarts and the timer doesn't. The spend-budget monitor re-evaluates every
+minute (and once at worker startup), so a restarted worker reconciles a stale
+pause, day rollover resumes naturally, and the override takes effect within
+a minute. The pause marker (`workspace_kv.spend_pause_active_day`) ensures
+the monitor only resumes queues *it* paused.
+
+## Observation
+
+```
+nexaas health      # "Spend budget: $19.80 of $25.00 (79%)" + warning ≥80%, critical when paused
+nexaas config      # shows the configured budget
+```
+
+| WAL op | When |
+|---|---|
+| `spend_budget_exceeded` | Queue paused (spent/budget/model-call counts in payload) |
+| `spend_budget_resumed` | Queue resumed (reason: override vs rollover/budget change) |
+| `ai_skill_skipped` with `spend_budget: true` | A queued run arrived while over budget |
+
+An ops alert (severity critical, deduped per workspace-day) fires on breach
+via the unified notification dispatch (Telegram/email/palace).
+
+```sql
+-- Spend history
+SELECT day, usd, model_calls FROM nexaas_memory.spend_daily
+ WHERE workspace = :ws ORDER BY day DESC LIMIT 14;
+```
+
+## Limits / notes
+
+- Runs whose tier has no pricing in `model-registry.yaml` record $0 — keep
+  pricing populated or the budget undercounts.
+- `spend_daily` is framework accounting, not billing truth — reconcile
+  against the provider console for invoicing.
+- Anthropic-side per-key spend limits remain the backstop (key provisioning
+  is operator-side work, tracked in the Nexmatic repo).

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -6,6 +6,8 @@
  *   nexaas config set timezone America/Toronto
  *   nexaas config set default-model-tier good
  *   nexaas config set display-name "Phoenix Voyages"
+ *   nexaas config set spend-budget 25     Daily AI budget in USD (#215); "off" = unlimited
+ *   nexaas config set spend-override today   Disable budget enforcement for today only
  */
 
 import { execSync } from "child_process";
@@ -30,6 +32,46 @@ export async function run(args: string[]) {
     const key = args[1];
     const value = args.slice(2).join(" ");
 
+    // Daily spend budget (#215). Numeric column; "off"/"none" clears it
+    // (NULL = unlimited, the default for every existing workspace).
+    if (key === "spend-budget") {
+      if (value === "off" || value === "none") {
+        exec(`psql "${dbUrl}" -c "UPDATE nexaas_memory.workspace_config SET spend_daily_budget_usd = NULL, updated_at = now() WHERE workspace = '${workspace}'" 2>/dev/null`);
+        console.log(`\n  ✓ spend-budget = off (unlimited)\n`);
+        return;
+      }
+      const budget = Number(value);
+      if (!Number.isFinite(budget) || budget <= 0) {
+        console.error(`  spend-budget must be a positive number of USD, or "off"`);
+        process.exit(1);
+      }
+      exec(`psql "${dbUrl}" -c "UPDATE nexaas_memory.workspace_config SET spend_daily_budget_usd = ${budget}, updated_at = now() WHERE workspace = '${workspace}'" 2>/dev/null`);
+      console.log(`\n  ✓ spend-budget = $${budget.toFixed(2)}/day\n`);
+      return;
+    }
+
+    // One-day budget override (#215): "today" resolves to the workspace's
+    // local date; an explicit YYYY-MM-DD is accepted for pre-arming. The
+    // worker's spend-budget monitor resumes the queue within a minute.
+    if (key === "spend-override") {
+      let day = value;
+      if (value === "today") {
+        const tz = exec(`psql "${dbUrl}" -t -A -c "SELECT timezone FROM nexaas_memory.workspace_config WHERE workspace = '${workspace}'" 2>/dev/null`) || "UTC";
+        try {
+          day = new Intl.DateTimeFormat("en-CA", { timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date());
+        } catch {
+          day = new Date().toISOString().slice(0, 10);
+        }
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+        console.error(`  spend-override takes "today" or a YYYY-MM-DD date`);
+        process.exit(1);
+      }
+      exec(`psql "${dbUrl}" -c "INSERT INTO nexaas_memory.workspace_kv (workspace, key, value) VALUES ('${workspace}', 'spend_budget_override_date', '${day}') ON CONFLICT (workspace, key) DO UPDATE SET value = EXCLUDED.value" 2>/dev/null`);
+      console.log(`\n  ✓ spend-override = ${day} (budget enforcement disabled for that local day)\n`);
+      return;
+    }
+
     const columnMap: Record<string, string> = {
       "timezone": "timezone",
       "tz": "timezone",
@@ -44,7 +86,7 @@ export async function run(args: string[]) {
     const column = columnMap[key];
     if (!column) {
       console.error(`  Unknown config key: ${key}`);
-      console.error(`  Valid keys: timezone, default-model-tier, display-name, workspace-root`);
+      console.error(`  Valid keys: timezone, default-model-tier, display-name, workspace-root, spend-budget, spend-override`);
       process.exit(1);
     }
 
@@ -55,6 +97,9 @@ export async function run(args: string[]) {
 
   // Show current config
   const row = exec(`psql "${dbUrl}" -c "SELECT timezone, display_name, default_model_tier, workspace_root, created_at::text, updated_at::text FROM nexaas_memory.workspace_config WHERE workspace = '${workspace}'" -t -A 2>/dev/null`);
+  // Queried separately: the column arrives with migration 026, and config
+  // must keep working against a not-yet-migrated DB (upgrade-window skew).
+  const budget = exec(`psql "${dbUrl}" -c "SELECT spend_daily_budget_usd::text FROM nexaas_memory.workspace_config WHERE workspace = '${workspace}'" -t -A 2>/dev/null`);
 
   if (!row) {
     console.log(`\n  No config found for workspace '${workspace}'. Run 'nexaas config set timezone America/Toronto' to initialize.\n`);
@@ -67,6 +112,7 @@ export async function run(args: string[]) {
   console.log(`  Display name:       ${parts[1] || "(not set)"}`);
   console.log(`  Default model tier: ${parts[2] || "good"}`);
   console.log(`  Workspace root:     ${parts[3] || "(not set)"}`);
+  console.log(`  Daily spend budget: ${budget ? `$${Number(budget).toFixed(2)}/day` : "(unlimited)"}`);
   console.log(`  Created:            ${parts[4]}`);
   console.log(`  Updated:            ${parts[5]}`);
   console.log("");

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -86,6 +86,37 @@ export async function run() {
   const cost = parseFloat(costRes.rows[0]?.cost ?? "0");
   if (cost > 20) alerts.push({ sev: "warning", comp: "cost", msg: `$${cost.toFixed(2)} today` });
 
+  // Daily spend budget (#215). Tolerates a not-yet-migrated DB (the
+  // spend_daily table arrives with migration 026) — health must not break
+  // during the upgrade window.
+  let budgetLine = "(unlimited)";
+  try {
+    const budgetRes = await pool.query(
+      `SELECT c.spend_daily_budget_usd::text AS budget,
+              COALESCE(s.usd, 0)::text AS spent,
+              (SELECT value FROM nexaas_memory.workspace_kv kv
+                WHERE kv.workspace = c.workspace AND kv.key = 'spend_pause_active_day') AS paused_day
+         FROM nexaas_memory.workspace_config c
+         LEFT JOIN nexaas_memory.spend_daily s
+           ON s.workspace = c.workspace
+          AND s.day = (now() AT TIME ZONE c.timezone)::date
+        WHERE c.workspace = $1`,
+      [workspace],
+    );
+    const b = budgetRes.rows[0];
+    if (b?.budget) {
+      const budgetUsd = parseFloat(b.budget);
+      const spentUsd = parseFloat(b.spent ?? "0");
+      const pct = budgetUsd > 0 ? Math.round((100 * spentUsd) / budgetUsd) : 0;
+      budgetLine = `$${spentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)} (${pct}%)${b.paused_day ? " — QUEUE PAUSED" : ""}`;
+      if (b.paused_day) {
+        alerts.push({ sev: "critical", comp: "spend-budget", msg: `daily budget exceeded — queue paused (resumes at local midnight or via spend-override)` });
+      } else if (pct >= 80) {
+        alerts.push({ sev: "warning", comp: "spend-budget", msg: `${pct}% of daily budget spent ($${spentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)})` });
+      }
+    }
+  } catch { /* pre-026 schema — no budget machinery yet */ }
+
   // Counts
   const walRes = await pool.query(`SELECT count(*) FROM nexaas_memory.wal WHERE workspace = $1`, [workspace]);
   const palaceRes = await pool.query(`SELECT count(*) FROM nexaas_memory.events WHERE workspace = $1 AND wing IS NOT NULL`, [workspace]);
@@ -108,6 +139,7 @@ export async function run() {
   console.log(`    Worker uptime:      ${Math.round(uptime)}s`);
   console.log(`    Last hour:          ${ok} ok, ${fail} fail (${rate}%)`);
   console.log(`    API cost today:     $${cost.toFixed(2)}`);
+  console.log(`    Spend budget:       ${budgetLine}`);
   console.log(`    WAL entries:        ${walRes.rows[0]?.count}`);
   console.log(`    Palace drawers:     ${palaceRes.rows[0]?.count}`);
   console.log(`    Memory:             ${memUsed}GB used, ${memAvail}GB available`);

--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -20,6 +20,8 @@ import { runTracker } from "./run-tracker.js";
 import { McpClient, loadMcpConfigs } from "./mcp/client.js";
 import { acquireMcpClient, releaseMcpClient } from "./mcp/pool.js";
 import { runAgenticLoop, type McpTool, type AgenticLimits } from "./models/agentic-loop.js";
+import { getBudgetState } from "./models/spend-governor.js";
+import { pauseForBudgetBreach } from "./tasks/spend-budget-monitor.js";
 import { resolveTier, estimateCost, type ModelEntry } from "./models/registry.js";
 import { verifyOutputs, summarizeFailures, type OutputVerification } from "./ai-skill-verify.js";
 import type { OutputKind, ManifestApproval, RoutingDecision } from "./tag/route.js";
@@ -234,6 +236,41 @@ export async function runAiSkill(
       console.error(`[nexaas] AI skill '${manifest.id}' preflight failed (exit ${exitCode}): ${errSummary}`);
       return { success: false, turns: 0, toolCalls: 0, content: errSummary };
     }
+  }
+
+  // Daily spend budget gate (#215) — checked after preflight, before any
+  // MCP spawn or model cost. A breached budget skips the run (not fails:
+  // failure would pollute silent-failure counters for what is a policy
+  // stop) and pauses the workspace queue immediately rather than waiting
+  // for the next monitor tick. In-flight runs are unaffected per spec.
+  try {
+    const budget = await getBudgetState(workspace);
+    if (budget.exceeded) {
+      const reason =
+        `daily spend budget exceeded: $${budget.spentUsd.toFixed(4)} of $${budget.budgetUsd?.toFixed(2)} (resumes at local midnight)`;
+      const room = manifest.rooms?.primary ?? { wing: "operations", hall: "ai", room: manifest.id };
+      await session.writeDrawer(room, JSON.stringify({
+        skill: manifest.id,
+        success: true,
+        skipped: true,
+        reason,
+      }));
+      await appendWal({
+        workspace,
+        op: "ai_skill_skipped",
+        actor: `skill:${manifest.id}`,
+        payload: { run_id: runId, reason, spend_budget: true },
+      });
+      await runTracker.markStepCompleted(runId, stepId);
+      await runTracker.markSkipped(runId, reason);
+      await pauseForBudgetBreach(workspace, budget);
+      console.warn(`[nexaas] AI skill '${manifest.id}' skipped: ${reason}`);
+      return { success: true, turns: 0, toolCalls: 0, content: `skipped: ${reason}` };
+    }
+  } catch (err) {
+    // Budget evaluation must never block execution — fail open and let the
+    // monitor task be the enforcement backstop.
+    console.error(`[nexaas] spend-budget pre-run check failed (continuing):`, err);
   }
 
   // Load the prompt

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -40,6 +40,14 @@ export {
 } from "./bullmq/index.js";
 export { runCompaction } from "./tasks/closet-compaction.js";
 export { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-reaper.js";
+export {
+  recordSpend,
+  getBudgetState,
+  assertWithinBudget,
+  SpendBudgetExceededError,
+  type BudgetState,
+} from "./models/spend-governor.js";
+export { spendBudgetTick } from "./tasks/spend-budget-monitor.js";
 
 // Skill terminal-state primitives (#171–#174 silent-failure arc)
 export {

--- a/packages/runtime/src/models/agentic-loop.ts
+++ b/packages/runtime/src/models/agentic-loop.ts
@@ -20,6 +20,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { appendWal } from "@nexaas/palace";
 import type { ModelAction } from "./gateway.js";
 import { isRetryable as isRetryableAnthropicError } from "./providers/anthropic.js";
+import { recordSpend } from "./spend-governor.js";
 
 let _client: Anthropic | null = null;
 
@@ -537,6 +538,16 @@ export async function runAgenticLoop(params: {
     });
   }
 
+  const totalCostUsd = costOf(
+    modelPricing, totalInputTokens, totalOutputTokens,
+    totalCacheCreationTokens, totalCacheReadTokens,
+  );
+
+  // Daily spend accounting (#215). This is the single chokepoint covering
+  // every agentic caller (ai-skill, PA service, future surfaces). Never
+  // throws — see spend-governor.ts.
+  await recordSpend(workspace, totalCostUsd, turns);
+
   return {
     content: finalContent,
     toolCalls: allToolCalls,
@@ -545,10 +556,7 @@ export async function runAgenticLoop(params: {
     outputTokens: totalOutputTokens,
     cacheCreationTokens: totalCacheCreationTokens,
     cacheReadTokens: totalCacheReadTokens,
-    costUsd: costOf(
-      modelPricing, totalInputTokens, totalOutputTokens,
-      totalCacheCreationTokens, totalCacheReadTokens,
-    ),
+    costUsd: totalCostUsd,
     turns,
     stopReason,
     aborted,

--- a/packages/runtime/src/models/gateway.ts
+++ b/packages/runtime/src/models/gateway.ts
@@ -16,6 +16,7 @@ import {
 import * as anthropicProvider from "./providers/anthropic.js";
 import * as openaiProvider from "./providers/openai.js";
 import { appendWal } from "@nexaas/palace";
+import { assertWithinBudget, recordSpend } from "./spend-governor.js";
 
 export type ModelTier = "cheap" | "good" | "better" | "best";
 
@@ -157,6 +158,14 @@ async function tryWithRetries(
 export const ModelGateway = {
   async execute(params: ExecuteParams): Promise<ExecuteResult> {
     const { tier, messages, system, tools, workspaceId, runId, stepId } = params;
+
+    // Daily budget gate (#215) — evaluated BEFORE resolving providers so a
+    // breach can never enter tryWithRetries or the fallback chain below.
+    // SpendBudgetExceededError propagates to the caller as-is; it is a
+    // policy stop, not a provider failure, and must never be "recovered"
+    // by falling back to another (still billable) provider.
+    await assertWithinBudget(workspaceId);
+
     const { primary, fallbacks } = resolveTier(tier);
 
     // Build the full message list including retrieval context
@@ -202,6 +211,8 @@ export const ModelGateway = {
           step_id: stepId,
         },
       });
+
+      await recordSpend(workspaceId, cost);
 
       return {
         content: primaryResult.content,
@@ -251,6 +262,8 @@ export const ModelGateway = {
             step_id: stepId,
           },
         });
+
+        await recordSpend(workspaceId, cost);
 
         return {
           content: fallbackResult.content,

--- a/packages/runtime/src/models/spend-governor.ts
+++ b/packages/runtime/src/models/spend-governor.ts
@@ -1,0 +1,164 @@
+/**
+ * Spend governor — per-workspace daily AI budget (#215).
+ *
+ * Recording: `recordSpend()` is called from the two model chokepoints
+ * (agentic loop, model gateway) after each completed call/run, upserting
+ * into nexaas_memory.spend_daily keyed by workspace-local day.
+ *
+ * Enforcement is deliberately *not* in the per-turn hot path. The spec'd
+ * behavior (#215) is "in-flight runs finish their current step and park":
+ *   - ai-skill checks the budget pre-run (before MCP/model cost) and skips
+ *     cleanly — no failure noise, no silent-failure counter pollution
+ *   - the gateway checks pre-call and throws SpendBudgetExceededError,
+ *     which the fallback chain must never catch (a budget breach surfacing
+ *     as a provider error would route around the cap and keep spending on
+ *     the fallback key)
+ *   - the worker's spend-budget-monitor task pauses/resumes the workspace
+ *     queue persistently (survives worker restarts, unlike the in-memory
+ *     429 backoff timers in bullmq/rate-limit.ts)
+ *
+ * Overshoot is bounded by per-run caps (#25): at most
+ * worker-concurrency × max_spend_usd beyond the budget.
+ *
+ * Override: workspace_kv key `spend_budget_override_date` set to the
+ * workspace-local day (YYYY-MM-DD) disables enforcement for that day only —
+ * the operator's "yes, I mean it, keep running today" escape hatch.
+ */
+
+import { sql, sqlOne } from "@nexaas/palace";
+
+export class SpendBudgetExceededError extends Error {
+  readonly code = "spend_budget_exceeded";
+  constructor(
+    readonly workspace: string,
+    readonly spentUsd: number,
+    readonly budgetUsd: number,
+  ) {
+    super(
+      `Daily AI spend budget exceeded for workspace '${workspace}': ` +
+        `$${spentUsd.toFixed(4)} spent of $${budgetUsd.toFixed(2)} budget. ` +
+        `Resumes at local midnight, or set workspace_kv 'spend_budget_override_date' to today.`,
+    );
+    this.name = "SpendBudgetExceededError";
+  }
+}
+
+export interface BudgetState {
+  day: string;
+  budgetUsd: number | null;
+  spentUsd: number;
+  modelCalls: number;
+  overridden: boolean;
+  exceeded: boolean;
+}
+
+// Timezone changes are rare; a short cache keeps the per-run/-call DB
+// overhead at one query (the spend row) instead of three.
+const TZ_CACHE_MS = 5 * 60_000;
+const _tzCache = new Map<string, { tz: string; at: number }>();
+
+async function workspaceTimezone(workspace: string): Promise<string> {
+  const cached = _tzCache.get(workspace);
+  if (cached && Date.now() - cached.at < TZ_CACHE_MS) return cached.tz;
+  let tz = "UTC";
+  try {
+    const row = await sqlOne<{ timezone: string }>(
+      `SELECT timezone FROM nexaas_memory.workspace_config WHERE workspace = $1`,
+      [workspace],
+    );
+    if (row?.timezone) tz = row.timezone;
+  } catch {
+    /* unconfigured workspace — UTC */
+  }
+  _tzCache.set(workspace, { tz, at: Date.now() });
+  return tz;
+}
+
+/** YYYY-MM-DD in the given IANA timezone (en-CA locale formats exactly that). */
+export function localDay(tz: string, at: Date = new Date()): string {
+  try {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(at);
+  } catch {
+    return at.toISOString().slice(0, 10);
+  }
+}
+
+/**
+ * Record completed model spend. Never throws — a spend-accounting failure
+ * must not fail the run that already happened.
+ */
+export async function recordSpend(
+  workspace: string,
+  usd: number,
+  modelCalls = 1,
+): Promise<void> {
+  if (!(usd > 0) && modelCalls <= 0) return;
+  try {
+    const day = localDay(await workspaceTimezone(workspace));
+    await sql(
+      `INSERT INTO nexaas_memory.spend_daily (workspace, day, usd, model_calls)
+         VALUES ($1, $2, $3, $4)
+       ON CONFLICT (workspace, day)
+         DO UPDATE SET usd = nexaas_memory.spend_daily.usd + EXCLUDED.usd,
+                       model_calls = nexaas_memory.spend_daily.model_calls + EXCLUDED.model_calls,
+                       updated_at = now()`,
+      [workspace, day, usd, modelCalls],
+    );
+  } catch (err) {
+    console.error(`[nexaas] spend-governor: failed to record spend for ${workspace}:`, err);
+  }
+}
+
+export async function getBudgetState(workspace: string): Promise<BudgetState> {
+  const tz = await workspaceTimezone(workspace);
+  const day = localDay(tz);
+
+  const cfg = await sqlOne<{ spend_daily_budget_usd: string | null }>(
+    `SELECT spend_daily_budget_usd FROM nexaas_memory.workspace_config WHERE workspace = $1`,
+    [workspace],
+  );
+  const budgetRaw = cfg?.spend_daily_budget_usd;
+  const budgetUsd = budgetRaw == null ? null : Number(budgetRaw);
+
+  const spent = await sqlOne<{ usd: string; model_calls: number }>(
+    `SELECT usd, model_calls FROM nexaas_memory.spend_daily WHERE workspace = $1 AND day = $2`,
+    [workspace, day],
+  );
+  const spentUsd = spent ? Number(spent.usd) : 0;
+  const modelCalls = spent ? Number(spent.model_calls) : 0;
+
+  let overridden = false;
+  try {
+    const kv = await sqlOne<{ value: string }>(
+      `SELECT value FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = 'spend_budget_override_date'`,
+      [workspace],
+    );
+    overridden = kv?.value === day;
+  } catch {
+    /* kv table absent on very old schemas — no override */
+  }
+
+  const exceeded =
+    budgetUsd != null && Number.isFinite(budgetUsd) && !overridden && spentUsd >= budgetUsd;
+
+  return { day, budgetUsd, spentUsd, modelCalls, overridden, exceeded };
+}
+
+/**
+ * Throw SpendBudgetExceededError when the workspace is over its daily
+ * budget. Callers in the model path invoke this BEFORE any provider call —
+ * the error class is the contract that lets the gateway distinguish
+ * "budget" from "provider failed" and skip the fallback chain.
+ */
+export async function assertWithinBudget(workspace: string): Promise<BudgetState> {
+  const state = await getBudgetState(workspace);
+  if (state.exceeded) {
+    throw new SpendBudgetExceededError(workspace, state.spentUsd, state.budgetUsd as number);
+  }
+  return state;
+}

--- a/packages/runtime/src/pa/service.ts
+++ b/packages/runtime/src/pa/service.ts
@@ -15,6 +15,8 @@
 import { randomUUID } from "crypto";
 import { palace, appendWal, sql } from "@nexaas/palace";
 import { runAgenticLoop, type McpTool } from "../models/agentic-loop.js";
+import { getBudgetState } from "../models/spend-governor.js";
+import { resolveTier } from "../models/registry.js";
 import { McpClient, loadMcpConfigs } from "../mcp/client.js";
 import { runTracker } from "../run-tracker.js";
 
@@ -57,6 +59,27 @@ export async function handlePaMessage(
 ): Promise<{ response: string; turns: number; toolCalls: number }> {
   const runId = randomUUID();
   const model = TIER_MAP[persona.modelTier] ?? "claude-sonnet-4-6";
+
+  // Daily spend budget gate (#215) — checked before run tracking, MCP
+  // spawn, or any model cost. PA requests arrive over HTTP, so the queue
+  // pause that stops skills doesn't stop them; without this check a chatty
+  // operator could keep burning the key all day. A clear refusal beats a
+  // cryptic error; the conversation resumes at local midnight.
+  try {
+    const budget = await getBudgetState(workspace);
+    if (budget.exceeded) {
+      return {
+        response:
+          `I've hit this workspace's daily AI budget ` +
+          `($${budget.spentUsd.toFixed(2)} of $${budget.budgetUsd?.toFixed(2)}), so I have to pause until midnight. ` +
+          `An operator can override for today with: nexaas config set spend-override today`,
+        turns: 0,
+        toolCalls: 0,
+      };
+    }
+  } catch (err) {
+    console.error(`[nexaas] pa: spend-budget check failed (continuing):`, err);
+  }
 
   await runTracker.createRun({
     runId,
@@ -286,6 +309,21 @@ Be helpful, context-aware, and follow the brand voice.`;
     // Anthropic response from holding the HTTP handler indefinitely.
     // Default 2 min; override via NEXAAS_PA_TIMEOUT_MS.
     const paTimeoutMs = parseInt(process.env.NEXAAS_PA_TIMEOUT_MS ?? "120000", 10);
+
+    // Resolve pricing so PA conversations land in daily spend accounting
+    // (#215) — without it the agentic loop computes costUsd=0 and PA usage
+    // is invisible to the budget. Mirrors ai-skill.ts.
+    let modelPricing: { inputCostPerM: number; outputCostPerM: number } | undefined;
+    try {
+      const resolved = resolveTier(persona.modelTier);
+      if (resolved.primary.input_cost_per_m != null && resolved.primary.output_cost_per_m != null) {
+        modelPricing = {
+          inputCostPerM: resolved.primary.input_cost_per_m,
+          outputCostPerM: resolved.primary.output_cost_per_m,
+        };
+      }
+    } catch { /* registry not available — spend goes unrecorded, as before */ }
+
     const result = await Promise.race([
       runAgenticLoop({
         model,
@@ -294,6 +332,7 @@ Be helpful, context-aware, and follow the brand voice.`;
         tools: allTools,
         executeTool,
         limits: { maxTurns: persona.maxTurns ?? 15 },
+        modelPricing,
         workspace,
         runId,
         skillId: `pa/${persona.id}`,

--- a/packages/runtime/src/tasks/spend-budget-monitor.ts
+++ b/packages/runtime/src/tasks/spend-budget-monitor.ts
@@ -1,0 +1,139 @@
+/**
+ * Spend-budget monitor — pause/resume the workspace queue on daily budget
+ * breach (#215).
+ *
+ * Runs every minute as a worker background task. Monitor-driven rather than
+ * timer-driven on purpose: the 429 backoff (#27, bullmq/rate-limit.ts) uses
+ * in-memory setTimeout resumes, which is fine for 5-minute cooldowns but
+ * wrong for an overnight budget pause — BullMQ pause state persists in
+ * Redis across worker restarts, the timer doesn't, and the queue would
+ * stay paused forever. This monitor re-evaluates the budget on every tick:
+ *
+ *   over budget  + no pause marker → pause queue, alert ops, WAL
+ *   under budget + pause marker    → resume queue, WAL
+ *                                    (day rollover and the operator's
+ *                                     override both land here naturally)
+ *
+ * The pause marker lives in workspace_kv (`spend_pause_active_day`), so a
+ * restarted worker resumes a stale pause and never resumes a queue some
+ * other subsystem paused.
+ */
+
+import { appendWal, sql, sqlOne } from "@nexaas/palace";
+import { getSkillQueue } from "../bullmq/queues.js";
+import { getBudgetState, type BudgetState } from "../models/spend-governor.js";
+import { notify } from "../notifications.js";
+
+const MARKER_KEY = "spend_pause_active_day";
+
+async function readMarker(workspace: string): Promise<string | null> {
+  const row = await sqlOne<{ value: string }>(
+    `SELECT value FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = $2`,
+    [workspace, MARKER_KEY],
+  );
+  return row?.value ?? null;
+}
+
+async function writeMarker(workspace: string, day: string): Promise<void> {
+  await sql(
+    `INSERT INTO nexaas_memory.workspace_kv (workspace, key, value) VALUES ($1, $2, $3)
+     ON CONFLICT (workspace, key) DO UPDATE SET value = EXCLUDED.value`,
+    [workspace, MARKER_KEY, day],
+  );
+}
+
+async function clearMarker(workspace: string): Promise<void> {
+  await sql(
+    `DELETE FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = $2`,
+    [workspace, MARKER_KEY],
+  );
+}
+
+/**
+ * Pause the workspace queue for a budget breach. Idempotent per local day.
+ * Also callable directly from ai-skill's pre-run gate so the pause lands
+ * immediately instead of waiting for the next monitor tick.
+ */
+export async function pauseForBudgetBreach(
+  workspace: string,
+  state: BudgetState,
+): Promise<void> {
+  const marker = await readMarker(workspace);
+  if (marker === state.day) return; // already paused for today
+
+  const queue = getSkillQueue(workspace);
+  try {
+    await queue.pause();
+  } catch (err) {
+    console.error(`[nexaas] spend-budget: failed to pause queue ${workspace}:`, err);
+    return;
+  }
+  await writeMarker(workspace, state.day);
+  await appendWal({
+    workspace,
+    op: "spend_budget_exceeded",
+    actor: "spend-budget-monitor",
+    payload: {
+      day: state.day,
+      spent_usd: state.spentUsd,
+      budget_usd: state.budgetUsd,
+      model_calls: state.modelCalls,
+      resumes: "local midnight (or workspace_kv spend_budget_override_date = today)",
+    },
+  });
+  console.warn(
+    `[nexaas] spend-budget: workspace ${workspace} paused — $${state.spentUsd.toFixed(4)} spent of $${state.budgetUsd?.toFixed(2)} daily budget`,
+  );
+  try {
+    await notify({
+      workspace,
+      severity: "critical",
+      component: "spend-budget",
+      title: `Daily AI budget exceeded — queue paused`,
+      body:
+        `Workspace '${workspace}' spent $${state.spentUsd.toFixed(2)} of its $${state.budgetUsd?.toFixed(2)} daily budget ` +
+        `(${state.modelCalls} model calls). Skill queue is paused until local midnight. ` +
+        `To resume today: nexaas config set spend-override today`,
+      dedupeKey: `spend-budget-${workspace}-${state.day}`,
+      dedupeWindowMinutes: 24 * 60,
+    });
+  } catch (err) {
+    console.error(`[nexaas] spend-budget: alert dispatch failed:`, err);
+  }
+}
+
+async function resumeAfterBudgetPause(workspace: string, state: BudgetState): Promise<void> {
+  const queue = getSkillQueue(workspace);
+  try {
+    await queue.resume();
+  } catch (err) {
+    console.error(`[nexaas] spend-budget: failed to resume queue ${workspace}:`, err);
+    return;
+  }
+  await clearMarker(workspace);
+  await appendWal({
+    workspace,
+    op: "spend_budget_resumed",
+    actor: "spend-budget-monitor",
+    payload: {
+      day: state.day,
+      reason: state.overridden ? "operator_override" : "day_rollover_or_budget_change",
+    },
+  });
+  console.log(`[nexaas] spend-budget: workspace ${workspace} queue resumed`);
+}
+
+/** One monitor tick. Exported for the worker's background-task loop. */
+export async function spendBudgetTick(workspace: string): Promise<void> {
+  try {
+    const state = await getBudgetState(workspace);
+    if (state.exceeded) {
+      await pauseForBudgetBreach(workspace, state);
+    } else {
+      const marker = await readMarker(workspace);
+      if (marker) await resumeAfterBudgetPause(workspace, state);
+    }
+  } catch (err) {
+    console.error(`[nexaas] spend-budget monitor tick failed:`, err);
+  }
+}

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -40,6 +40,7 @@ import { randomUUID } from "crypto";
 import { bearerAuth } from "./middleware/bearer-auth.js";
 import { runCompaction } from "./tasks/closet-compaction.js";
 import { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-reaper.js";
+import { spendBudgetTick } from "./tasks/spend-budget-monitor.js";
 import { runAndRecord, sendAlerts } from "./tasks/health-monitor.js";
 import { handlePaMessage } from "./pa/service.js";
 import { loadMcpConfigs } from "./mcp/client.js";
@@ -1299,6 +1300,15 @@ async function main() {
     }
   }, 5 * 60 * 1000);
 
+  // Spend-budget monitor (#215) — pause on daily-budget breach, resume on
+  // day rollover / override / budget change. Runs once at startup too:
+  // BullMQ pause state persists in Redis across restarts, so a worker that
+  // died mid-pause must reconcile immediately, not a minute later.
+  spendBudgetTick(WORKSPACE!).catch(() => { /* logged inside */ });
+  setInterval(() => {
+    spendBudgetTick(WORKSPACE!).catch(() => { /* logged inside */ });
+  }, 60 * 1000);
+
   // Delay initial health check
   setTimeout(async () => {
     try {
@@ -1309,7 +1319,7 @@ async function main() {
     }
   }, 15000);
 
-  console.log("[nexaas] Background tasks started (compaction + waitpoint reaper + health monitor)");
+  console.log("[nexaas] Background tasks started (compaction + waitpoint reaper + health monitor + spend-budget monitor)");
   console.log("[nexaas] Worker ready. Waiting for jobs...");
 }
 


### PR DESCRIPTION
Production hardening T3 (#215, umbrella #219).

## What

A per-workspace **daily** AI budget that pauses the skill queue when crossed — margin protection for operator-provisioned keys. NULL budget (the default) = unlimited; every existing workspace is unaffected until opted in.

```
nexaas config set spend-budget 25        # $25/day
nexaas config set spend-override today   # operator escape hatch, expires at day rollover
```

## Design

**Recording** at the two model chokepoints (agentic loop covers ai-skill **and** PA; gateway covers the pillar path) into `spend_daily (workspace, local-day)`. PA now passes `modelPricing` — its spend was previously invisible ($0 cost computation).

**Enforcement** follows the spec (in-flight runs finish their step and park; overshoot bounded by per-run caps × concurrency):
- **ai-skill pre-run**: skip (not fail — keeps silent-failure counters clean) + immediate queue pause
- **gateway pre-call**: `SpendBudgetExceededError` thrown *before* resolving providers — structurally impossible for the fallback chain to route around the budget onto a still-billable fallback key (the #215 critical requirement)
- **PA**: clear refusal message (HTTP path — queue pause alone wouldn't stop it)
- **worker monitor** (60s + startup tick): persistent pause/resume. Monitor-driven on purpose: BullMQ pause state survives restarts in Redis, in-memory resume timers don't — fine for #27's 5-minute 429 cooldowns, wrong overnight. Day rollover, budget changes, and the override all resume naturally; the `workspace_kv` marker guarantees the monitor only resumes queues *it* paused.

Budget day = **workspace-local day** (`workspace_config.timezone`), so "resumes at midnight" matches the operator's clock.

## Observability

`nexaas health`: spend vs budget line, warning ≥80%, critical + `QUEUE PAUSED` on breach (tolerates pre-026 schemas during the upgrade window). WAL: `spend_budget_exceeded` / `spend_budget_resumed`. Critical ops alert, deduped per workspace-day. Full doc: `docs/spend-governance.md`.

## Validation (scratch DB + dev worker, all live)

1. Mock conformance run recorded $0.0001 / 1 model call into `spend_daily`
2. Spend bumped over budget → monitor paused the queue within one tick (WAL + marker + alert log)
3. In-process ai-skill while breached → skipped cleanly with the budget reason
4. Job enqueued while paused → parked, 0 executions
5. `nexaas health` → CRITICAL with "QUEUE PAUSED"
6. `spend-override today` → resumed within one tick (`reason: operator_override`), marker cleared, **the parked job then completed**
7. Conformance suite stayed green (8/8 + opt-in) with governance active — no regression

Untested live: the gateway path breach (structurally guaranteed — check precedes the provider loop) and worker-restart reconcile (startup tick is the same code as the proven interval tick).

## Follow-ups

- Conformance scenario for budget breach (noted on #213)
- Daily spend + budget state in heartbeat v0.3 (#216)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily AI spend budget governance with per-workspace configuration via CLI commands `spend-budget` and `spend-override`.
  * Automatic workspace queue pausing when daily spend limits are exceeded, with resumption when within limits.
  * Daily spend health monitoring and reporting with budget status alerts.
  * Date-specific budget overrides for operational flexibility.

* **Documentation**
  * Added comprehensive spend governance documentation covering configuration, enforcement, operational commands, and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->