### PR TITLE
fix(reaper): expired-waitpoint escalation is single-fire (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,20 @@ backward compatibility; see the rollback policy in `docs/releases.md`).
 
 ## Unreleased
 
-_Nothing yet._
+### Fixed
+- Waitpoint timeout reaper re-alerted on the same expired waitpoint every
+  60s tick forever — the `escalate` policy (default) wrote an ops_alert but
+  never marked the waitpoint terminal (#231). Phoenix logged ~35k
+  severity-high `waitpoint_timeout` alerts per 12h off ~295 abandoned
+  approvals. Expiry is now single-fire via `events.timeout_handled_at`;
+  `escalate` keeps `dormant_signal` set so the waitpoint stays resolvable
+  by a human. Conformance gains a `waitpoint-expiry` regression check.
+
+### Migrations
+- `027_waitpoint_timeout_handled.sql` — adds nullable
+  `events.timeout_handled_at` + partial index; backfills currently-expired
+  active waitpoints as handled (silences the existing backlog with zero
+  further alerts). Additive/nullable — rollback to v0.3.2 unconstrained.
 
 ## v0.3.2 — 2026-06-10
 

--- a/database/migrations/027_waitpoint_timeout_handled.sql
+++ b/database/migrations/027_waitpoint_timeout_handled.sql
@@ -1,0 +1,42 @@
+-- Migration 027: Waitpoint timeout handled marker (issue #231)
+-- Date: 2026-06-19
+--
+-- The timeout reaper's `escalate` policy (the default) wrote an ops_alert
+-- and a WAL entry on every 60s tick but never marked the waitpoint, so an
+-- expired-but-unconsumed waitpoint re-alerted forever. Phoenix accumulated
+-- ~295 abandoned approval waitpoints from April–May 2026, each firing once
+-- per tick = ~35k severity-high ops_alerts every 12 hours, drowning real
+-- timeouts and bloating ops_alerts/WAL.
+--
+-- The auto_{approve,reject,cancel} policies already terminate by clearing
+-- dormant_signal — but `escalate` must keep the waitpoint resolvable
+-- (resolveWaitpoint looks it up `WHERE dormant_signal = $1`, so a human can
+-- still approve it after the escalation). So expiry needs a marker that
+-- removes the waitpoint from the *reaper's* view without removing it from
+-- the *resolver's* view, and without losing dormant_until for forensics.
+--
+-- `timeout_handled_at`: NULL = the reaper has not yet applied a timeout
+-- policy to this waitpoint. Set once, on the tick that handles expiry.
+-- Additive + nullable → backward compatible one release (code N-1 ignores
+-- it; rollback unconstrained).
+
+ALTER TABLE nexaas_memory.events
+  ADD COLUMN IF NOT EXISTS timeout_handled_at timestamptz;
+
+-- Backfill the existing backlog: every currently-expired active waitpoint
+-- is marked handled NOW, silently. They have already alerted thousands of
+-- times — they need zero further alerts, just to stop. They stay resolvable
+-- (dormant_signal untouched). New expiries (dormant_until passing after this
+-- migration) alert exactly once via the fixed reaper.
+UPDATE nexaas_memory.events
+   SET timeout_handled_at = now()
+ WHERE dormant_signal IS NOT NULL
+   AND dormant_until IS NOT NULL
+   AND dormant_until < now()
+   AND timeout_handled_at IS NULL;
+
+-- Precise partial index for the reaper's post-fix query shape — keeps the
+-- expired-and-unhandled scan cheap at fleet scale (Phoenix events ≈ 8.9M).
+CREATE INDEX IF NOT EXISTS ix_events_dormant_unhandled
+  ON nexaas_memory.events (dormant_until)
+  WHERE dormant_signal IS NOT NULL AND timeout_handled_at IS NULL;

--- a/packages/cli/src/conformance.ts
+++ b/packages/cli/src/conformance.ts
@@ -242,6 +242,64 @@ export async function run(args: string[] = []) {
     };
   });
 
+  await check("waitpoint-expiry", async () => {
+    // Regression guard for #231: an expired waitpoint under the default
+    // (escalate) policy must alert EXACTLY once, not re-alert every reaper
+    // tick. Uses the real createWaitpoint insert path, then backdates the
+    // deadline; runs the reaper twice and asserts a single escalation.
+    const { palace, createPool: _cp } = await import("@nexaas/palace");
+    _cp(); // ensure the palace pool targets this DATABASE_URL
+    const { reapExpiredWaitpoints } = await import("@nexaas/runtime");
+
+    const signal = `wp_conformance_${randomUUID()}`;
+    const room = { wing: "ops", hall: "conformance", room: "waitpoint-expiry" };
+    const session = palace.enter({
+      workspace,
+      runId: randomUUID(),
+      skillId: "conformance/waitpoint-expiry",
+      stepId: "expiry",
+    });
+    await session.createWaitpoint({ signal, room, state: { conformance: true } });
+    // Backdate so it's already expired for the reaper.
+    await pool.query(
+      `UPDATE nexaas_memory.events SET dormant_until = now() - interval '1 hour' WHERE dormant_signal = $1`,
+      [signal],
+    );
+
+    try {
+      await reapExpiredWaitpoints();
+      await reapExpiredWaitpoints(); // second tick must produce no new alert
+      const alerts = await pool.query(
+        `SELECT count(*)::int AS n FROM nexaas_memory.ops_alerts
+          WHERE workspace = $1 AND event_type = 'waitpoint_timeout' AND payload->>'signal' = $2`,
+        [workspace, signal],
+      );
+      const handled = await pool.query(
+        `SELECT timeout_handled_at IS NOT NULL AS done, dormant_signal IS NOT NULL AS resolvable
+           FROM nexaas_memory.events WHERE dormant_signal = $1`,
+        [signal],
+      );
+      const n = alerts.rows[0]?.n ?? 0;
+      if (n !== 1) {
+        return { status: "fail", detail: `expired waitpoint alerted ${n}× across 2 reaper ticks (expected exactly 1) — #231 regression` };
+      }
+      if (!handled.rows[0]?.done) {
+        return { status: "fail", detail: "timeout_handled_at not set after reaping" };
+      }
+      if (!handled.rows[0]?.resolvable) {
+        return { status: "fail", detail: "escalate cleared dormant_signal — waitpoint no longer resolvable by a human" };
+      }
+      return { status: "pass", detail: "expired waitpoint escalated once across 2 ticks; stays resolvable" };
+    } finally {
+      // Residue cleanup: the synthetic waitpoint + the alert it produced.
+      await pool.query(
+        `DELETE FROM nexaas_memory.ops_alerts WHERE workspace = $1 AND payload->>'signal' = $2`,
+        [workspace, signal],
+      );
+      await pool.query(`DELETE FROM nexaas_memory.events WHERE dormant_signal = $1`, [signal]);
+    }
+  });
+
   // ── Execution proofs ────────────────────────────────────────────────
 
   const artifactsDir = mkdtempSync(join(tmpdir(), "nexaas-conformance-"));

--- a/packages/runtime/src/tasks/waitpoint-reaper.ts
+++ b/packages/runtime/src/tasks/waitpoint-reaper.ts
@@ -6,7 +6,15 @@
  * - auto_approve: resolve as approved
  * - auto_reject: resolve as rejected
  * - auto_cancel: cancel the run
- * - remind_and_extend: send reminder, extend timeout
+ *
+ * Expiry is a TERMINAL, single-fire transition (#231). Every waitpoint the
+ * reaper processes is stamped `timeout_handled_at` and excluded from
+ * subsequent ticks. Before the fix, the `escalate` policy (the default)
+ * left dormant_signal/dormant_until intact, so an expired waitpoint nothing
+ * consumed re-escalated every tick forever — Phoenix logged ~35k severity-
+ * high ops_alerts per 12h off ~295 abandoned approvals. `escalate`
+ * deliberately keeps dormant_signal set (so resolveWaitpoint can still
+ * approve it later); `timeout_handled_at` is what stops the re-alert.
  */
 
 import { sql, appendWal, resolveWaitpoint } from "@nexaas/palace";
@@ -26,7 +34,9 @@ interface ExpiredWaitpoint {
 }
 
 export async function reapExpiredWaitpoints(): Promise<number> {
-  // Find waitpoints that have passed their timeout
+  // Find waitpoints that have passed their timeout and not yet been handled
+  // (#231). `timeout_handled_at IS NULL` is the single-fire guard — without
+  // it the escalate policy re-alerted every tick.
   const expired = await sql<ExpiredWaitpoint>(`
     SELECT id, workspace, skill_id, run_id, step_id, dormant_signal,
            dormant_until, metadata, reminder_at, reminder_sent
@@ -34,6 +44,7 @@ export async function reapExpiredWaitpoints(): Promise<number> {
     WHERE dormant_signal IS NOT NULL
       AND dormant_until IS NOT NULL
       AND dormant_until < now()
+      AND timeout_handled_at IS NULL
     LIMIT 50
   `);
 
@@ -100,6 +111,17 @@ export async function reapExpiredWaitpoints(): Promise<number> {
           });
           break;
       }
+
+      // Terminal, single-fire (#231): mark handled so this waitpoint is
+      // never re-processed, regardless of policy. auto_* already cleared
+      // dormant_signal; escalate keeps it resolvable and relies on this
+      // stamp. Set last, so a throw before this point leaves it for retry
+      // on the next tick rather than silently swallowing an unhandled
+      // expiry.
+      await sql(
+        `UPDATE nexaas_memory.events SET timeout_handled_at = now() WHERE id = $1`,
+        [wp.id],
+      );
 
       reaped++;
     } catch (err) {


### PR DESCRIPTION
Fixes #231 — found in the v0.3.2 stable-promotion soak review.

## Root cause

The timeout reaper's `escalate` policy (the default) wrote an `ops_alert` + WAL entry every 60s tick but never made any terminal change. So `dormant_signal IS NOT NULL AND dormant_until < now()` stayed true and the same expired waitpoint re-escalated forever. Phoenix: ~295 abandoned April–May approval waitpoints → **~35k severity-high `waitpoint_timeout` alerts per 12h**, drowning real timeouts and bloating ops_alerts + the WAL.

`auto_{approve,reject,cancel}` already terminate by clearing `dormant_signal` — but `escalate` **must not**, because `resolveWaitpoint` looks up `WHERE dormant_signal = $1`. Clearing it would make a later human approval of the escalated waitpoint unresolvable. So expiry needs a marker that removes the waitpoint from the *reaper's* view while keeping it *resolvable*.

## Fix

- **Migration 027**: nullable `events.timeout_handled_at` + a precise partial index. **Backfills currently-expired active waitpoints as handled** — the existing backlog (Phoenix's ~295) goes silent immediately, zero further alerts, and stays resolvable. Additive/nullable; rollback to v0.3.2 unconstrained.
- **Reaper**: SELECT gains `AND timeout_handled_at IS NULL`; every processed waitpoint is stamped once, *after* successful handling (a throw before the stamp leaves it for next-tick retry rather than silently dropping an unhandled expiry).
- **Conformance**: new `waitpoint-expiry` check — creates an expired waitpoint, reaps twice, asserts exactly one alert + handled + still-resolvable.

## Validated (scratch DB)

- New expiry: 1 alert across 5 reaper ticks; `timeout_handled_at` set; `dormant_signal` intact (still resolvable)
- Backfill: a simulated pre-027 expired row is silenced (0 alerts across 2 ticks)
- Full conformance **10/10**, residue-free (synthetic waitpoint + its alert cleaned up)

## Note on `remind_and_extend`

The doc comment listed it but it was never implemented — it fell through to `escalate`. I dropped it from the doc comment; reminders are already handled separately by `sendPendingReminders` (the `reminder_at`/`reminder_sent` path). Proper deadline-extension remains a separate feature, out of scope here.

The Phoenix-side question (what registered ~295 abandoned `sensitivity_scan` approvals) is flagged on #231 for the Phoenix team; the framework fix stands regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed a bug where expired waitpoints repeatedly triggered timeout escalation alerts across multiple reaper runs instead of just once. Expired waitpoints now correctly register as handled after the initial alert is sent, preventing duplicate notifications while remaining resolvable for manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->