### PR TITLE
fix(mcp-palace): write WAL via canonical appendWal, not a bogus inline hash (#234)

### DIFF
--- a/mcp/servers/palace/package.json
+++ b/mcp/servers/palace/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@nexaas/palace": "^0.1.0",
     "pg": "^8.20.0",
     "zod": "^3.23.0"
   }

--- a/mcp/servers/palace/src/index.ts
+++ b/mcp/servers/palace/src/index.ts
@@ -23,6 +23,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import pg from "pg";
+import { appendWal } from "@nexaas/palace";
 
 // ── Database ────────────────────────────────────────────────────────────
 
@@ -169,20 +170,19 @@ server.tool(
       [WORKSPACE, wing, hall, room, content, hash, skill_id ?? "interactive"],
     );
 
-    // WAL entry for audit
-    await sql(
-      `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-       SELECT $1, 'palace_mcp_write', 'palace-mcp',
-         $2::jsonb,
-         COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-         encode(digest($4, 'sha256'), 'hex')`,
-      [
-        WORKSPACE,
-        JSON.stringify({ wing, hall, room, drawer_id: result[0]?.id, content_length: content.length }),
-        "0".repeat(64),
-        `palace-write-${Date.now()}`,
-      ],
-    );
+    // WAL entry for audit — through the canonical appendWal so the row is
+    // hash-chained correctly under the per-workspace advisory lock. The
+    // previous hand-rolled INSERT computed hash = sha256("palace-write-<ts>")
+    // — a bogus value never derived from the canonical
+    // prev_hash|op|actor|payload|created_at, and took no lock — so every
+    // palace_mcp_write row was unverifiable and broke `verify-wal` at the
+    // first such row (#234; surfaced on Phoenix during the #231 rollout).
+    await appendWal({
+      workspace: WORKSPACE,
+      op: "palace_mcp_write",
+      actor: "palace-mcp",
+      payload: { wing, hall, room, drawer_id: result[0]?.id, content_length: content.length },
+    });
 
     return jsonResult({
       written: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*",
         "integrations/*",
         "mcp/servers/email-outbound",
-        "mcp/servers/webstudio"
+        "mcp/servers/webstudio",
+        "mcp/servers/palace"
       ],
       "devDependencies": {
         "@changesets/cli": "^2.27.0",
@@ -66,6 +67,16 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "typescript": "^5.5.0"
+      }
+    },
+    "mcp/servers/palace": {
+      "name": "@nexaas/mcp-palace",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@nexaas/palace": "^0.1.0",
+        "pg": "^8.20.0",
+        "zod": "^3.23.0"
       }
     },
     "mcp/servers/webstudio": {
@@ -1699,6 +1710,10 @@
     },
     "node_modules/@nexaas/mcp-email-outbound": {
       "resolved": "mcp/servers/email-outbound",
+      "link": true
+    },
+    "node_modules/@nexaas/mcp-palace": {
+      "resolved": "mcp/servers/palace",
       "link": true
     },
     "node_modules/@nexaas/mcp-webstudio": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "packages/*",
     "integrations/*",
     "mcp/servers/email-outbound",
-    "mcp/servers/webstudio"
+    "mcp/servers/webstudio",
+    "mcp/servers/palace"
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",


### PR DESCRIPTION
Forward fix for #234 (full root-cause there). The palace MCP `palace_write` tool wrote its WAL row with `hash = sha256("palace-write-" + Date.now())` — never the canonical `prev_hash|op|actor|payload|created_at` — and took no advisory lock. Every `palace_mcp_write` row was unverifiable; `verifyWalChain` breaks at the first one. Surfaced on Phoenix during the #231 (v0.3.3) rollout when the conformance gate caught it and **auto-rolled back** — the safety mechanism working exactly as designed.

## Change
- Route the WAL write through `@nexaas/palace`'s `appendWal` — the single canonical, advisory-locked, hash-chained writer.
- Added `@nexaas/palace` as a dependency and registered the palace MCP server in the root `workspaces` array. It was standalone (sdk/pg/zod only), which is precisely why it had drifted into a second, broken WAL implementation.

## Validation
Scratch DB: a drawer written through the fixed path produces a chain `verifyWalChain` accepts (`{valid:true}`). Standalone typecheck clean.

## Scope
Forward fix only — stops new invalid rows. Repairing the **1009 existing** pre-fix rows on Phoenix (and unblocking `verify-wal --full` there) needs a remediation decision (#234, options laid out) because it touches an append-only audit log. Phoenix stays on v0.3.2 until that's chosen; the #231 fix ships to Phoenix together with the remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)