### PR TITLE
fix(wal): hash nested payloads — canon v2 (#254)

### DIFF
--- a/database/migrations/029_wal_canon_v2.sql
+++ b/database/migrations/029_wal_canon_v2.sql
@@ -1,0 +1,59 @@
+-- Migration 029: WAL canonicalization v2 — hash nested payloads (issue #254)
+-- Date: 2026-07-02
+--
+-- The v1 canonicalizer (packages/palace/src/wal.ts) hashed the payload with
+-- `JSON.stringify(payload, Object.keys(payload).sort())`. A replacer *array*
+-- is a key allowlist applied at EVERY depth, so any nested object serialized
+-- as `{}` — nested WAL payload fields could be altered in the database with
+-- no change to the hash. Verification was self-consistent (it dropped the
+-- same data at recompute), which is why 8.9M+ Phoenix rows never surfaced it.
+-- v1 also mis-hashed top-level numbers that JS renders in exponent form.
+--
+-- Fix without rewriting the append-only chain (the #234 / 028 playbook):
+--   * `canon_version` tags each row with the algorithm that produced its
+--     hash. Existing rows default to 1 and keep verifying under the v1 JS
+--     canonicalizer (bug and all — that is historical fact); new rows are
+--     written v2 and verify under wal_hash_v2 below.
+--   * wal_hash_v2 is ONE canonical implementation used by BOTH the writer
+--     (appendWal) and the verifier. It hashes over `payload::text` — jsonb's
+--     deterministic, fully-nested, number-normalized serialization — so the
+--     write-time and verify-time inputs are byte-identical by construction,
+--     sidestepping every JS-vs-jsonb representation mismatch. Nested tamper
+--     now changes payload::text and is detected.
+--
+-- Additive column + a function + a targeted exempt flag. No history rewrite;
+-- rollback to pre-029 code is safe (older code ignores canon_version and
+-- recomputes everything with v1 — which then flags v2 rows broken, so DO NOT
+-- run pre-029 verify against a v2-written chain; the column is the guard).
+
+ALTER TABLE nexaas_memory.wal
+  ADD COLUMN IF NOT EXISTS canon_version smallint NOT NULL DEFAULT 1;
+
+-- Canonical hash, v2. IMMUTABLE so it can be used in indexes/SELECT freely.
+-- Input order matches the v1 pipe-join: prev|op|actor|<payload>|created.
+CREATE OR REPLACE FUNCTION nexaas_memory.wal_hash_v2(
+  prev text, op text, actor text, payload jsonb, created text
+) RETURNS text LANGUAGE sql IMMUTABLE AS $func$
+  SELECT encode(
+    digest(prev || '|' || op || '|' || actor || '|' || payload::text || '|' || created, 'sha256'),
+    'hex'
+  )
+$func$;
+
+-- Flag the pre-#254 raw-CLI WAL writers (library/gdpr/propagate/seed) as
+-- integrity-exempt. Those rows were written by hand-rolled INSERTs with a
+-- bogus `sha256('<field-json>')` hash — never canonical under ANY version,
+-- and with no advisory lock. PR #254 routes those commands through appendWal
+-- so NEW rows are canonical v2; these EXISTING rows can't be recomputed, so
+-- verify treats them as linkage-only anchors (same as workspace_genesis and
+-- the 028 palace_mcp_write rows). Only rows that exist now are flagged; new
+-- appendWal-written rows of these ops default to not-exempt and verify.
+UPDATE nexaas_memory.wal
+   SET integrity_exempt = true
+ WHERE integrity_exempt = false
+   AND op IN (
+     'library_contribute', 'library_promote',
+     'library_propagate', 'proposal_accepted',
+     'gdpr_export', 'gdpr_delete', 'gdpr_redact',
+     'palace_seeded'
+   );

--- a/packages/cli/src/gdpr.ts
+++ b/packages/cli/src/gdpr.ts
@@ -11,6 +11,7 @@
 
 import { createHash, randomBytes, createCipheriv, createDecipheriv } from "crypto";
 import pg from "pg";
+import { appendWal, getPool } from "@nexaas/palace";
 
 export async function run(args: string[]) {
   const subcommand = args[0];
@@ -92,20 +93,13 @@ export async function run(args: string[]) {
         console.log(`  Operator record: yes (role: ${operator.rows[0].role})`);
       }
 
-      // Log the export
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'gdpr_export', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          workspace,
-          JSON.stringify({ subject_email: email, drawers_found: drawers.rows.length, wal_entries: walEntries.rows.length }),
-          "0".repeat(64),
-          `gdpr-export-${email}-${Date.now()}`,
-        ],
-      );
+      // Log the export — canonical, advisory-locked writer (#254).
+      await appendWal({
+        workspace,
+        op: "gdpr_export",
+        actor: "nexaas-cli",
+        payload: { subject_email: email, drawers_found: drawers.rows.length, wal_entries: walEntries.rows.length },
+      });
 
       console.log(`\n  Export logged to WAL.\n`);
       break;
@@ -169,25 +163,18 @@ export async function run(args: string[]) {
         [workspace, JSON.stringify({ email, deleted_at: new Date().toISOString() })],
       );
 
-      // WAL audit
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'gdpr_delete', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          workspace,
-          JSON.stringify({
-            subject_email: email,
-            keys_revoked: revoked.rows.length,
-            drawers_tombstoned: tombstoned.rows.length,
-            operator_disabled: disabled.rows.length > 0,
-          }),
-          "0".repeat(64),
-          `gdpr-delete-${email}-${Date.now()}`,
-        ],
-      );
+      // WAL audit — canonical, advisory-locked writer (#254).
+      await appendWal({
+        workspace,
+        op: "gdpr_delete",
+        actor: "nexaas-cli",
+        payload: {
+          subject_email: email,
+          keys_revoked: revoked.rows.length,
+          drawers_tombstoned: tombstoned.rows.length,
+          operator_disabled: disabled.rows.length > 0,
+        },
+      });
 
       console.log(`\n  ✓ Erasure complete. Logged to WAL.\n`);
       break;
@@ -303,4 +290,6 @@ export async function run(args: string[]) {
   }
 
   await pool.end();
+
+  await getPool().end().catch(() => {});
 }

--- a/packages/cli/src/library.ts
+++ b/packages/cli/src/library.ts
@@ -14,6 +14,7 @@ import { createHash } from "crypto";
 import { execSync } from "child_process";
 import { load as yamlLoad } from "js-yaml";
 import pg from "pg";
+import { appendWal, getPool } from "@nexaas/palace";
 
 function exec(cmd: string): string {
   try { return execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim(); } catch { return ""; }
@@ -149,20 +150,13 @@ export async function run(args: string[]) {
         ],
       );
 
-      // WAL entry
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'library_contribute', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          workspace,
-          JSON.stringify({ skill_id: manifest.id, version: manifest.version }),
-          "0".repeat(64),
-          `contribute-${manifest.id}-${Date.now()}`,
-        ],
-      );
+      // WAL entry — canonical, advisory-locked writer (#254).
+      await appendWal({
+        workspace,
+        op: "library_contribute",
+        actor: "nexaas-cli",
+        payload: { skill_id: manifest.id, version: manifest.version },
+      });
 
       console.log(`\n  ✓ Contributed: ${manifest.id} v${manifest.version} to the library`);
       console.log(`    Files: ${Object.keys(files).join(", ")}`);
@@ -309,20 +303,13 @@ export async function run(args: string[]) {
         ],
       );
 
-      // WAL entry
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'library_promote', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          workspace,
-          JSON.stringify({ skill_id: skillId, version: data.version }),
-          "0".repeat(64),
-          `promote-${skillId}-${Date.now()}`,
-        ],
-      );
+      // WAL entry — canonical, advisory-locked writer (#254).
+      await appendWal({
+        workspace,
+        op: "library_promote",
+        actor: "nexaas-cli",
+        payload: { skill_id: skillId, version: data.version },
+      });
 
       console.log(`\n  ✓ Promoted: ${skillId} v${data.version} → canonical`);
       console.log(`    This version is now the recommended baseline for all workspaces.\n`);
@@ -390,6 +377,8 @@ export async function run(args: string[]) {
   }
 
   await pool.end();
+
+  await getPool().end().catch(() => {});
 }
 
 function findSkillManifests(dir: string): Array<SkillManifest & { path: string }> {

--- a/packages/cli/src/propagate.ts
+++ b/packages/cli/src/propagate.ts
@@ -11,6 +11,7 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import pg from "pg";
+import { appendWal, getPool } from "@nexaas/palace";
 
 interface ProposalRow {
   id: number;
@@ -131,19 +132,12 @@ export async function run(args: string[]) {
         console.log(`\n  ✓ Created ${proposed} proposal(s)\n`);
       }
 
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'library_propagate', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          workspace,
-          JSON.stringify({ skill_id: skillId, version: libData.version, proposals_created: proposed }),
-          "0".repeat(64),
-          `propagate-${skillId}-${Date.now()}`,
-        ],
-      );
+      await appendWal({
+        workspace,
+        op: "library_propagate",
+        actor: "nexaas-cli",
+        payload: { skill_id: skillId, version: libData.version, proposals_created: proposed },
+      });
       break;
     }
 
@@ -184,19 +178,12 @@ export async function run(args: string[]) {
         [proposalId],
       );
 
-      await pool.query(
-        `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-         SELECT $1, 'proposal_accepted', 'nexaas-cli',
-           $2::jsonb,
-           COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-           encode(digest($4, 'sha256'), 'hex')`,
-        [
-          p.workspace,
-          JSON.stringify({ proposal_id: proposalId, skill_id: p.skill_id, version: libData.version }),
-          "0".repeat(64),
-          `accept-${proposalId}-${Date.now()}`,
-        ],
-      );
+      await appendWal({
+        workspace: p.workspace,
+        op: "proposal_accepted",
+        actor: "nexaas-cli",
+        payload: { proposal_id: proposalId, skill_id: p.skill_id, version: libData.version },
+      });
 
       console.log(`\n  ✓ Accepted proposal #${proposalId}`);
       console.log(`    Skill: ${p.skill_id} updated to v${libData.version}`);
@@ -236,6 +223,8 @@ export async function run(args: string[]) {
   }
 
   await pool.end();
+
+  await getPool().end().catch(() => {});
 }
 
 async function ensureProposalTable(pool: pg.Pool) {

--- a/packages/cli/src/seed-palace.ts
+++ b/packages/cli/src/seed-palace.ts
@@ -14,6 +14,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { join, basename, relative } from "path";
 import { createHash } from "crypto";
 import pg from "pg";
+import { appendWal, getPool } from "@nexaas/palace";
 
 interface SeedEntry {
   filePath: string;
@@ -255,22 +256,19 @@ export async function run(args: string[]) {
   console.log(`\n  Results: ${seeded} seeded, ${skipped} skipped (already in palace), ${errors} errors`);
 
   if (!dryRun && seeded > 0) {
-    await pool.query(
-      `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash)
-       SELECT $1, 'palace_seeded', 'nexaas-cli', $2::jsonb,
-         COALESCE((SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1), $3),
-         encode(digest($4, 'sha256'), 'hex')`,
-      [
-        workspace,
-        JSON.stringify({ files_seeded: seeded, files_skipped: skipped, errors }),
-        "0".repeat(64),
-        `seed-${Date.now()}`,
-      ],
-    );
+    // Canonical, advisory-locked writer (#254).
+    await appendWal({
+      workspace,
+      op: "palace_seeded",
+      actor: "nexaas-cli",
+      payload: { files_seeded: seeded, files_skipped: skipped, errors },
+    });
     console.log(`  WAL entry recorded\n`);
   } else {
     console.log("");
   }
 
   await pool.end();
+
+  await getPool().end().catch(() => {});
 }

--- a/packages/palace/src/wal.ts
+++ b/packages/palace/src/wal.ts
@@ -10,7 +10,16 @@ export interface WalEntry {
   signature?: Buffer;
 }
 
-function canonicalize(entry: WalEntry, createdAt: string, prevHash: string): string {
+/**
+ * v1 canonicalizer — RETAINED ONLY to verify pre-#254 rows (`canon_version`
+ * defaults to 1). It is buggy by design-fact: the `JSON.stringify(payload,
+ * sortedTopKeys)` replacer-array filters keys at every depth, so nested
+ * payload objects serialize as `{}` (nested tamper is invisible). We do NOT
+ * fix this — v1 rows were hashed with exactly this, and must be recomputed
+ * with exactly this to verify. New rows are written v2 (wal_hash_v2 in the
+ * DB, hashing over jsonb `payload::text`). See #254 / migration 029.
+ */
+function canonicalizeV1(entry: WalEntry, createdAt: string, prevHash: string): string {
   const parts = [prevHash, entry.op, entry.actor, JSON.stringify(entry.payload, Object.keys(entry.payload).sort()), createdAt];
   return parts.join("|");
 }
@@ -20,6 +29,9 @@ function computeHash(canonical: string): string {
 }
 
 const GENESIS_HASH = "0".repeat(64);
+
+/** Current canonicalization epoch new rows are written with. */
+const CANON_VERSION = 2;
 
 export async function appendWal(entry: WalEntry): Promise<void> {
   const maxRetries = 3;
@@ -50,26 +62,32 @@ export async function appendWal(entry: WalEntry): Promise<void> {
 
         const prevHash = prevResult.rows[0]?.hash ?? GENESIS_HASH;
         const createdAt = new Date().toISOString();
-        const canonical = canonicalize(entry, createdAt, prevHash);
-        const hash = computeHash(canonical);
 
-        const signedContentHash = entry.signature
-          ? computeHash(canonical)
-          : null;
-
+        // v2 hash (#254): computed in SQL by wal_hash_v2 over `payload::text`
+        // (jsonb's deterministic, fully-nested serialization) so the write-
+        // time and verify-time hash inputs are byte-identical by construction.
+        // The payload param ($4) is cast to jsonb and passed to the function;
+        // signed_content_hash mirrors the hash only when a signature is
+        // supplied (signing is scaffolding today — see verifyWalChain notes).
         await client.query(
           `INSERT INTO nexaas_memory.wal
-            (workspace, op, actor, payload, prev_hash, hash,
+            (workspace, op, actor, payload, prev_hash, hash, canon_version,
              signed_by_key_id, signature, signed_content_hash, created_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+           VALUES (
+             $1, $2, $3, $4::jsonb, $5,
+             nexaas_memory.wal_hash_v2($5, $2, $3, $4::jsonb, $6),
+             $7::smallint, $8, $9,
+             CASE WHEN $9::bytea IS NOT NULL
+                  THEN nexaas_memory.wal_hash_v2($5, $2, $3, $4::jsonb, $6)
+                  ELSE NULL END,
+             $6::timestamptz
+           )`,
           [
             entry.workspace, entry.op, entry.actor,
             JSON.stringify(entry.payload),
-            prevHash, hash,
+            prevHash, createdAt, CANON_VERSION,
             entry.signedByKeyId ?? null,
             entry.signature ?? null,
-            signedContentHash,
-            createdAt,
           ],
         );
       });
@@ -103,6 +121,12 @@ type WalVerifyRow = {
   hash: string;
   created_at: string;
   integrity_exempt: boolean;
+  canon_version: number;
+  // For canon_version >= 2, the DB recomputes the hash inline via
+  // wal_hash_v2 (over jsonb payload::text) so verification never has to
+  // reproduce jsonb's serialization in JS. NULL for v1 rows (recomputed in
+  // JS via canonicalizeV1 instead). See #254.
+  recomputed_v2: string | null;
 };
 
 export async function verifyWalChain(
@@ -125,7 +149,13 @@ export async function verifyWalChain(
       `SELECT id, op, actor, payload, prev_hash, hash,
               to_char(created_at AT TIME ZONE 'UTC',
                       'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at,
-              integrity_exempt
+              integrity_exempt, canon_version,
+              CASE WHEN canon_version >= 2
+                   THEN nexaas_memory.wal_hash_v2(
+                          prev_hash, op, actor, payload,
+                          to_char(created_at AT TIME ZONE 'UTC',
+                                  'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+                   ELSE NULL END AS recomputed_v2
        FROM nexaas_memory.wal
        WHERE workspace = $1 AND id > $2
        ORDER BY id ASC
@@ -167,32 +197,35 @@ function verifyBatch(
     }
 
     // Hash recomputation is skipped for two kinds of trust-anchor rows whose
-    // stored hash was provably not produced by canonicalize():
+    // stored hash was provably not produced by the canonicalizer:
     //   - `workspace_genesis`: written by `nexaas init` via raw SQL as the
     //     chain's root anchor (see #70).
-    //   - `integrity_exempt` rows: pre-#234 palace_mcp_write rows whose hash
-    //     was sha256('palace-write-'||ts), never canonical. Flagged by
-    //     migration 028. We never claimed integrity for them and won't
-    //     rewrite the append-only chain to fake it.
-    // Both still have their prev_hash *linkage* verified above; we only skip
-    // re-deriving their hash. Post-#234 palace_mcp_write rows are NOT exempt
-    // and are fully recomputed.
+    //   - `integrity_exempt` rows: pre-#234 palace_mcp_write (migration 028)
+    //     and pre-#254 raw-CLI writers (migration 029), whose stored hash was
+    //     never canonical under any version. We never claimed integrity for
+    //     them and won't rewrite the append-only chain to fake it.
+    // Everything else recomputes under the algorithm its `canon_version`
+    // declares: v2 rows (#254) are recomputed by the DB via wal_hash_v2
+    // (over jsonb payload::text — nested tamper is detected); v1 rows use the
+    // historical JS canonicalizeV1. Both still have prev_hash linkage checked
+    // above regardless.
     if (row.integrity_exempt) {
       exemptSkipped++;
     } else if (row.op !== "workspace_genesis") {
-      const canonical = canonicalize(
-        { workspace, op: row.op, actor: row.actor, payload: row.payload },
-        row.created_at,
-        row.prev_hash,
-      );
-      const recomputed = computeHash(canonical);
+      const recomputed = row.canon_version >= 2
+        ? row.recomputed_v2 ?? ""
+        : computeHash(canonicalizeV1(
+            { workspace, op: row.op, actor: row.actor, payload: row.payload },
+            row.created_at,
+            row.prev_hash,
+          ));
 
       if (recomputed !== row.hash) {
         return {
           broken: {
             valid: false,
             brokenAt: row.id,
-            error: `hash mismatch at id ${row.id}: expected ${recomputed}, got ${row.hash}`,
+            error: `hash mismatch at id ${row.id} (canon v${row.canon_version}): expected ${recomputed}, got ${row.hash}`,
           },
           exemptSkipped,
         };

--- a/scripts/test-wal-canon-254.mjs
+++ b/scripts/test-wal-canon-254.mjs
@@ -1,0 +1,77 @@
+// Regression harness for #254 — WAL canonicalization v2.
+// Proves: v2 hashes nested payloads (nested tamper detected), v1 legacy rows
+// still verify, mixed v1/v2 chains verify, exempt rows skip, top-level tamper
+// still caught. Run: DATABASE_URL=... node --import tsx scripts/test-wal-canon-254.mjs
+import { createHash } from "crypto";
+import pg from "pg";
+import { applyPendingMigrations } from "../packages/cli/src/migrations.js";
+import { appendWal, verifyWalChain, createPool, sql } from "../packages/palace/src/index.js";
+
+let pass = 0, fail = 0;
+const ok = (c, m) => { if (c) { pass++; console.log("  ✓", m); } else { fail++; console.log("  ✗", m); } };
+
+const WS = "walcanon";
+const migPool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 2 });
+await applyPendingMigrations(migPool, "/opt/nexaas", () => {});
+// confirm 029 landed
+const col = await migPool.query(`SELECT 1 FROM information_schema.columns WHERE table_schema='nexaas_memory' AND table_name='wal' AND column_name='canon_version'`);
+ok(col.rowCount === 1, "migration 029: canon_version column exists");
+const fn = await migPool.query(`SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='nexaas_memory' AND p.proname='wal_hash_v2'`);
+ok(fn.rowCount === 1, "migration 029: wal_hash_v2 function exists");
+await migPool.end();
+createPool();
+
+// 1. v2 write with a NESTED payload, verify clean
+await appendWal({ workspace: WS, op: "seed", actor: "t", payload: { n: 1 } });
+await appendWal({ workspace: WS, op: "invoice", actor: "t", payload: { meta: { amount: 9999, vendor: "acme" }, top: "x" } });
+await appendWal({ workspace: WS, op: "seed", actor: "t", payload: { n: 2 } });
+let v = await verifyWalChain(WS);
+ok(v.valid, "v2 chain with nested payloads verifies clean");
+const cv = await sql(`SELECT DISTINCT canon_version FROM nexaas_memory.wal WHERE workspace=$1`, [WS]);
+ok(cv.length === 1 && Number(cv[0].canon_version) === 2, "appendWal stamps canon_version=2");
+
+// 2. THE SECURITY FIX — tamper a NESTED field, verify must break at that row
+const inv = (await sql(`SELECT id FROM nexaas_memory.wal WHERE workspace=$1 AND op='invoice'`, [WS]))[0].id;
+await sql(`UPDATE nexaas_memory.wal SET payload = jsonb_set(payload, '{meta,amount}', '1') WHERE id=$1`, [inv]);
+v = await verifyWalChain(WS);
+ok(v.valid === false && String(v.brokenAt) === String(inv), "NESTED tamper detected (v2) — the #254 fix");
+// restore
+await sql(`UPDATE nexaas_memory.wal SET payload = jsonb_set(payload, '{meta,amount}', '9999') WHERE id=$1`, [inv]);
+ok((await verifyWalChain(WS)).valid, "restore → verifies again");
+
+// 3. v1 legacy row still verifies (mixed chain). Insert a row exactly as old appendWal did.
+const prev = (await sql(`SELECT hash FROM nexaas_memory.wal WHERE workspace=$1 ORDER BY id DESC LIMIT 1`, [WS]))[0].hash;
+const created = "2026-07-02T10:00:00.000Z";
+const payloadV1 = { b: 2, a: 1 };
+const canonV1 = [prev, "legacy_op", "t", JSON.stringify(payloadV1, Object.keys(payloadV1).sort()), created].join("|");
+const hashV1 = createHash("sha256").update(canonV1).digest("hex");
+await sql(`INSERT INTO nexaas_memory.wal (workspace,op,actor,payload,prev_hash,hash,canon_version,created_at) VALUES ($1,'legacy_op','t',$2::jsonb,$3,$4,1,$5::timestamptz)`,
+  [WS, JSON.stringify(payloadV1), prev, hashV1, created]);
+v = await verifyWalChain(WS);
+ok(v.valid, "mixed chain: v1 legacy row verifies under canonicalizeV1");
+// append another v2 AFTER the v1 row — chain continues
+await appendWal({ workspace: WS, op: "after_legacy", actor: "t", payload: { ok: true } });
+ok((await verifyWalChain(WS)).valid, "v2 row appended after v1 row — chain intact");
+
+// 4. exempt: a pre-029 bogus CLI row (bogus hash) breaks verify unless flagged
+const prev2 = (await sql(`SELECT hash FROM nexaas_memory.wal WHERE workspace=$1 ORDER BY id DESC LIMIT 1`, [WS]))[0].hash;
+const bogus = await sql(`INSERT INTO nexaas_memory.wal (workspace,op,actor,payload,prev_hash,hash,canon_version) VALUES ($1,'library_contribute','nexaas-cli','{"x":1}'::jsonb,$2,encode(digest('bogus','sha256'),'hex'),1) RETURNING id`, [WS, prev2]);
+const bogusId = bogus[0].id;
+v = await verifyWalChain(WS);
+ok(v.valid === false && String(v.brokenAt) === String(bogusId), "unflagged bogus CLI row breaks verify");
+await sql(`UPDATE nexaas_memory.wal SET integrity_exempt=true WHERE id=$1`, [bogusId]);
+v = await verifyWalChain(WS);
+ok(v.valid && v.exemptSkipped >= 1, "flagged exempt (as migration 029 does) → skipped, chain valid");
+
+// 5. C1: appendWal-written library_contribute (v2) verifies (not exempt)
+await appendWal({ workspace: WS, op: "library_contribute", actor: "nexaas-cli", payload: { skill_id: "marketing/x", version: "1.0.0" } });
+ok((await verifyWalChain(WS)).valid, "new appendWal library_contribute (v2) verifies");
+
+// 6. top-level tamper still caught (v2)
+const last = (await sql(`SELECT id FROM nexaas_memory.wal WHERE workspace=$1 ORDER BY id DESC LIMIT 1`, [WS]))[0].id;
+await sql(`UPDATE nexaas_memory.wal SET payload = jsonb_set(payload, '{version}', '"9.9.9"') WHERE id=$1`, [last]);
+v = await verifyWalChain(WS);
+ok(v.valid === false && String(v.brokenAt) === String(last), "top-level tamper still detected (v2)");
+
+console.log(`\n  ${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #254 (H1 of the framework-hardening v2 umbrella #253).

## The bug
The v1 WAL canonicalizer hashed payloads with `JSON.stringify(payload, Object.keys(payload).sort())`. A **replacer array is a key allowlist applied at every depth**, so any nested object serialized as `{}`. Consequences:
- Nested WAL payload fields could be mutated in the DB with **no change to the hash** — tamper-invisible.
- Verification was self-consistent (it dropped the same nested data at recompute time), so 8.9M+ Phoenix rows never surfaced it.
- Top-level numbers JS renders in exponent form also mis-hashed.

## The fix (no append-only rewrite — #234/028 playbook)
- **Migration 029**: additive `canon_version smallint` (existing rows default to `1`) + `nexaas_memory.wal_hash_v2(prev, op, actor, payload jsonb, created)` — one `IMMUTABLE` SQL function used by **both** writer and verifier, hashing over `payload::text` (jsonb's deterministic, fully-nested, number-normalized serialization). Write-time and verify-time inputs are byte-identical by construction; nested tamper now changes `payload::text` and is caught.
- **wal.ts**: `appendWal` writes v2 (hash computed in SQL). `verifyWalChain` recomputes v2 rows via `wal_hash_v2` inline, keeps `canonicalizeV1` for pre-#254 rows under their historical (buggy-as-written) algorithm. Mixed v1/v2 chains verify; `prev_hash` linkage checked for every row.
- **CLI raw writers** (library/propagate/gdpr/seed) now route through `appendWal` → canonical v2 hashes + per-workspace advisory lock (#71) instead of hand-rolled `sha256('<field-json>')` inserts. Migration 029 marks their pre-existing rows `integrity_exempt` (linkage-only anchors, same treatment as `workspace_genesis` and the 028 `palace_mcp_write` rows).

## Verification
- `scripts/test-wal-canon-254.mjs` — 12/12: **nested tamper detected**, v1 legacy + mixed v1/v2 chains verify, exempt-skip, top-level tamper.
- Full `nexaas conformance` **10 passed / 0 failed** on a scratch worker — `wal-chain (full)` valid after live shell-roundtrip, ai-pillar (WAL audit), and waitpoint-roundtrip v2 writes.

## Rollback
Safe to roll back to pre-029 code, but pre-029 verify recomputes everything under v1 and will flag v2 rows broken — the `canon_version` column is the guard, so **do not run pre-029 verify against a v2-written chain**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)