### PR TITLE
feat(worker): POST /api/approvals/:signal/resolve (#205)

### DIFF
--- a/packages/runtime/src/tasks/approval-resolver.ts
+++ b/packages/runtime/src/tasks/approval-resolver.ts
@@ -368,6 +368,96 @@ export async function resolvePendingApprovals(workspace: string): Promise<{
   return { resolved, ignored, errors };
 }
 
+/**
+ * Resolve an approval directly by its waitpoint signal (#205) — the
+ * synchronous alternative to the drawer-then-poll path. Backs the worker's
+ * POST /api/approvals/:signal/resolve so ops dashboards skip the ~3s
+ * resolver poll latency. Produces the IDENTICAL outcome to a button click:
+ * same `resolveWaitpoint` + `enqueueResumption` + WAL ops. The poll path
+ * (channel adapters that can't HTTP back) is unchanged.
+ */
+export async function resolveApprovalBySignal(
+  workspace: string,
+  signal: string,
+  decision: string,
+  actor: string,
+): Promise<
+  | { ok: true; runId: string | null; strategy: string; handlerSkill?: string }
+  | { ok: false; status: number; error: string }
+> {
+  // Locate the approval_request drawer carrying this signal. `content` is a
+  // JSON string — filter with a cheap LIKE, then JSON.parse in JS to avoid
+  // ::jsonb casts blowing up on non-JSON drawers.
+  const candidates = await sql<{ content: string }>(
+    `SELECT content FROM nexaas_memory.events
+      WHERE workspace = $1 AND content LIKE '%' || $2 || '%'
+      ORDER BY id DESC LIMIT 20`,
+    [workspace, signal],
+  );
+  let approval: ApprovalRequestContent | null = null;
+  for (const c of candidates) {
+    try {
+      const parsed = JSON.parse(c.content) as ApprovalRequestContent;
+      if (parsed.kind === "approval_request" && parsed.waitpoint_signal === signal) {
+        approval = parsed;
+        break;
+      }
+    } catch { /* non-JSON drawer — skip */ }
+  }
+  if (!approval) {
+    return { ok: false, status: 404, error: `no approval_request found for signal '${signal}'` };
+  }
+
+  // Same guard as the poll path: don't resolve with a decision the skill
+  // never declared.
+  const decisionIds = (approval.decisions ?? []).map((d) => d.id);
+  if (decisionIds.length > 0 && !decisionIds.includes(decision)) {
+    return { ok: false, status: 400, error: `decision '${decision}' not in allowed set: ${decisionIds.join(", ")}` };
+  }
+
+  try {
+    const result = await resolveWaitpoint(
+      signal,
+      { decision, output_id: approval.output_id, resolved_via: "api-direct" },
+      actor,
+    );
+    const resumption = await enqueueResumption(workspace, approval, decision, actor);
+
+    await appendWal({
+      workspace,
+      op: decision === "approve" ? "approval_granted"
+        : decision === "reject" ? "approval_denied"
+        : "approval_resolved",
+      actor,
+      payload: {
+        run_id: result.runId,
+        skill_id: result.skillId,
+        step_id: result.stepId,
+        signal,
+        decision,
+        channel_role: approval.channel_role,
+        resolved_via: "api-direct",
+        resumption_strategy: resumption.strategy,
+        handler_skill: resumption.handler_skill,
+        resumption_error: resumption.error,
+      },
+    });
+    if (resumption.error) {
+      await appendWal({
+        workspace, op: "approval_handler_missing", actor,
+        payload: { signal, decision, handler_skill: resumption.handler_skill, error: resumption.error },
+      });
+    }
+    return { ok: true, runId: result.runId ?? null, strategy: resumption.strategy, handlerSkill: resumption.handler_skill };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("Waitpoint not found")) {
+      return { ok: false, status: 409, error: "waitpoint not found or already resolved" };
+    }
+    return { ok: false, status: 500, error: msg.slice(0, 300) };
+  }
+}
+
 export function startApprovalResolver(
   workspace: string,
   opts: { intervalMs?: number } = {},

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -53,7 +53,7 @@ import { ingestDocument } from "./ingest/index.js";
 import { loadWorkspaceManifest } from "./schemas/load-manifest.js";
 import { startNotificationDispatcher } from "./tasks/notification-dispatcher.js";
 import { startInboundDispatcher } from "./tasks/inbound-dispatcher.js";
-import { startApprovalResolver } from "./tasks/approval-resolver.js";
+import { startApprovalResolver, resolveApprovalBySignal } from "./tasks/approval-resolver.js";
 import { startOutputStalenessWatchdog } from "./tasks/output-staleness-watchdog.js";
 import { startSchedulerWatchdog } from "./tasks/scheduler-watchdog.js";
 import { startBatchDispatcher } from "./tasks/batch-dispatcher.js";
@@ -550,6 +550,40 @@ async function main() {
         return;
       }
       res.status(outcome.status).json(outcome.body);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Direct approval resolution (#205) — synchronous alternative to the
+  // drawer-then-poll path for ops dashboards / HTTP callers. Same outcome
+  // (resolveWaitpoint + handler enqueue + WAL) as a channel button click,
+  // minus the ~3s resolver poll latency. The poll path stays for channel
+  // adapters that can't HTTP back.
+  app.post("/api/approvals/:signal/resolve", bearerAuth(), async (req, res) => {
+    try {
+      const body = req.body ?? {};
+      const signal = req.params.signal as string;
+      const workspace = typeof body.workspace === "string" ? body.workspace : WORKSPACE;
+      const decision = body.decision;
+      const actorId = typeof body.actor === "string" ? body.actor : null;
+      if (!workspace) { res.status(400).json({ error: "workspace is required" }); return; }
+      if (typeof decision !== "string" || !decision) { res.status(400).json({ error: "decision is required" }); return; }
+      if (!actorId) { res.status(400).json({ error: "actor is required" }); return; }
+      const actor = body.actor_display ? `api:${actorId} (${body.actor_display})` : `api:${actorId}`;
+
+      const outcome = await resolveApprovalBySignal(workspace, signal, decision, actor);
+      if (outcome.ok) {
+        res.status(200).json({
+          ok: true,
+          resolved: true,
+          run_id: outcome.runId,
+          resumption: outcome.strategy,
+          ...(outcome.handlerSkill ? { handler_enqueued: outcome.handlerSkill } : {}),
+        });
+      } else {
+        res.status(outcome.status).json({ ok: false, error: outcome.error });
+      }
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }


### PR DESCRIPTION
Direct approval resolution endpoint — synchronous alternative to the drawer-then-poll path, removing the ~3s poll latency for ops dashboards. Reuses `resolveWaitpoint` + the handler-enqueue path, identical WAL audit (`resolved_via: api-direct`). Bearer-authed; 200 / 400 / 404 / 409. Poll path unchanged for channel adapters. Validated live on scratch across all five cases (auth, bad decision, unknown signal, valid resolve + WAL + waitpoint cleared, double-resolve). Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)