### PR TITLE
engine: fail loudly on auto_execute external_send/mcp_tool_call (phantom-send fix)

### DIFF
--- a/packages/runtime/src/engine/apply.ts
+++ b/packages/runtime/src/engine/apply.ts
@@ -159,10 +159,40 @@ export async function apply(
         break;
       }
 
-      // Default path — non-notification kinds write to events.skill.executed
-      // as before. Palace_write / external_send / mcp_tool_call / etc. go
-      // through this branch; future stages add their own kind-specific
-      // routing if needed.
+      // Delivery-bearing kinds have NO delivery adapter in the engine yet.
+      // Recording them in events.skill.executed and returning success made
+      // agents believe a customer send happened when nothing was dispatched
+      // (phantom-send incident 2026-07-08: ops/ticket-review emitted
+      // send_ticket_reply for a week; every "sent" reply silently vanished
+      // while runs completed green). Fail loudly instead: the
+      // framework__produce_output handler catches this and returns
+      // ok:false to the agent mid-loop, so it can deliver via a direct MCP
+      // tool call or escalate; a primary_output of these kinds fails the
+      // run with this message as the error summary.
+      if (action.output_kind === "external_send" || action.output_kind === "mcp_tool_call") {
+        await appendWal({
+          workspace,
+          op: "action_delivery_unimplemented",
+          actor: `skill:${session.ctx.skillId}`,
+          payload: {
+            run_id: runId,
+            step_id: stepId,
+            action_kind: action.action.kind,
+            output_kind: action.output_kind,
+            source: action.source,
+          },
+        });
+        throw new Error(
+          `auto_execute has no delivery adapter for output kind '${action.output_kind}' ` +
+          `('${action.action.kind}') — NOTHING was sent. Deliver via a direct MCP tool ` +
+          `call in the agentic loop (and verify the tool result), or route this output ` +
+          `through an approval handler skill that performs the send.`,
+        );
+      }
+
+      // Default path — remaining kinds (palace_write, custom kinds) write to
+      // events.skill.executed as before; the drawer write IS the execution
+      // for those. Future stages add their own kind-specific routing.
       await session.writeDrawer(
         { wing: "events", hall: "skill", room: "executed" },
         JSON.stringify({


### PR DESCRIPTION
## Problem

`apply()`'s `auto_execute` default branch treats **delivery-bearing output kinds as executed when nothing was delivered**. For `external_send` / `mcp_tool_call` it writes a drawer to `events.skill.executed`, logs `action_auto_executed`, and returns success — but the engine has no delivery adapter for these kinds, so nothing is dispatched. `framework__produce_output` then returns `ok: true` to the agent, which reasonably reports the send as done.

**Real-world impact (systemsaholic workspace, Jul 2–8):** `ops/ticket-review` emitted `send_ticket_reply` (external_send, auto_execute) per its prompt for a week. Every one of those customer replies — including a password delivery and an outage-resolved notice — silently vanished into `events.skill.executed` while runs completed green and FreeScout notes claimed "reply sent". It was only caught because a customer-facing gap was noticed by a human. The skill's Jul 2 end-to-end test passed only because the model happened to call the FreeScout MCP tool directly on that run.

## Fix

In the `auto_execute` case, `external_send` and `mcp_tool_call` now:
1. append WAL op `action_delivery_unimplemented` (audit trail of the refusal), and
2. **throw** with an actionable message ("NOTHING was sent — deliver via a direct MCP tool call… or route through an approval handler skill").

Downstream this is loud in every path:
- `framework__produce_output` already catches apply() errors → the agent gets `ok: false` **mid-loop** and can deliver via a direct MCP call or escalate.
- `primary_output` auto-map (ai-skill.ts) → run fails with the message as error summary.
- pillar pipeline (pipeline.ts) → existing catch marks the step failed and rethrows.

`palace_write` and custom kinds keep the current drawer-write behavior — for those, the drawer **is** the execution.

## Notes for reviewers

- No behavior change for `notification`, `chain_signal`, `approval_required`, `escalate`, `flag`, `defer`.
- Skills that emit these kinds purely as "audit records" after sending manually will start seeing `ok:false` on the emission; they should record audit info via their room drawer / a `palace_write`-kind output instead. (We've already adjusted `ops/ticket-review` on our side.)
- The long-term fix is a real delivery adapter registry for `external_send`/`mcp_tool_call`; this PR just removes the silent-success failure mode until that exists.
- `npm -w @nexaas/runtime` typecheck (`tsc --noEmit`) is clean; no test suite exists for this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-executed delivery actions that aren’t supported now fail clearly instead of appearing to succeed.
  * This prevents misleading “sent” behavior for certain output types and surfaces an error directing the action to the proper handling path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->