### PR TITLE
fix(upgrade): actually ship the --include=dev fix v0.3.5 only claimed

### DIFF
--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -474,7 +474,13 @@ function postCheckoutSteps(nexaasRoot: string, fromCommit: string): void {
   );
   if (changedFiles.includes("package.json") || changedFiles.includes("package-lock.json")) {
     console.log("  Running npm install...");
-    exec(`cd ${nexaasRoot} && npm install --production 2>/dev/null`, { timeout: 300_000 });
+    // --include=dev, NOT --production: the build step below runs `tsc`
+    // (each workspace's build script), and typescript is a devDependency.
+    // A --production install prunes it, so the very next `npm run build`
+    // fails with "tsc: not found" — exactly what broke the v0.3.4 testlab
+    // upgrade (the first release since channels to change root package.json,
+    // which is what triggers this reinstall). Matches init.ts.
+    exec(`cd ${nexaasRoot} && npm install --include=dev 2>/dev/null`, { timeout: 300_000 });
     console.log("  Dependencies updated");
   }
 


### PR DESCRIPTION
v0.3.5's CHANGELOG claims `nexaas upgrade` switched to `--include=dev`, but only VERSION + CHANGELOG were committed — the upgrade.ts edit was never staged. v0.3.5 and channel/stable still run `npm install --production`, which prunes typescript and breaks the next `npm run build` when a release changes root package.json (#238 condition). This lands the real one-line fix. Lands in v0.3.6; the v0.3.5→v0.3.6 hop is safe because it doesn't change package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)