### PR TITLE
fix(wal): integrity_exempt repair for pre-#234 palace_mcp_write rows (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ backward compatibility; see the rollback policy in `docs/releases.md`).
 
 ## Unreleased
 
-_Nothing yet._
+### Fixed
+- WAL integrity remediation (#234): migration 028 adds `wal.integrity_exempt`
+  and flags the pre-fix `palace_mcp_write` backlog (whose hashes were
+  `sha256('palace-write-'||ts)`, never canonical). `verifyWalChain` skips
+  hash *recomputation* for flagged rows — like the `workspace_genesis`
+  anchor — while still verifying their `prev_hash` linkage, and reports the
+  skipped count. Restores `verify-wal --full` / the conformance gate on
+  affected workspaces without rewriting the append-only chain. Post-#234
+  `palace_mcp_write` rows (written via `appendWal`, PR #235) are not flagged
+  and are fully verified; genuine tampering of any non-exempt row is still
+  caught. Pairs with the forward fix in #235.
+
+### Migrations
+- `028_wal_integrity_exempt.sql` — adds `wal.integrity_exempt boolean`
+  (metadata-only default on PG 11+) and flags existing `palace_mcp_write`
+  rows. Additive; rollback to v0.3.3 safe (older code ignores the column).
 
 ## v0.3.3 — 2026-06-19
 

--- a/database/migrations/028_wal_integrity_exempt.sql
+++ b/database/migrations/028_wal_integrity_exempt.sql
@@ -1,0 +1,35 @@
+-- Migration 028: WAL integrity-exempt marker for pre-fix palace_mcp_write rows (#234)
+-- Date: 2026-06-19
+--
+-- The palace MCP `palace_write` tool wrote its WAL rows with
+-- hash = sha256('palace-write-' || now-ish) — never the canonical
+-- prev_hash|op|actor|payload|created_at — and took no advisory lock. So
+-- every existing `palace_mcp_write` row is unverifiable: verifyWalChain
+-- recomputes the canonical hash, gets a different value, and reports the
+-- chain broken at the first such row (Phoenix: 1009 rows from id 4183,
+-- breaking verify-wal --full and the upgrade gate). PR #235 fixed the
+-- writer forward (it now uses appendWal); this migration repairs the
+-- backlog.
+--
+-- These rows were NEVER canonically hashed, so we cannot recompute them —
+-- and we will not rewrite the append-only chain. Instead we mark them
+-- integrity-exempt: verifyWalChain skips hash *recomputation* for flagged
+-- rows (exactly as it already does for the workspace_genesis anchor) while
+-- still verifying their prev_hash *linkage*. Honest about what was never
+-- protected; rewrites no history; forward-safe — post-#235 palace_mcp_write
+-- rows are written by appendWal, are NOT flagged, and are fully verified.
+--
+-- Additive column with a constant default = metadata-only on PG 11+ (no
+-- table rewrite, important on Phoenix's ~11.5M-row wal). Rollback to v0.3.3
+-- is safe: older code simply never reads the column.
+
+ALTER TABLE nexaas_memory.wal
+  ADD COLUMN IF NOT EXISTS integrity_exempt boolean NOT NULL DEFAULT false;
+
+-- Flag the existing buggy backlog. Only rows that already exist now (all
+-- written by the pre-#235 inline INSERT) are flagged; new appendWal-written
+-- palace_mcp_write rows default to false and verify normally.
+UPDATE nexaas_memory.wal
+   SET integrity_exempt = true
+ WHERE op = 'palace_mcp_write'
+   AND integrity_exempt = false;

--- a/packages/cli/src/verify-wal.ts
+++ b/packages/cli/src/verify-wal.ts
@@ -61,6 +61,9 @@ export async function run(args: string[]) {
 
   if (result.valid) {
     console.log(`  ✓ WAL chain verified (${elapsed}ms)`);
+    if (result.exemptSkipped && result.exemptSkipped > 0) {
+      console.log(`  Linkage verified; hash recompute skipped for ${result.exemptSkipped} integrity-exempt row(s) (pre-#234 palace_mcp_write — migration 028).`);
+    }
     console.log(`  No integrity issues found.\n`);
   } else {
     console.error(`  ✗ WAL chain BROKEN at row ${result.brokenAt}`);

--- a/packages/palace/src/wal.ts
+++ b/packages/palace/src/wal.ts
@@ -102,16 +102,18 @@ type WalVerifyRow = {
   prev_hash: string;
   hash: string;
   created_at: string;
+  integrity_exempt: boolean;
 };
 
 export async function verifyWalChain(
   workspace: string,
   fromId?: number,
-): Promise<{ valid: boolean; brokenAt?: number; error?: string }> {
+): Promise<{ valid: boolean; brokenAt?: number; error?: string; exemptSkipped?: number }> {
   // Keyset cursor: `id > lastId` reproduces the original `id >= fromId`
   // window when seeded with fromId - 1, and genesis-to-tip when seeded 0.
   let lastId = fromId ? fromId - 1 : 0;
   let expectedPrevHash = fromId ? undefined : GENESIS_HASH;
+  let exemptSkipped = 0;
 
   for (;;) {
     const rows = await sql<WalVerifyRow>(
@@ -122,7 +124,8 @@ export async function verifyWalChain(
       // so the default formatting always fails recomputation. See #70.
       `SELECT id, op, actor, payload, prev_hash, hash,
               to_char(created_at AT TIME ZONE 'UTC',
-                      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
+                      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at,
+              integrity_exempt
        FROM nexaas_memory.wal
        WHERE workspace = $1 AND id > $2
        ORDER BY id ASC
@@ -132,39 +135,51 @@ export async function verifyWalChain(
     if (rows.length === 0) break;
 
     const verdict = verifyBatch(workspace, rows, expectedPrevHash);
-    if (verdict) return verdict;
+    if (verdict.broken) return verdict.broken;
+    exemptSkipped += verdict.exemptSkipped;
 
     expectedPrevHash = rows[rows.length - 1]!.hash;
     lastId = rows[rows.length - 1]!.id;
     if (rows.length < VERIFY_BATCH_SIZE) break;
   }
 
-  return { valid: true };
+  return { valid: true, exemptSkipped };
 }
 
 function verifyBatch(
   workspace: string,
   rows: WalVerifyRow[],
   startPrevHash: string | undefined,
-): { valid: false; brokenAt: number; error: string } | null {
+): { broken: { valid: false; brokenAt: number; error: string } | null; exemptSkipped: number } {
   let expectedPrevHash = startPrevHash;
+  let exemptSkipped = 0;
 
   for (const row of rows) {
     if (expectedPrevHash !== undefined && row.prev_hash !== expectedPrevHash) {
       return {
-        valid: false,
-        brokenAt: row.id,
-        error: `prev_hash mismatch at id ${row.id}: expected ${expectedPrevHash}, got ${row.prev_hash}`,
+        broken: {
+          valid: false,
+          brokenAt: row.id,
+          error: `prev_hash mismatch at id ${row.id}: expected ${expectedPrevHash}, got ${row.prev_hash}`,
+        },
+        exemptSkipped,
       };
     }
 
-    // The `workspace_genesis` row is written by `nexaas init` via raw SQL
-    // (not through appendWal), so its hash was not produced by canonicalize().
-    // It serves as the chain's trust anchor — integrity for subsequent rows
-    // comes from prev_hash linkage, not from re-deriving the anchor. Verify
-    // the anchor exists and links correctly, but skip hash recomputation.
-    // See #70 for the longer explanation.
-    if (row.op !== "workspace_genesis") {
+    // Hash recomputation is skipped for two kinds of trust-anchor rows whose
+    // stored hash was provably not produced by canonicalize():
+    //   - `workspace_genesis`: written by `nexaas init` via raw SQL as the
+    //     chain's root anchor (see #70).
+    //   - `integrity_exempt` rows: pre-#234 palace_mcp_write rows whose hash
+    //     was sha256('palace-write-'||ts), never canonical. Flagged by
+    //     migration 028. We never claimed integrity for them and won't
+    //     rewrite the append-only chain to fake it.
+    // Both still have their prev_hash *linkage* verified above; we only skip
+    // re-deriving their hash. Post-#234 palace_mcp_write rows are NOT exempt
+    // and are fully recomputed.
+    if (row.integrity_exempt) {
+      exemptSkipped++;
+    } else if (row.op !== "workspace_genesis") {
       const canonical = canonicalize(
         { workspace, op: row.op, actor: row.actor, payload: row.payload },
         row.created_at,
@@ -174,9 +189,12 @@ function verifyBatch(
 
       if (recomputed !== row.hash) {
         return {
-          valid: false,
-          brokenAt: row.id,
-          error: `hash mismatch at id ${row.id}: expected ${recomputed}, got ${row.hash}`,
+          broken: {
+            valid: false,
+            brokenAt: row.id,
+            error: `hash mismatch at id ${row.id}: expected ${recomputed}, got ${row.hash}`,
+          },
+          exemptSkipped,
         };
       }
     }
@@ -184,5 +202,5 @@ function verifyBatch(
     expectedPrevHash = row.hash;
   }
 
-  return null;
+  return { broken: null, exemptSkipped };
 }


### PR DESCRIPTION
Backlog repair for #234 (forward fix was #235). Operator chose the `integrity_exempt` flag over a chain reseal.

The pre-fix `palace_mcp_write` rows were hashed as `sha256('palace-write-'||ts)` — never canonical — so they can't be recomputed, and rewriting an append-only audit log to fake it is the wrong move. Instead, acknowledge them honestly:

- **Migration 028**: `wal.integrity_exempt boolean` (constant default → metadata-only on PG 11+, important on Phoenix's ~11.5M-row wal); flags existing `palace_mcp_write` rows.
- **`verifyWalChain`**: skips hash *recomputation* for flagged rows — exactly as it already does for the `workspace_genesis` anchor — while still verifying `prev_hash` *linkage*; returns an `exemptSkipped` count.
- **`verify-wal`**: reports the skipped count for audit transparency.

Forward-safe: post-#235 `palace_mcp_write` rows go through `appendWal`, aren't flagged, and are fully verified.

## Validation (scratch)
- Exempt bad row + a post-fix canonical `palace_mcp_write` → chain valid, `exemptSkipped=1`
- An **unflagged** bad row → still breaks (the exemption is precise, not a blanket op-type bypass)
- A tampered *normal* row → still caught (integrity guarantee preserved)

Unblocks `verify-wal --full` and the conformance gate on affected workspaces. With this + #235 + the #231 reaper fix, Phoenix can take the next release and clear both the WAL-chain break and the alert storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)