### PR TITLE
fix(palace): batch WAL chain verification — OOM on production-sized WALs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,17 @@ backward compatibility; see the rollback policy in `docs/releases.md`).
 
 ## Unreleased
 
-_Nothing yet._
+### Fixed
+- `verifyWalChain` streams the chain in 5000-row keyset batches — the
+  previous single unbounded SELECT materialized every row and exhausted the
+  V8 heap on production-sized WALs (node OOM-crash, found by the v0.3.1
+  Phoenix canary's conformance run against 1.34M rows). Tamper detection
+  semantics unchanged across batch boundaries.
+- Conformance `wal-chain` check verifies a recent window (last 5000
+  entries) instead of genesis-to-tip — right-sized for a routine gate;
+  `nexaas verify-wal --full` remains the audit mode (now memory-safe).
+- `nexaas verify-wal` default was labeled "incremental" but scanned the
+  full chain; it is now a true recent window (last 10,000 entries).
 
 ## v0.3.1 — 2026-06-10
 

--- a/packages/cli/src/conformance.ts
+++ b/packages/cli/src/conformance.ts
@@ -167,11 +167,25 @@ export async function run(args: string[] = []) {
   });
 
   await check("wal-chain", async () => {
-    const r = await verifyWalChain(workspace);
+    // Recent-window verification (last 5000 entries). Genesis-to-tip on a
+    // production WAL is minutes of hashing — wrong for a routine gate that
+    // runs on every upgrade; `nexaas verify-wal --full` exists for audits.
+    // (The v0.3.1 canary on Phoenix also exposed an unbounded-memory full
+    // scan here — fixed in palace, but the scope change stands on its own.)
+    const anchor = await pool.query(
+      `SELECT id FROM nexaas_memory.wal WHERE workspace = $1
+        ORDER BY id DESC LIMIT 1 OFFSET 4999`,
+      [workspace],
+    );
+    const fromId = anchor.rows[0]?.id as number | undefined;
+    const r = await verifyWalChain(workspace, fromId);
     if (!r.valid) {
       return { status: "fail", detail: `WAL chain broken at id ${r.brokenAt}: ${r.error}` };
     }
-    return { status: "pass", detail: "hash chain valid" };
+    return {
+      status: "pass",
+      detail: fromId ? `hash chain valid (last 5000 entries, from id ${fromId})` : "hash chain valid (full)",
+    };
   });
 
   await check("secrets-hygiene", async () => {

--- a/packages/cli/src/verify-wal.ts
+++ b/packages/cli/src/verify-wal.ts
@@ -2,13 +2,22 @@
  * nexaas verify-wal — verify WAL chain integrity.
  *
  * Usage:
- *   nexaas verify-wal                  Incremental (since last verification)
+ *   nexaas verify-wal                  Recent window (last 10,000 entries)
  *   nexaas verify-wal --full           Full chain from genesis
  *   nexaas verify-wal --from-id 100    From a specific WAL row ID
+ *
+ * The no-flag default used to claim "incremental" while actually scanning
+ * genesis-to-tip (fromId was never computed) — which both lied about its
+ * cost and, before the batched verifier landed in @nexaas/palace, exhausted
+ * the heap on production-sized WALs (found by the v0.3.1 Phoenix canary).
+ * Default is now a true recent window; --full is the explicit audit mode and
+ * is memory-safe at any size (batched), just proportionally slow.
  */
 
 import { verifyWalChain } from "@nexaas/palace";
-import { createPool } from "@nexaas/palace";
+import { createPool, sqlOne } from "@nexaas/palace";
+
+const DEFAULT_WINDOW = 10_000;
 
 export async function run(args: string[]) {
   const workspace = process.env.NEXAAS_WORKSPACE;
@@ -28,8 +37,23 @@ export async function run(args: string[]) {
     }
   }
 
+  let mode = "full chain";
+  if (!fullMode) {
+    if (fromId === undefined) {
+      const anchor = await sqlOne<{ id: number }>(
+        `SELECT id FROM nexaas_memory.wal WHERE workspace = $1
+          ORDER BY id DESC LIMIT 1 OFFSET ${DEFAULT_WINDOW - 1}`,
+        [workspace],
+      );
+      fromId = anchor?.id; // small WALs: undefined → full chain (cheap anyway)
+      mode = fromId ? `recent window (last ${DEFAULT_WINDOW} entries, from id ${fromId})` : "full chain (small WAL)";
+    } else {
+      mode = `from id ${fromId}`;
+    }
+  }
+
   console.log(`\n  Verifying WAL for workspace: ${workspace}`);
-  console.log(`  Mode: ${fullMode ? "full chain" : fromId ? `from id ${fromId}` : "incremental"}\n`);
+  console.log(`  Mode: ${mode}\n`);
 
   const start = Date.now();
   const result = await verifyWalChain(workspace, fullMode ? undefined : fromId);

--- a/packages/palace/src/wal.ts
+++ b/packages/palace/src/wal.ts
@@ -85,38 +85,69 @@ export async function appendWal(entry: WalEntry): Promise<void> {
   }
 }
 
+/**
+ * Rows verified per round-trip. Verification streams the chain in keyset-
+ * paginated batches instead of materializing every row: a production WAL
+ * (Phoenix: 1.34M+ rows with jsonb payloads) loaded as one array exhausts
+ * the V8 heap — found live when the v0.3.1 canary's conformance wal-chain
+ * check OOM-crashed node on Phoenix. Memory is now bounded by one batch.
+ */
+const VERIFY_BATCH_SIZE = 5000;
+
+type WalVerifyRow = {
+  id: number;
+  op: string;
+  actor: string;
+  payload: Record<string, unknown>;
+  prev_hash: string;
+  hash: string;
+  created_at: string;
+};
+
 export async function verifyWalChain(
   workspace: string,
   fromId?: number,
 ): Promise<{ valid: boolean; brokenAt?: number; error?: string }> {
-  const condition = fromId ? `AND id >= $2` : "";
-  const params: unknown[] = [workspace];
-  if (fromId) params.push(fromId);
-
-  const rows = await sql<{
-    id: number;
-    op: string;
-    actor: string;
-    payload: Record<string, unknown>;
-    prev_hash: string;
-    hash: string;
-    created_at: string;
-  }>(
-    // to_char the timestamp into the exact shape `new Date().toISOString()`
-    // produced at write time. Postgres' default `::text` cast uses
-    // "2026-04-22 11:15:00.094+00" which differs byte-for-byte from
-    // "2026-04-22T11:15:00.094Z" — the hash input the row was built with —
-    // so the default formatting always fails recomputation. See #70.
-    `SELECT id, op, actor, payload, prev_hash, hash,
-            to_char(created_at AT TIME ZONE 'UTC',
-                    'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
-     FROM nexaas_memory.wal
-     WHERE workspace = $1 ${condition}
-     ORDER BY id ASC`,
-    params,
-  );
-
+  // Keyset cursor: `id > lastId` reproduces the original `id >= fromId`
+  // window when seeded with fromId - 1, and genesis-to-tip when seeded 0.
+  let lastId = fromId ? fromId - 1 : 0;
   let expectedPrevHash = fromId ? undefined : GENESIS_HASH;
+
+  for (;;) {
+    const rows = await sql<WalVerifyRow>(
+      // to_char the timestamp into the exact shape `new Date().toISOString()`
+      // produced at write time. Postgres' default `::text` cast uses
+      // "2026-04-22 11:15:00.094+00" which differs byte-for-byte from
+      // "2026-04-22T11:15:00.094Z" — the hash input the row was built with —
+      // so the default formatting always fails recomputation. See #70.
+      `SELECT id, op, actor, payload, prev_hash, hash,
+              to_char(created_at AT TIME ZONE 'UTC',
+                      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
+       FROM nexaas_memory.wal
+       WHERE workspace = $1 AND id > $2
+       ORDER BY id ASC
+       LIMIT ${VERIFY_BATCH_SIZE}`,
+      [workspace, lastId],
+    );
+    if (rows.length === 0) break;
+
+    const verdict = verifyBatch(workspace, rows, expectedPrevHash);
+    if (verdict) return verdict;
+
+    expectedPrevHash = rows[rows.length - 1]!.hash;
+    lastId = rows[rows.length - 1]!.id;
+    if (rows.length < VERIFY_BATCH_SIZE) break;
+  }
+
+  return { valid: true };
+}
+
+function verifyBatch(
+  workspace: string,
+  rows: WalVerifyRow[],
+  startPrevHash: string | undefined,
+): { valid: false; brokenAt: number; error: string } | null {
+  let expectedPrevHash = startPrevHash;
 
   for (const row of rows) {
     if (expectedPrevHash !== undefined && row.prev_hash !== expectedPrevHash) {
@@ -153,5 +184,5 @@ export async function verifyWalChain(
     expectedPrevHash = row.hash;
   }
 
-  return { valid: true };
+  return null;
 }


### PR DESCRIPTION
Hotfix found by the v0.3.1 canary doing its job: Phoenix's conformance run OOM-crashed node on the `wal-chain` check — `verifyWalChain` materialized the entire 1.34M-row WAL as one array. The testlab's small WAL could never expose this; production scale did, at canary stage 2, before `channel/stable` exists. `nexaas verify-wal`'s no-flag default had the same bomb (labeled "incremental", actually genesis-to-tip).

**Fix**: keyset-paginated 5000-row batches in palace (memory bounded by one batch at any size, semantics identical — genesis anchor, fromId windows, tamper detection across boundaries). Conformance's gate check now verifies the **last 5000 entries** (right-sized for an every-upgrade gate; `verify-wal --full` remains the audit mode, now memory-safe). `verify-wal`'s default is an honest 10k-entry window.

**Validated** on a scratch DB under a deliberate 128MB heap cap: 12,500 chained rows across two batch boundaries verify clean (368ms full / 123ms windowed); a mid-chain tamper at row 7001 caught with the exact id. The production-scale proof will be Phoenix's conformance run after this ships as v0.3.2 through the canary channel — which also live-exercises the hotfix loop end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--full` flag for complete genesis-to-tip WAL chain verification; default behavior now verifies the last 10,000 entries for better performance.

* **Bug Fixes**
  * Fixed WAL chain verification to process in memory-efficient batches, preventing heap exhaustion on large chains.
  * Corrected default verification mode label and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->