### PR TITLE
feat(fleet): heartbeat payload v3 + /events escalation path (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ backward compatibility; see the rollback policy in `docs/releases.md`).
 
 ## Unreleased
 
+### Added
+- Fleet heartbeat payload v3 (#216): release `describe` + channel, 24h run
+  error rates, daily spend/budget state, pending migrations, last
+  conformance result, queue depths — all best-effort collectors
+- `POST {fleet}/events` escalation path + `pushFleetEvent()`: silent-failure
+  watchdog escalates upstream even with no local channel role; spend-budget
+  breach pages the fleet (one event per workspace-day)
+- `nexaas conformance` persists its result to `workspace_kv.last_conformance`
+  for the heartbeat to carry
+
 ### Fixed
 - `VERSION` stamped to 0.3.0 — v0.3.0 shipped self-reporting `0.2.0` in the
   fleet heartbeat because the stamp wasn't part of the release procedure;

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,9 @@ Canonical documentation for the Nexaas framework — context-aware AI execution 
 | [`deployment-patterns.md`](./deployment-patterns.md) | The two valid deployment modes — direct adopter (Phoenix-style) vs operator-managed (Nexmatic-style). Framework is tenant-agnostic by contract. | Early — decide which mode before deploying. |
 | [`skill-authoring.md`](./skill-authoring.md) | Building skills — shell vs AI, nexaasification, model tiers, MCP integration, agentic loop, palace vs Claude Code memory | When you're ready to build. |
 | [`deployment-ops.md`](./deployment-ops.md) | Deploying & operating — systemd config, legacy cleanup, worker startup, monitoring, backups, upgrading. Lessons from Phoenix production. | When deploying or troubleshooting. |
-| [`fleet-protocol.md`](./fleet-protocol.md) | Wire contract between a client VPS worker and an operator-managed fleet dashboard (heartbeat + bootstrap registration). | When wiring operator-managed deployments. |
+| [`fleet-protocol.md`](./fleet-protocol.md) | Wire contract between a client VPS worker and an operator-managed fleet dashboard (registration + heartbeat v3 + escalated events). | When wiring operator-managed deployments. |
+| [`releases.md`](./releases.md) | Cutting releases, channel promotion (canary→stable), hotfix push, rollback + migration back-compat rules. | When cutting or promoting a release. |
+| [`spend-governance.md`](./spend-governance.md) | Per-workspace daily AI budget — config, enforcement surfaces, pause/resume semantics, observation. | When setting client budgets or debugging a paused queue. |
 | [`migration-guide.md`](./migration-guide.md) | Moving from Trigger.dev, n8n, or any automation system to Nexaas — parallel operation, per-flow revert, risk tiers | When migrating existing systems. |
 | [`adoption-patterns/`](./adoption-patterns/README.md) | Framework-agnostic patterns distilled from canary adoption — telegram channel, 2FA intercept, approval-gated outputs, etc. | When implementing a specific flow for the first time. |
 | [`glossary.md`](./glossary.md) | Terminology cheat sheet — every named concept in the system | As needed. |

--- a/docs/fleet-protocol.md
+++ b/docs/fleet-protocol.md
@@ -1,7 +1,11 @@
 # Fleet Protocol
 
-How each Nexaas client VPS reports its framework version and worker
-health to the central Nexmatic ops dashboard.
+How each Nexaas client VPS reports its framework version, workspace health,
+and escalated events to the central Nexmatic ops dashboard.
+
+*Heartbeat payload v3 + the `/events` endpoint shipped for #216 (production
+hardening T4). Consumed by the Nexmatic fleet receiver
+(Systemsaholic/nexmatic#10).*
 
 This document defines the wire contract. The VPS side is implemented in
 `packages/runtime/src/fleet/heartbeat.ts` and `packages/cli/src/init.ts`.
@@ -23,6 +27,10 @@ the endpoints described here.
 │ fleet heartbeat ────┼─── POST /heartbeat ────▶│  upsert fleet row    │
 │                     │    Bearer <token>       │  update dashboard    │
 │                     │◀── 200 {ok:true} ───────│                      │
+│                     │                         │                      │
+│ watchdogs/monitors  │    3. as they happen    │                      │
+│ fleet events ───────┼─── POST /events ───────▶│  page or digest      │
+│                     │    Bearer <token>       │  per severity        │
 └─────────────────────┘                         └──────────────────────┘
 ```
 
@@ -104,27 +112,64 @@ startup and after `nexaas upgrade`.
 
 - **Auth:** `Authorization: Bearer <NEXAAS_FLEET_TOKEN>`
 - **Content-Type:** `application/json`
-- **Body:**
+- **Body (payload v3, #216):**
 
-```json
+```jsonc
 {
+  "payload_version": 3,
   "workspace": "phoenix-voyages",
-  "version": "0.2.0",
-  "commit_sha": "44bf213",
-  "branch": "main",
+  "version": "0.3.0",                  // VERSION file (release stamp)
+  "commit_sha": "151c629",
+  "branch": "main",                    // "HEAD" when detached on a tag/channel ref
+  "describe": "v0.3.0",                // git describe --tags --always — the human version
+  "channel": "canary",                 // workspace_kv framework_channel; null = legacy tracking-branch
   "hostname": "phoenix.vps.ovh.net",
-  "started_at": "2026-04-19T10:15:22.431Z",
-  "now": "2026-04-19T10:20:22.431Z",
-  "worker_status": "running"
+  "started_at": "2026-06-10T10:15:22.431Z",
+  "now": "2026-06-10T10:20:22.431Z",
+  "worker_status": "running",
+  "uptime_s": 300,
+  "runs_24h": {                        // nullable
+    "completed": 412, "failed": 3, "skipped": 9,
+    "success_rate_pct": 99             // null when no terminal runs in 24h
+  },
+  "spend": {                           // nullable (#215)
+    "day": "2026-06-10",               // workspace-local day
+    "spent_usd": 4.91,
+    "budget_usd": 25.0,                // null = unlimited
+    "paused": false                    // true = queue paused on budget breach
+  },
+  "migrations": {                      // nullable
+    "applied": 24,
+    "pending": 0                       // >0 = upgrade incomplete — surface it
+  },
+  "conformance": {                     // nullable — last `nexaas conformance` run, any age (#213)
+    "at": "2026-06-10T11:58:00Z",
+    "passed": 8, "failed": 0, "skipped": 1,
+    "failed_checks": []
+  },
+  "queue": {                           // nullable
+    "waiting": 0, "active": 1, "delayed": 2, "failed": 0,
+    "paused": false
+  }
 }
 ```
 
 Field notes:
 - `started_at` — when the worker process booted. Useful for uptime calc.
+  A `started_at` newer than the previous beat's means the worker restarted
+  in between; a restart loop (several per hour) is page-worthy.
 - `now` — client clock at send time. Compare to server-side `received_at`
   to detect clock skew.
 - `worker_status` — always `"running"` in v1. Future: `"draining"`,
   `"degraded"`, with subfields for reason.
+- **Every v3 collector is best-effort on the sender**: a field documented
+  as nullable arrives `null` when its collector failed, which is itself
+  signal (e.g. `queue: null` usually means Redis is down). A degraded
+  collector never blocks the beat.
+- Receivers MUST tolerate unknown additional fields — the payload grows
+  additively; `payload_version` bumps only on breaking shape changes.
+- The payload contains operational metadata only — no drawer contents, no
+  message bodies, no client business data. Keep it that way.
 
 ### Response (200)
 
@@ -148,12 +193,84 @@ entry, but **never crashes the worker**.
 
 1. Extract bearer token; look up `fleet_tokens` by SHA-256 hash
 2. Verify `tokens.workspace === body.workspace`
-3. Upsert into `fleet_heartbeats (workspace, version, commit_sha, branch, hostname, started_at, received_at, worker_status)`
+3. Upsert into `fleet_heartbeats` (store the full v3 payload as jsonb
+   alongside the indexed columns)
 4. Return `200 {ok:true}`
 
-For the dashboard `/fleet` page, query the latest heartbeat per
-workspace. Anything with `now() - received_at > 15 min` is "stale"
-(yellow badge); `> 1 hr` is "dead" (red).
+### Missed-beat semantics (the receiver's half of the contract)
+
+A dead worker cannot self-report — **absence of beats is the signal** and
+detecting it is entirely receiver-side. Expect a beat every 5 minutes per
+workspace; the sender never queues or replays missed beats (the next beat
+implicitly carries current state).
+
+For the dashboard `/fleet` page, query the latest heartbeat per workspace:
+- `now() - received_at > 15 min` (3 missed beats) → "stale" (yellow) and
+  **page** — a silent VPS is indistinguishable from a down one
+- `> 1 hr` → "dead" (red)
+
+Version/channel rollups from the v3 payload feed the canary-promotion
+decision (`docs/releases.md`): promote `channel/stable` only when every
+canary-channel workspace reports the new `describe` with green
+`conformance` and sane error rates.
+
+## Endpoint: `POST {endpoint}/events`
+
+Escalated events (#216), pushed as they happen — not batched with beats.
+This path exists for exactly the case where a workspace's own channel
+bindings are broken: it must not share fate with workspace-level alerting.
+
+### Request
+
+- **Auth:** `Authorization: Bearer <NEXAAS_FLEET_TOKEN>`
+- **Content-Type:** `application/json`
+- **Body:**
+
+```jsonc
+{
+  "payload_version": 3,
+  "workspace": "phoenix-voyages",
+  "hostname": "phoenix.vps.ovh.net",
+  "at": "2026-06-10T12:03:11Z",
+  "type": "silent_failure",            // stable machine type
+  "severity": "page",                  // "page" | "digest"
+  "title": "Silent failure: ops/lead-sync failed 5 runs in a row",
+  "body": "First failure in streak: ...\nLast error: ...",
+  "dedupe_key": "silent-failure:ops/lead-sync:2026-06-10T11:40:00Z",
+  "data": { "skill_id": "ops/lead-sync", "streak": 5 }
+}
+```
+
+**Severity discipline** (solo-operator rule, #219): `page` = wake a human
+now; `digest` = batch into the daily rollup. The sender assigns severity;
+the receiver applies the delivery policy. Receivers MUST de-dupe on
+`(workspace, dedupe_key)` — senders may re-emit on restart.
+
+Event types currently emitted:
+
+| `type` | severity | source |
+|---|---|---|
+| `silent_failure` | page | silent-failure watchdog (#69) — fires upstream even when no local channel role is configured |
+| `spend_budget_exceeded` | page | spend-budget monitor (#215) — one per workspace-day |
+
+New types will be added without a `payload_version` bump; receivers SHOULD
+render unknown types generically (title/body/severity) rather than drop
+them.
+
+### Response
+
+Any 2xx acknowledges; the body is ignored. Delivery is
+at-least-once-attempted: a failed POST is WAL-logged (`fleet_event_failed`)
+but not retried — the heartbeat's state fields (e.g. `spend.paused`) act
+as the eventual-consistency backstop for anything an event missed.
+
+### Sender-side observability
+
+| Where | What |
+|---|---|
+| `nexaas_memory.framework_heartbeat` | single row: identity + last push status/HTTP code |
+| WAL `framework_heartbeat_sent/skipped/failed` | every beat attempt |
+| WAL `fleet_event_sent/failed` | every event attempt |
 
 ## Suggested Nexmatic schema
 

--- a/packages/cli/src/conformance.ts
+++ b/packages/cli/src/conformance.ts
@@ -426,11 +426,28 @@ export async function run(args: string[] = []) {
   // ── Summary ─────────────────────────────────────────────────────────
 
   if (!keepArtifacts) rmSync(artifactsDir, { recursive: true, force: true });
-  await pool.end();
 
   const passed = results.filter((r) => r.status === "pass").length;
   const failed = results.filter((r) => r.status === "fail").length;
   const skipped = results.filter((r) => r.status === "skip").length;
+
+  // Persist the result for the fleet heartbeat (#216) — best-effort; a
+  // pre-014 schema without workspace_kv must not fail the suite.
+  try {
+    await pool.query(
+      `INSERT INTO nexaas_memory.workspace_kv (workspace, key, value) VALUES ($1, 'last_conformance', $2)
+       ON CONFLICT (workspace, key) DO UPDATE SET value = EXCLUDED.value`,
+      [workspace, JSON.stringify({
+        at: new Date().toISOString(),
+        passed,
+        failed,
+        skipped,
+        failed_checks: results.filter((r) => r.status === "fail").map((r) => r.id),
+      })],
+    );
+  } catch { /* workspace_kv absent — heartbeat reports conformance: null */ }
+
+  await pool.end();
 
   if (json) {
     console.log(JSON.stringify({ workspace, results, summary: { passed, failed, skipped } }, null, 2));

--- a/packages/runtime/src/fleet/heartbeat.ts
+++ b/packages/runtime/src/fleet/heartbeat.ts
@@ -1,16 +1,23 @@
 /**
- * Fleet heartbeat — reports framework version + worker state to the
- * central Nexmatic ops dashboard so operators can see what's running
- * on every client VPS.
+ * Fleet heartbeat — reports framework version + workspace health to the
+ * central ops dashboard so a solo operator can see what's running on every
+ * client VPS without SSHing into any of them.
  *
  * Local side:
- *   - Reads VERSION file + `git rev-parse HEAD/abbrev-ref` at startup
+ *   - Reads VERSION file + git identity at startup
  *   - Maintains a single-row state in `nexaas_memory.framework_heartbeat`
  *   - Logs every push attempt to the WAL
  *
- * Remote side (Nexmatic ops-console — implemented separately):
- *   - POST ${NEXAAS_FLEET_ENDPOINT}/heartbeat with Bearer token
- *   - Body: { workspace, version, commit_sha, branch, hostname, started_at, now, worker_status }
+ * Remote side (receiver contract: docs/fleet-heartbeat-contract.md):
+ *   - POST ${NEXAAS_FLEET_ENDPOINT}/heartbeat — payload v3 (#216): identity
+ *     + release channel (#214) + 24h error rates + daily spend/budget state
+ *     (#215) + pending migrations + last conformance result (#213) + queue
+ *     depths. Every v3 collector is best-effort: a broken collector nulls
+ *     its field, it never blocks the beat.
+ *   - POST ${NEXAAS_FLEET_ENDPOINT}/events — escalated events (page/digest)
+ *     via pushFleetEvent(). Used by the silent-failure watchdog (#69) and
+ *     the spend-budget monitor (#215) so fleet ops hears about a workspace
+ *     even when that workspace's own channel bindings are broken.
  *
  * Environment:
  *   NEXAAS_FLEET_ENDPOINT   base URL (e.g. https://nexmatic.ca/api/fleet)
@@ -18,15 +25,17 @@
  *   NEXAAS_ROOT             path to framework install (default /opt/nexaas)
  *
  * If endpoint/token are missing, the module maintains the local state row
- * only — remote push is skipped silently. This keeps backwards compat for
- * installs that aren't yet wired to the fleet dashboard.
+ * only — remote push (and pushFleetEvent) is a silent no-op. Direct
+ * adopters see zero behavior change.
  */
 
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 import { hostname } from "os";
-import { appendWal, sql } from "@nexaas/palace";
+import { appendWal, sql, sqlOne } from "@nexaas/palace";
+import { getBudgetState } from "../models/spend-governor.js";
+import { getSkillQueue } from "../bullmq/queues.js";
 
 const HEARTBEAT_INTERVAL_MS = 5 * 60_000;
 const HEARTBEAT_HTTP_TIMEOUT_MS = 10_000;
@@ -36,8 +45,23 @@ export interface FrameworkIdentity {
   version: string;
   commit_sha: string | null;
   branch: string | null;
+  /** `git describe --tags --always` — the release-aware version (#214). */
+  describe: string | null;
   hostname: string;
   started_at: string;
+}
+
+export interface FleetEvent {
+  /** Stable event type, e.g. "silent_failure", "spend_budget_exceeded". */
+  type: string;
+  /** "page" = wake a human; "digest" = batch into the daily rollup. */
+  severity: "page" | "digest";
+  title: string;
+  body: string;
+  /** Receiver-side de-dupe key. */
+  dedupe_key?: string;
+  /** Structured extras for the dashboard. */
+  data?: Record<string, unknown>;
 }
 
 let _identity: FrameworkIdentity | null = null;
@@ -50,6 +74,17 @@ function exec(cmd: string): string | null {
   } catch {
     return null;
   }
+}
+
+function fleetConfig(): { endpoint: string; token: string } | null {
+  const endpoint = process.env.NEXAAS_FLEET_ENDPOINT;
+  const token = process.env.NEXAAS_FLEET_TOKEN;
+  if (!endpoint || !token) return null;
+  return { endpoint: endpoint.replace(/\/$/, ""), token };
+}
+
+export function isFleetConfigured(): boolean {
+  return fleetConfig() !== null;
 }
 
 export function getFrameworkIdentity(): FrameworkIdentity {
@@ -65,17 +100,176 @@ export function getFrameworkIdentity(): FrameworkIdentity {
 
   const commit_sha = exec(`git -C ${nexaasRoot} rev-parse --short HEAD`);
   const branch = exec(`git -C ${nexaasRoot} rev-parse --abbrev-ref HEAD`);
+  const describe = exec(`git -C ${nexaasRoot} describe --tags --always`);
 
   _identity = {
     workspace,
     version,
     commit_sha,
     branch,
+    describe,
     hostname: hostname(),
     started_at: new Date().toISOString(),
   };
   return _identity;
 }
+
+// ── v3 collectors ─────────────────────────────────────────────────────
+// Each returns null on any failure. The heartbeat is the operator's last
+// line of sight into a degraded VPS — a collector hitting the exact
+// breakage being reported must not take the whole beat down with it.
+
+async function collectChannel(workspace: string): Promise<string | null> {
+  try {
+    const row = await sqlOne<{ value: string }>(
+      `SELECT value FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = 'framework_channel'`,
+      [workspace],
+    );
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function collectRuns24h(workspace: string): Promise<{
+  completed: number;
+  failed: number;
+  skipped: number;
+  success_rate_pct: number | null;
+} | null> {
+  try {
+    const row = await sqlOne<{ completed: string; failed: string; skipped: string }>(
+      `SELECT count(*) FILTER (WHERE status = 'completed') AS completed,
+              count(*) FILTER (WHERE status = 'failed') AS failed,
+              count(*) FILTER (WHERE status = 'skipped') AS skipped
+         FROM nexaas_memory.skill_runs
+        WHERE workspace = $1 AND started_at > now() - interval '24 hours'`,
+      [workspace],
+    );
+    const completed = Number(row?.completed ?? 0);
+    const failed = Number(row?.failed ?? 0);
+    const skipped = Number(row?.skipped ?? 0);
+    const terminal = completed + failed;
+    return {
+      completed,
+      failed,
+      skipped,
+      success_rate_pct: terminal > 0 ? Math.round((100 * completed) / terminal) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function collectSpend(workspace: string): Promise<{
+  day: string;
+  spent_usd: number;
+  budget_usd: number | null;
+  paused: boolean;
+} | null> {
+  try {
+    const state = await getBudgetState(workspace);
+    let paused = false;
+    try {
+      const marker = await sqlOne<{ value: string }>(
+        `SELECT value FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = 'spend_pause_active_day'`,
+        [workspace],
+      );
+      paused = marker?.value === state.day;
+    } catch { /* kv missing */ }
+    return { day: state.day, spent_usd: state.spentUsd, budget_usd: state.budgetUsd, paused };
+  } catch {
+    return null;
+  }
+}
+
+async function collectMigrations(workspace: string): Promise<{
+  applied: number;
+  pending: number;
+} | null> {
+  void workspace;
+  try {
+    const nexaasRoot = process.env.NEXAAS_ROOT ?? "/opt/nexaas";
+    const onDisk = readdirSync(join(nexaasRoot, "database", "migrations"))
+      .filter((f) => f.endsWith(".sql"));
+    const rows = await sql<{ filename: string }>(
+      `SELECT filename FROM nexaas_memory.schema_migrations`,
+    );
+    const applied = new Set(rows.map((r) => r.filename));
+    const pending = onDisk.filter((f) => !applied.has(f)).length;
+    return { applied: applied.size, pending };
+  } catch {
+    return null;
+  }
+}
+
+async function collectConformance(workspace: string): Promise<Record<string, unknown> | null> {
+  try {
+    const row = await sqlOne<{ value: string }>(
+      `SELECT value FROM nexaas_memory.workspace_kv WHERE workspace = $1 AND key = 'last_conformance'`,
+      [workspace],
+    );
+    return row?.value ? (JSON.parse(row.value) as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function collectQueue(workspace: string): Promise<{
+  waiting: number;
+  active: number;
+  delayed: number;
+  failed: number;
+  paused: boolean;
+} | null> {
+  try {
+    const queue = getSkillQueue(workspace);
+    const counts = await queue.getJobCounts("waiting", "active", "delayed", "failed");
+    const paused = await queue.isPaused();
+    return {
+      waiting: counts.waiting ?? 0,
+      active: counts.active ?? 0,
+      delayed: counts.delayed ?? 0,
+      failed: counts.failed ?? 0,
+      paused,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildPayloadV3(identity: FrameworkIdentity): Promise<Record<string, unknown>> {
+  const [channel, runs_24h, spend, migrations, conformance, queue] = await Promise.all([
+    collectChannel(identity.workspace),
+    collectRuns24h(identity.workspace),
+    collectSpend(identity.workspace),
+    collectMigrations(identity.workspace),
+    collectConformance(identity.workspace),
+    collectQueue(identity.workspace),
+  ]);
+
+  return {
+    payload_version: 3,
+    workspace: identity.workspace,
+    version: identity.version,
+    commit_sha: identity.commit_sha,
+    branch: identity.branch,
+    describe: identity.describe,
+    channel,
+    hostname: identity.hostname,
+    started_at: identity.started_at,
+    now: new Date().toISOString(),
+    worker_status: "running",
+    uptime_s: Math.round(process.uptime()),
+    runs_24h,
+    spend,
+    migrations,
+    conformance,
+    queue,
+  };
+}
+
+// ── local state + push ────────────────────────────────────────────────
 
 async function upsertLocalState(
   identity: FrameworkIdentity,
@@ -113,25 +307,11 @@ async function upsertLocalState(
   }
 }
 
-async function pushRemote(identity: FrameworkIdentity): Promise<{ status: string; httpCode: number | null }> {
-  const endpoint = process.env.NEXAAS_FLEET_ENDPOINT;
-  const token = process.env.NEXAAS_FLEET_TOKEN;
-  if (!endpoint || !token) {
-    return { status: "skipped:unconfigured", httpCode: null };
-  }
-
-  const url = endpoint.replace(/\/$/, "") + "/heartbeat";
-  const body = {
-    workspace: identity.workspace,
-    version: identity.version,
-    commit_sha: identity.commit_sha,
-    branch: identity.branch,
-    hostname: identity.hostname,
-    started_at: identity.started_at,
-    now: new Date().toISOString(),
-    worker_status: "running",
-  };
-
+async function postJson(
+  url: string,
+  token: string,
+  body: unknown,
+): Promise<{ status: string; httpCode: number | null }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), HEARTBEAT_HTTP_TIMEOUT_MS);
   try {
@@ -153,6 +333,15 @@ async function pushRemote(identity: FrameworkIdentity): Promise<{ status: string
   } finally {
     clearTimeout(timeout);
   }
+}
+
+async function pushRemote(identity: FrameworkIdentity): Promise<{ status: string; httpCode: number | null }> {
+  const config = fleetConfig();
+  if (!config) {
+    return { status: "skipped:unconfigured", httpCode: null };
+  }
+  const payload = await buildPayloadV3(identity);
+  return postJson(`${config.endpoint}/heartbeat`, config.token, payload);
 }
 
 export async function pushHeartbeat(): Promise<void> {
@@ -180,6 +369,46 @@ export async function pushHeartbeat(): Promise<void> {
       http_code: push.httpCode,
     },
   });
+}
+
+/**
+ * Escalate an event to the fleet receiver (#216). Silent no-op when the
+ * fleet endpoint isn't configured (direct adopters), so callers don't need
+ * to gate on configuration. Never throws.
+ *
+ * This is the path that works precisely when the workspace's own channel
+ * bindings don't — e.g. the silent-failure watchdog escalating "this
+ * workspace can't deliver its own alerts".
+ */
+export async function pushFleetEvent(workspace: string, event: FleetEvent): Promise<void> {
+  const config = fleetConfig();
+  if (!config) return;
+
+  const identity = getFrameworkIdentity();
+  const result = await postJson(`${config.endpoint}/events`, config.token, {
+    payload_version: 3,
+    workspace,
+    hostname: identity.hostname,
+    at: new Date().toISOString(),
+    ...event,
+  });
+
+  try {
+    await appendWal({
+      workspace,
+      op: result.status === "ok" ? "fleet_event_sent" : "fleet_event_failed",
+      actor: "fleet-heartbeat",
+      payload: {
+        type: event.type,
+        severity: event.severity,
+        dedupe_key: event.dedupe_key,
+        status: result.status,
+        http_code: result.httpCode,
+      },
+    });
+  } catch (err) {
+    console.error("[nexaas] fleet event WAL append failed:", err);
+  }
 }
 
 export function startHeartbeatLoop(): void {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -48,6 +48,14 @@ export {
   type BudgetState,
 } from "./models/spend-governor.js";
 export { spendBudgetTick } from "./tasks/spend-budget-monitor.js";
+export {
+  pushHeartbeat,
+  pushFleetEvent,
+  isFleetConfigured,
+  getFrameworkIdentity,
+  type FleetEvent,
+  type FrameworkIdentity,
+} from "./fleet/heartbeat.js";
 
 // Skill terminal-state primitives (#171–#174 silent-failure arc)
 export {

--- a/packages/runtime/src/tasks/silent-failure-watchdog.ts
+++ b/packages/runtime/src/tasks/silent-failure-watchdog.ts
@@ -16,13 +16,18 @@
  *
  * Configuration (all env-var, no manifest dependency):
  *   NEXAAS_SILENT_FAILURE_THRESHOLD        default 5; minimum 2
- *   NEXAAS_SILENT_FAILURE_CHANNEL_ROLE     no default — unset = disabled
+ *   NEXAAS_SILENT_FAILURE_CHANNEL_ROLE     no default — unset = no local drawer
  *
- * The watchdog is a no-op when the channel role isn't set, so existing
- * adopters see no behavior change until they opt in.
+ * Fleet escalation (#216): when NEXAAS_FLEET_ENDPOINT is configured, every
+ * threshold crossing ALSO pushes a page-severity fleet event — even with no
+ * channel role set. A workspace whose channel bindings are broken is exactly
+ * the case silent-failure exists for; the upstream path must not depend on
+ * the local one. With neither a channel role nor a fleet endpoint, the
+ * watchdog stays a complete no-op (existing adopters unchanged).
  */
 
 import { sql, palace, appendWal } from "@nexaas/palace";
+import { isFleetConfigured, pushFleetEvent } from "../fleet/heartbeat.js";
 
 const THRESHOLD = (() => {
   const raw = process.env.NEXAAS_SILENT_FAILURE_THRESHOLD;
@@ -44,7 +49,7 @@ export async function checkFailureStreak(
   workspace: string,
   skillId: string,
 ): Promise<void> {
-  if (!CHANNEL_ROLE) return;
+  if (!CHANNEL_ROLE && !isFleetConfigured()) return;
 
   // Pull THRESHOLD+1 most recent terminal runs. We need one extra row to
   // tell a *fresh* threshold crossing (streak exactly == THRESHOLD) from an
@@ -69,18 +74,33 @@ export async function checkFailureStreak(
   const firstFailedAt = recent[THRESHOLD - 1].started_at;
   const lastError = recent[0].error_summary ?? "(no error summary)";
 
-  const session = palace.enter({ workspace });
-  await session.writeDrawer(
-    { wing: "notifications", hall: "pending", room: "ops-alerts.silent-failure" },
-    JSON.stringify({
-      idempotency_key: `silent-failure:${skillId}:${firstFailedAt}`,
-      channel_role: CHANNEL_ROLE,
-      content:
-        `⚠️ Silent failure: skill ${skillId} has failed ${THRESHOLD} runs in a row.\n` +
-        `First failure in streak: ${firstFailedAt}\n` +
-        `Last error: ${lastError.slice(0, 400)}`,
-    }),
-  );
+  if (CHANNEL_ROLE) {
+    const session = palace.enter({ workspace });
+    await session.writeDrawer(
+      { wing: "notifications", hall: "pending", room: "ops-alerts.silent-failure" },
+      JSON.stringify({
+        idempotency_key: `silent-failure:${skillId}:${firstFailedAt}`,
+        channel_role: CHANNEL_ROLE,
+        content:
+          `⚠️ Silent failure: skill ${skillId} has failed ${THRESHOLD} runs in a row.\n` +
+          `First failure in streak: ${firstFailedAt}\n` +
+          `Last error: ${lastError.slice(0, 400)}`,
+      }),
+    );
+  }
+
+  // Upstream escalation (#216) — fires regardless of the local channel
+  // role; silent no-op when the fleet endpoint isn't configured.
+  await pushFleetEvent(workspace, {
+    type: "silent_failure",
+    severity: "page",
+    title: `Silent failure: ${skillId} failed ${THRESHOLD} runs in a row`,
+    body:
+      `First failure in streak: ${firstFailedAt}\n` +
+      `Last error: ${lastError.slice(0, 400)}`,
+    dedupe_key: `silent-failure:${skillId}:${firstFailedAt}`,
+    data: { skill_id: skillId, streak: THRESHOLD, first_failed_at: firstFailedAt },
+  });
 
   await appendWal({
     workspace,
@@ -90,7 +110,8 @@ export async function checkFailureStreak(
       skill_id: skillId,
       streak: THRESHOLD,
       first_failed_at: firstFailedAt,
-      channel_role: CHANNEL_ROLE,
+      channel_role: CHANNEL_ROLE ?? null,
+      fleet_escalated: isFleetConfigured(),
       last_error: lastError.slice(0, 500),
     },
   });

--- a/packages/runtime/src/tasks/spend-budget-monitor.ts
+++ b/packages/runtime/src/tasks/spend-budget-monitor.ts
@@ -23,6 +23,7 @@ import { appendWal, sql, sqlOne } from "@nexaas/palace";
 import { getSkillQueue } from "../bullmq/queues.js";
 import { getBudgetState, type BudgetState } from "../models/spend-governor.js";
 import { notify } from "../notifications.js";
+import { pushFleetEvent } from "../fleet/heartbeat.js";
 
 const MARKER_KEY = "spend_pause_active_day";
 
@@ -100,6 +101,25 @@ export async function pauseForBudgetBreach(
   } catch (err) {
     console.error(`[nexaas] spend-budget: alert dispatch failed:`, err);
   }
+
+  // Fleet escalation (#216): a budget breach burns the operator's margin —
+  // page severity. Silent no-op without a fleet endpoint. The dedupe key
+  // matches the local alert's (one event per workspace-day).
+  await pushFleetEvent(workspace, {
+    type: "spend_budget_exceeded",
+    severity: "page",
+    title: `Daily AI budget exceeded — queue paused`,
+    body:
+      `$${state.spentUsd.toFixed(2)} spent of $${state.budgetUsd?.toFixed(2)} daily budget ` +
+      `(${state.modelCalls} model calls). Queue paused until local midnight or operator override.`,
+    dedupe_key: `spend-budget-${workspace}-${state.day}`,
+    data: {
+      day: state.day,
+      spent_usd: state.spentUsd,
+      budget_usd: state.budgetUsd,
+      model_calls: state.modelCalls,
+    },
+  });
 }
 
 async function resumeAfterBudgetPause(workspace: string, state: BudgetState): Promise<void> {


### PR DESCRIPTION
Production hardening T4 (#216, umbrella #219).

## What

**Heartbeat payload v3** — the beat now carries everything the fleet view and the canary-promotion decision need: `git describe` + release channel (#214), 24h run error rates, daily spend/budget state with the paused flag (#215), pending-migrations count, the last `nexaas conformance` result (#213), and queue depths. Every collector is best-effort — a broken collector nulls its field rather than blocking the beat, and the null is itself signal (`queue: null` ≈ Redis down).

**`POST {fleet}/events`** — a new escalation path (`pushFleetEvent()`, page/digest severity, receiver-side dedupe):
- The **silent-failure watchdog (#69) now escalates upstream even when no local channel role is configured** — a workspace that can't deliver its own alerts is precisely the failure mode it exists for. With neither channel role nor fleet endpoint it remains a complete no-op.
- The **spend-budget monitor** pages the fleet on breach (one event per workspace-day).

**Contract**: merged into the existing canonical `docs/fleet-protocol.md` (register + heartbeat v3 + events + missed-beat semantics + severity discipline) rather than a new doc. Receiver build is Systemsaholic/nexmatic#10 — now unblocked.

`nexaas conformance` persists its result to `workspace_kv.last_conformance` so beats carry it.

## Do-no-harm

Direct adopters (fleet endpoint unset) are byte-for-byte unchanged — sender stays a silent no-op, `pushFleetEvent` returns immediately, the watchdog's no-op condition is preserved.

## Validation (scratch worker + mock fleet receiver, all live)

1. Startup beat arrived with the complete v3 payload (bearer auth, all collectors populated)
2. Conformance run → result persisted → carried in the next beat
3. **5 deliberate failures with NO channel role configured** → `silent_failure` page event arrived at `/events` on exactly the 5th failure; WAL `silent_failure_alerted` (`fleet_escalated: true`) + `fleet_event_sent`
4. Budget breach → `spend_budget_exceeded` page event
5. The following 5-minute beat showed `spend.paused: true`, `queue.paused: true`, and the failure streak reflected in `runs_24h` (29% success rate)
6. Testlab (no fleet endpoint) continued `skipped:unconfigured` throughout

## Remaining on #216 after this

Receiver-side work (Nexmatic #10). Framework-side: done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fleet heartbeat v3 payload now includes operational telemetry (spend/budget state, error rates, migration progress, conformance results, and queue depths).
  * Fleet event escalation system for upstream notifications, including spend-budget breach alerts.
  * Conformance results are now persisted and included in heartbeat reports.

* **Documentation**
  * Updated Fleet protocol documentation with v3 heartbeat and events specifications.
  * Expanded documentation index with release notes and governance references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->