### PR TITLE
feat(ci): PR-time verification — workflow, vitest, harness bridge, unit tests (#257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+# PR-time verification (#257, H4 of #253). Two jobs:
+#
+#   build — npm ci + full workspace build (strict tsc) + noEmit typecheck
+#           sweep. Catches the v0.3.5 class (changelog claimed a fix whose
+#           code never compiled anywhere) and type drift in workspaces the
+#           build never touched (palace MCP).
+#
+#   test  — vitest: 43+ unit tests (tests/*.test.ts) plus every
+#           scripts/test-*.mjs regression harness via the
+#           tests/harnesses.test.ts bridge. The pgvector+redis services
+#           unlock the DB-gated harnesses (WAL canon v2, PA delivery,
+#           waitpoint matching, ...) against a fully-migrated scratch DB.
+#
+# `nexaas conformance` stays the *deployment* gate on real workspaces; this
+# is the *development* gate that runs before code ever reaches a release.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # pgvector image: migrations 010/012 CREATE EXTENSION pg_trgm,
+        # vector, pgcrypto — service user is superuser so all three apply.
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nexaas_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/nexaas_ci
+      REDIS_URL: redis://localhost:6379
+      NEXAAS_WORKSPACE: ci
+      NEXAAS_ROOT: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Apply framework migrations to scratch DB
+        run: node --import tsx scripts/ci-migrate.mjs
+      - run: npm test

--- a/integrations/email-provider-postmark/package.json
+++ b/integrations/email-provider-postmark/package.json
@@ -16,7 +16,8 @@
     "nexaas-integration.yaml"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"

--- a/integrations/email-provider-resend/package.json
+++ b/integrations/email-provider-resend/package.json
@@ -16,7 +16,8 @@
     "nexaas-integration.yaml"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"

--- a/integrations/email-provider-sendgrid/package.json
+++ b/integrations/email-provider-sendgrid/package.json
@@ -16,7 +16,8 @@
     "nexaas-integration.yaml"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@nexaas/integration-sdk": "0.1.0"

--- a/mcp/servers/email-outbound/package.json
+++ b/mcp/servers/email-outbound/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/mcp-email-outbound",
   "version": "0.1.0",
-  "description": "Outbound email MCP server — implements the email-outbound capability (#78). Provider-pluggable; ships with Resend, Postmark, and SendGrid.",
+  "description": "Outbound email MCP server \u2014 implements the email-outbound capability (#78). Provider-pluggable; ships with Resend, Postmark, and SendGrid.",
   "type": "module",
   "exports": {
     ".": {
@@ -11,7 +11,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp/servers/palace/package.json
+++ b/mcp/servers/palace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/mcp-palace",
   "version": "0.1.0",
-  "description": "Palace MCP server — gives any Claude session live access to the Nexaas memory palace",
+  "description": "Palace MCP server \u2014 gives any Claude session live access to the Nexaas memory palace",
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
@@ -9,5 +9,8 @@
     "@nexaas/palace": "^0.1.0",
     "pg": "^8.20.0",
     "zod": "^3.23.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/mcp/servers/palace/tsconfig.json
+++ b/mcp/servers/palace/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/mcp/servers/webstudio/package.json
+++ b/mcp/servers/webstudio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/mcp-webstudio",
   "version": "0.1.0",
-  "description": "Web Studio MCP server (#148) — file-tool surface for the PA-driven edit loop. Five tools (list_files, read_file, write_file, grep, diff) scoped to a single working copy via WEBSTUDIO_REPO_ROOT.",
+  "description": "Web Studio MCP server (#148) \u2014 file-tool surface for the PA-driven edit loop. Five tools (list_files, read_file, write_file, grep, diff) scoped to a single working copy via WEBSTUDIO_REPO_ROOT.",
   "type": "module",
   "exports": {
     ".": {
@@ -11,7 +11,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
       ],
       "devDependencies": {
         "@changesets/cli": "^2.27.0",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "vitest": "^4.1.10"
       }
     },
     "integrations/email-provider-postmark": {
@@ -695,6 +696,40 @@
         "prettier": "^2.7.1"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -1194,6 +1229,13 @@
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -1684,6 +1726,25 @@
         "win32"
       ]
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nexaas/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -1770,6 +1831,298 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1781,6 +2134,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1790,6 +2154,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -1894,6 +2272,119 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abort-controller": {
@@ -2008,6 +2499,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2117,6 +2618,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -2165,6 +2676,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -2284,8 +2802,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2376,6 +2894,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2465,6 +2990,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2502,6 +3037,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -3168,6 +3713,267 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3213,6 +4019,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3355,6 +4171,25 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -3444,6 +4279,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -3635,6 +4484,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -3761,6 +4617,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postgres-array": {
@@ -4018,6 +4903,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -4273,6 +5192,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4294,6 +5220,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/spawndamnit": {
@@ -4323,6 +5259,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -4337,6 +5280,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -4372,6 +5322,81 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4517,6 +5542,200 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -4555,6 +5774,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nexaas",
   "version": "0.1.0",
   "private": true,
-  "description": "Nexaas — framework for context-aware AI execution",
+  "description": "Nexaas \u2014 framework for context-aware AI execution",
   "type": "module",
   "workspaces": [
     "packages/*",
@@ -18,7 +18,8 @@
     "verify-wal": "npm -w @nexaas/cli run verify-wal",
     "validate-skill": "npm -w @nexaas/cli run validate-skill",
     "changeset": "changeset",
-    "release": "changeset version"
+    "release": "changeset version",
+    "test": "vitest run"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/cli",
   "version": "0.1.0",
-  "description": "Nexaas CLI tools — verify-wal, validate-skill, install-agent, rebuild-skill-runs, dry-run",
+  "description": "Nexaas CLI tools \u2014 verify-wal, validate-skill, install-agent, rebuild-skill-runs, dry-run",
   "type": "module",
   "exports": {
     ".": {
@@ -14,7 +14,8 @@
     "nexaas": "src/index.ts"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@nexaas/palace": "^0.1.0",

--- a/packages/integration-sdk/package.json
+++ b/packages/integration-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/integration-sdk",
   "version": "0.1.0",
-  "description": "Authoring kit for Nexaas integrations — manifest schema, capability contracts, and shared helpers used by all integration packages (reference + adopter).",
+  "description": "Authoring kit for Nexaas integrations \u2014 manifest schema, capability contracts, and shared helpers used by all integration packages (reference + adopter).",
   "type": "module",
   "exports": {
     ".": {
@@ -11,7 +11,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "zod": "^3.23.0"

--- a/packages/palace/package.json
+++ b/packages/palace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/palace",
   "version": "0.1.0",
-  "description": "Palace substrate — data model, palace API, WAL, signing, verification, pgvector retrieval",
+  "description": "Palace substrate \u2014 data model, palace API, WAL, signing, verification, pgvector retrieval",
   "type": "module",
   "exports": {
     ".": {
@@ -11,7 +11,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "pg": "^8.20.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nexaas/runtime",
   "version": "0.1.0",
-  "description": "Pillar pipeline runtime — CAG, RAG, TAG, model gateway, BullMQ execution, sub-agents, Bull Board dashboard",
+  "description": "Pillar pipeline runtime \u2014 CAG, RAG, TAG, model gateway, BullMQ execution, sub-agents, Bull Board dashboard",
   "type": "module",
   "exports": {
     ".": {
@@ -11,7 +11,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/scripts/ci-migrate.mjs
+++ b/scripts/ci-migrate.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * CI helper: apply all framework migrations to $DATABASE_URL and exit
+ * non-zero on any failure. The DB-gated harnesses in scripts/ (see
+ * tests/harnesses.test.ts) expect a fully-migrated scratch database; CI
+ * runs this once before `vitest run`.
+ *
+ * NOTE applyPendingMigrations reports failure via `result.failed` — it does
+ * not throw (callers decide how fatal failures surface). Ignoring the return
+ * value silently truncates the schema at the first failing migration.
+ */
+import pg from "pg";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { applyPendingMigrations } from "../packages/cli/src/migrations.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL required");
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 2 });
+const result = await applyPendingMigrations(pool, root);
+await pool.end();
+
+if (result.failed) {
+  console.error(`\n✗ migration ${result.failed.filename} failed: ${result.failed.error}`);
+  process.exit(1);
+}
+console.log(`\n✓ migrations complete (${result.applied.length} applied, ${result.legacyResolved.length} legacy-resolved)`);

--- a/scripts/test-approval-render-93.mjs
+++ b/scripts/test-approval-render-93.mjs
@@ -48,7 +48,8 @@ function assert(cond, label) {
   assert(r.content.includes("<b>Subject:</b> Re: Friday tasting"), "email-shape: Subject label");
   assert(r.content.includes("<blockquote>Hi Joanne"), "email-shape: body wrapped in blockquote");
   assert(!r.content.includes("<pre>"), "email-shape: no <pre> block");
-  assert(r.content.startsWith("Mireille drafted a reply"), "email-shape: summary leads");
+  // eaf7b78 bolds the summary lead
+  assert(r.content.startsWith("<b>Mireille drafted a reply"), "email-shape: summary leads (bolded)");
   assert(r.inline_buttons?.length === 3, "email-shape: 3 inline_buttons");
   assert(r.inline_buttons?.[0]?.button_id === "approve", "email-shape: button_id matches decision id");
   assert(r.inline_buttons?.[0]?.text === "Approve", "email-shape: button text matches decision label");

--- a/scripts/test-pa-delivery.mjs
+++ b/scripts/test-pa-delivery.mjs
@@ -13,19 +13,24 @@
  *
  * Run:
  *   DATABASE_URL=postgresql://nexaas_test:test@127.0.0.1/pa_delivery_test \
- *     NEXAAS_PA_MAX_RETRIES=2 \
  *     node --import tsx scripts/test-pa-delivery.mjs
  */
 
-import {
+import { randomUUID } from "crypto";
+
+// The retry-exhaustion assertions assume MAX=2. delivery.ts captures
+// NEXAAS_PA_MAX_RETRIES into a module const at load, and static imports
+// hoist above assignments — so pin the env here and dynamic-import after.
+process.env.NEXAAS_PA_MAX_RETRIES = "2";
+
+const {
   enqueueDelivery,
   claimNextDelivery,
   markDeliverySent,
   markDeliveryFailed,
   reapStaleDeliveryClaims,
-} from "../packages/runtime/src/pa/delivery.ts";
-import { sql, getPool } from "../packages/palace/src/db.ts";
-import { randomUUID } from "crypto";
+} = await import("../packages/runtime/src/pa/delivery.ts");
+const { sql, getPool } = await import("../packages/palace/src/db.ts");
 
 const WORKSPACE = `test-${Date.now()}`;
 let pass = 0;
@@ -69,8 +74,8 @@ async function opsAlertCount(workspace) {
 console.log("\n1. enqueueDelivery is idempotent");
 {
   const drawer = await insertDrawer(WORKSPACE, "alice", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "alice", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "alice", "inbox");
+  await enqueueDelivery(WORKSPACE, drawer, "alice", "inbox", "immediate");
+  await enqueueDelivery(WORKSPACE, drawer, "alice", "inbox", "immediate");
   const rows = await sql(
     `SELECT COUNT(*)::text AS n FROM nexaas_memory.pa_delivery_marker
        WHERE workspace = $1 AND drawer_id = $2`,
@@ -78,7 +83,9 @@ console.log("\n1. enqueueDelivery is idempotent");
   );
   assert(Number(rows[0].n) === 1, "re-enqueue with same drawer_id is no-op (one row total)");
   const s = await statusOf(WORKSPACE, drawer);
-  assert(s.status === "queued", `status starts as 'queued' (got ${s.status})`);
+  // #191/#206: fresh markers write status=NULL (LEFT-JOIN-NULL eligibility);
+  // 'queued' survives only on legacy rows.
+  assert(s.status === null, `status starts as NULL post-#191 (got ${s.status})`);
 }
 
 // ── 2. Per-thread serialization via SKIP LOCKED ──────────────────────
@@ -86,8 +93,8 @@ console.log("\n2. Concurrent claims for the SAME thread serialize");
 {
   const d1 = await insertDrawer(WORKSPACE, "bob", "inbox");
   const d2 = await insertDrawer(WORKSPACE, "bob", "inbox");
-  await enqueueDelivery(WORKSPACE, d1, "bob", "inbox");
-  await enqueueDelivery(WORKSPACE, d2, "bob", "inbox");
+  await enqueueDelivery(WORKSPACE, d1, "bob", "inbox", "immediate");
+  await enqueueDelivery(WORKSPACE, d2, "bob", "inbox", "immediate");
 
   const [a, b] = await Promise.all([
     claimNextDelivery(WORKSPACE, "bob", "inbox"),
@@ -107,8 +114,8 @@ console.log("\n3. Different threads claim independently");
 {
   const d1 = await insertDrawer(WORKSPACE, "carol", "inbox");
   const d2 = await insertDrawer(WORKSPACE, "carol", "hr");
-  await enqueueDelivery(WORKSPACE, d1, "carol", "inbox");
-  await enqueueDelivery(WORKSPACE, d2, "carol", "hr");
+  await enqueueDelivery(WORKSPACE, d1, "carol", "inbox", "immediate");
+  await enqueueDelivery(WORKSPACE, d2, "carol", "hr", "immediate");
 
   const [inbox, hr] = await Promise.all([
     claimNextDelivery(WORKSPACE, "carol", "inbox"),
@@ -122,7 +129,7 @@ console.log("\n3. Different threads claim independently");
 console.log("\n4. markDeliverySent records channel_message_id and sent_at");
 {
   const drawer = await insertDrawer(WORKSPACE, "dave", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "dave", "inbox");
+  await enqueueDelivery(WORKSPACE, drawer, "dave", "inbox", "immediate");
   const claim = await claimNextDelivery(WORKSPACE, "dave", "inbox");
   await markDeliverySent(claim, "telegram-msg-12345");
   const s = await statusOf(WORKSPACE, drawer);
@@ -143,7 +150,7 @@ console.log("\n5. markDeliveryFailed cycles back to 'failed' below retry thresho
   // (status='failed', re-claimable); second failure is retries=2
   // (terminal 'dead').
   const drawer = await insertDrawer(WORKSPACE, "eve", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "eve", "inbox");
+  await enqueueDelivery(WORKSPACE, drawer, "eve", "inbox", "immediate");
 
   // First attempt fails.
   const c1 = await claimNextDelivery(WORKSPACE, "eve", "inbox");
@@ -176,7 +183,7 @@ console.log("\n6. Dead delivery emits an ops_alert row");
 console.log("\n7. Reaper resets stale 'claimed' rows back to 'failed'");
 {
   const drawer = await insertDrawer(WORKSPACE, "frank", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "frank", "inbox");
+  await enqueueDelivery(WORKSPACE, drawer, "frank", "inbox", "immediate");
   const claim = await claimNextDelivery(WORKSPACE, "frank", "inbox");
   assert(claim !== null, "claim succeeded");
 
@@ -203,7 +210,7 @@ console.log("\n7. Reaper resets stale 'claimed' rows back to 'failed'");
 console.log("\n8. Rows at MAX_RETRIES are not re-claimable");
 {
   const drawer = await insertDrawer(WORKSPACE, "grace", "inbox");
-  await enqueueDelivery(WORKSPACE, drawer, "grace", "inbox");
+  await enqueueDelivery(WORKSPACE, drawer, "grace", "inbox", "immediate");
   await sql(
     `UPDATE nexaas_memory.pa_delivery_marker
         SET retries = 2, status = 'failed'

--- a/scripts/test-wal-canon-254.mjs
+++ b/scripts/test-wal-canon-254.mjs
@@ -11,8 +11,14 @@ let pass = 0, fail = 0;
 const ok = (c, m) => { if (c) { pass++; console.log("  ✓", m); } else { fail++; console.log("  ✗", m); } };
 
 const WS = "walcanon";
+const repoRoot = new URL("..", import.meta.url).pathname;
 const migPool = new pg.Pool({ connectionString: process.env.DATABASE_URL, max: 2 });
-await applyPendingMigrations(migPool, "/opt/nexaas", () => {});
+// applyPendingMigrations reports failure via result.failed, it does NOT throw
+const mig = await applyPendingMigrations(migPool, repoRoot, () => {});
+if (mig.failed) {
+  console.error(`migration ${mig.failed.filename} failed: ${mig.failed.error}`);
+  process.exit(1);
+}
 // confirm 029 landed
 const col = await migPool.query(`SELECT 1 FROM information_schema.columns WHERE table_schema='nexaas_memory' AND table_name='wal' AND column_name='canon_version'`);
 ok(col.rowCount === 1, "migration 029: canon_version column exists");

--- a/tests/bearer-auth.test.ts
+++ b/tests/bearer-auth.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the cross-VPS bearer-token middleware (#53/#217) — one of
+ * the critical-function coverage gaps from #257. Exercises the three env
+ * postures (unset = open, set = enforced, rotation dual-accept) against a
+ * mock express req/res.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { bearerAuth } from "../packages/runtime/src/middleware/bearer-auth.js";
+
+const TOKEN_ENV = "NEXAAS_CROSS_VPS_BEARER_TOKEN";
+const PREV_ENV = "NEXAAS_CROSS_VPS_BEARER_TOKEN_PREVIOUS";
+
+afterEach(() => {
+  delete process.env[TOKEN_ENV];
+  delete process.env[PREV_ENV];
+});
+
+type Res = {
+  statusCode: number | null;
+  body: unknown;
+  status(code: number): Res;
+  json(payload: unknown): Res;
+};
+
+function invoke(authHeader?: string): { nexted: boolean; res: Res } {
+  const middleware = bearerAuth();
+  const req = {
+    header: (name: string) =>
+      name.toLowerCase() === "authorization" ? authHeader : undefined,
+  };
+  const res: Res = {
+    statusCode: null,
+    body: null,
+    status(code: number) { this.statusCode = code; return this; },
+    json(payload: unknown) { this.body = payload; return this; },
+  };
+  let nexted = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  middleware(req as any, res as any, () => { nexted = true; });
+  return { nexted, res };
+}
+
+describe("bearerAuth — token unset (direct-adopter posture)", () => {
+  it("passes every request through", () => {
+    const { nexted, res } = invoke(undefined);
+    expect(nexted).toBe(true);
+    expect(res.statusCode).toBeNull();
+  });
+});
+
+describe("bearerAuth — token set", () => {
+  it("accepts the correct token", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted } = invoke("Bearer secret-token");
+    expect(nexted).toBe(true);
+  });
+
+  it("401s a missing Authorization header", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted, res } = invoke(undefined);
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("401s a non-Bearer scheme", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted, res } = invoke("Basic secret-token");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("401s a wrong token of the same length", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted, res } = invoke("Bearer secret-tokeX");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("401s a wrong-length token without throwing (timingSafeEqual guard)", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted, res } = invoke("Bearer short");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("401s an empty bearer value", () => {
+    process.env[TOKEN_ENV] = "secret-token";
+    const { nexted, res } = invoke("Bearer ");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("bearerAuth — rotation dual-accept (#217)", () => {
+  it("accepts the previous token during the rotation window", () => {
+    process.env[TOKEN_ENV] = "new-token";
+    process.env[PREV_ENV] = "old-token";
+    expect(invoke("Bearer old-token").nexted).toBe(true);
+    expect(invoke("Bearer new-token").nexted).toBe(true);
+  });
+
+  it("still rejects a token matching neither", () => {
+    process.env[TOKEN_ENV] = "new-token";
+    process.env[PREV_ENV] = "old-token";
+    const { nexted, res } = invoke("Bearer stale-token");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects the old token once _PREVIOUS is removed (rotation complete)", () => {
+    process.env[TOKEN_ENV] = "new-token";
+    const { nexted, res } = invoke("Bearer old-token");
+    expect(nexted).toBe(false);
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/harnesses.test.ts
+++ b/tests/harnesses.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Bridge: runs every `scripts/test-*.mjs` regression harness under vitest
+ * so CI executes them on each PR (#257). The harnesses predate the test
+ * runner — each is a standalone assert-and-exit script (exit 0 = pass) that
+ * stays runnable directly (`node --import tsx scripts/test-x.mjs`) for
+ * issue-repro workflows. New harnesses dropped into scripts/ are picked up
+ * automatically; prefer writing new coverage as plain vitest tests in
+ * tests/ instead.
+ *
+ * Classification is by file content, not a hardcoded list:
+ *   - references DATABASE_URL / pg pools  → needs a migrated scratch
+ *     Postgres; skipped unless DATABASE_URL is set (CI provides one; never
+ *     point this at a production database — harnesses INSERT/UPDATE freely)
+ *   - references REDIS_URL / bullmq       → additionally needs REDIS_URL
+ */
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "vitest";
+
+const ROOT = join(__dirname, "..");
+const SCRIPTS = join(ROOT, "scripts");
+
+const DB_RE = /DATABASE_URL|new pg\.|createPool|getPool/;
+const REDIS_RE = /REDIS_URL|ioredis|bullmq/;
+
+const harnesses = readdirSync(SCRIPTS)
+  .filter((f) => /^test-.*\.mjs$/.test(f))
+  .sort()
+  .map((file) => {
+    const src = readFileSync(join(SCRIPTS, file), "utf-8");
+    return { file, db: DB_RE.test(src), redis: REDIS_RE.test(src) };
+  });
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+const hasRedis = Boolean(process.env.REDIS_URL);
+
+function runHarness(file: string): void {
+  try {
+    execFileSync("node", ["--import", "tsx", join(SCRIPTS, file)], {
+      cwd: ROOT,
+      stdio: "pipe",
+      timeout: 110_000,
+      env: process.env,
+    });
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer; status?: number };
+    throw new Error(
+      `${file} exited ${e.status}\n--- stdout ---\n${e.stdout ?? ""}\n--- stderr ---\n${e.stderr ?? ""}`,
+    );
+  }
+}
+
+describe("scripts/ regression harnesses", () => {
+  for (const h of harnesses) {
+    const skip = (h.db && !hasDb) || (h.redis && !hasRedis);
+    it.skipIf(skip)(
+      `${h.file}${h.db ? " [db]" : ""}${h.redis ? " [redis]" : ""}`,
+      () => runHarness(h.file),
+    );
+  }
+});

--- a/tests/model-registry.test.ts
+++ b/tests/model-registry.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for tier resolution + spend math (models/registry.ts) —
+ * critical-function coverage from #257. Also loads the real
+ * capabilities/model-registry.yaml as a shape guard so yaml drift
+ * (missing tier, renamed key) fails a PR instead of a production run.
+ */
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  estimateCost,
+  getProviderConfig,
+  loadRegistry,
+  resolveTier,
+  type ModelRegistry,
+} from "../packages/runtime/src/models/registry.js";
+
+const REPO_ROOT = join(__dirname, "..");
+
+const fakeRegistry = {
+  tiers: {
+    cheap: {
+      description: "cheap tier",
+      primary: { provider: "anthropic", model: "model-a", input_cost_per_m: 1, output_cost_per_m: 5 },
+      fallbacks: [{ provider: "openai", model: "model-b", input_cost_per_m: 2, output_cost_per_m: 8 }],
+    },
+    good: {
+      description: "default tier",
+      default_for_undeclared: true,
+      primary: { provider: "anthropic", model: "model-c", input_cost_per_m: 3, output_cost_per_m: 15 },
+      fallbacks: [],
+    },
+  },
+  providers: {
+    anthropic: { auth_env: "ANTHROPIC_API_KEY" },
+  },
+} as unknown as ModelRegistry;
+
+describe("resolveTier", () => {
+  it("resolves a declared tier to its primary + fallbacks", () => {
+    const r = resolveTier("cheap", fakeRegistry);
+    expect(r.primary.model).toBe("model-a");
+    expect(r.fallbacks).toHaveLength(1);
+    expect(r.fallbacks[0]!.provider).toBe("openai");
+  });
+
+  it("falls back to default_for_undeclared for an unknown tier", () => {
+    const r = resolveTier("no-such-tier", fakeRegistry);
+    expect(r.primary.model).toBe("model-c");
+  });
+
+  it("throws on unknown tier when no default is configured", () => {
+    const noDefault = {
+      tiers: { cheap: fakeRegistry.tiers.cheap },
+      providers: {},
+    } as unknown as ModelRegistry;
+    expect(() => resolveTier("no-such-tier", noDefault)).toThrow(/no default/);
+  });
+});
+
+describe("getProviderConfig", () => {
+  it("returns a declared provider", () => {
+    expect(getProviderConfig("anthropic", fakeRegistry).auth_env).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("throws on an unknown provider", () => {
+    expect(() => getProviderConfig("acme-llm", fakeRegistry)).toThrow(/Unknown provider/);
+  });
+});
+
+describe("estimateCost", () => {
+  const model = { provider: "anthropic", model: "m", input_cost_per_m: 3, output_cost_per_m: 15 };
+
+  it("computes plain input+output cost", () => {
+    // 1M in @ $3 + 1M out @ $15
+    expect(estimateCost(model, 1_000_000, 1_000_000)).toBe(18);
+  });
+
+  it("bills cache-creation tokens at 1.25× input rate", () => {
+    expect(estimateCost(model, 0, 0, 1_000_000, 0)).toBe(3.75);
+  });
+
+  it("bills cache-read tokens at 0.10× input rate", () => {
+    expect(estimateCost(model, 0, 0, 0, 1_000_000)).toBe(0.3);
+  });
+
+  it("rounds to 4 decimal places", () => {
+    expect(estimateCost(model, 333, 111)).toBe(0.0027);
+  });
+
+  it("treats missing rates as zero-cost (self-hosted models)", () => {
+    expect(estimateCost({ provider: "self", model: "local" }, 1_000_000, 1_000_000)).toBe(0);
+  });
+});
+
+describe("capabilities/model-registry.yaml shape guard", () => {
+  const real = loadRegistry(REPO_ROOT);
+
+  it("declares the four documented tiers", () => {
+    for (const tier of ["cheap", "good", "better", "best"]) {
+      expect(real.tiers[tier], `tier '${tier}' missing`).toBeDefined();
+      expect(real.tiers[tier]!.primary?.model, `tier '${tier}' has no primary model`).toBeTruthy();
+    }
+  });
+
+  it("every tier's primary provider exists in the providers map", () => {
+    for (const [name, tier] of Object.entries(real.tiers)) {
+      expect(
+        real.providers[tier.primary.provider],
+        `tier '${name}' primary provider '${tier.primary.provider}' undeclared`,
+      ).toBeDefined();
+    }
+  });
+
+  it("exactly one tier is default_for_undeclared", () => {
+    const defaults = Object.values(real.tiers).filter((t) => t.default_for_undeclared);
+    expect(defaults).toHaveLength(1);
+  });
+});

--- a/tests/skills-trigger-manifest.test.ts
+++ b/tests/skills-trigger-manifest.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the trigger-path manifest loader (#246 regression class)
+ * and the skill-id path resolver's traversal guard — critical-function
+ * coverage from #257. #246: registered contract.yaml skills 404'd on
+ * POST /api/skills/trigger because loadSkillManifest only accepted the
+ * native `id:` shape; a 5-line test would have caught it.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  loadSkillManifest,
+  resolveSkillManifestPath,
+} from "../packages/runtime/src/api/skills-trigger.js";
+
+const root = mkdtempSync(join(tmpdir(), "nexaas-manifest-test-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+let fixtureCount = 0;
+function fixture(yaml: string): string {
+  const path = join(root, `manifest-${fixtureCount++}.yaml`);
+  writeFileSync(path, yaml);
+  return path;
+}
+
+describe("loadSkillManifest — native skill.yaml shape", () => {
+  it("parses id/version/execution.type", () => {
+    const m = loadSkillManifest(fixture(
+      "id: marketing/daily-digest\nversion: 1.2.0\nexecution:\n  type: ai-skill\n",
+    ));
+    expect(m).toEqual({
+      id: "marketing/daily-digest",
+      version: "1.2.0",
+      execution: { type: "ai-skill" },
+    });
+  });
+
+  it("coerces a numeric version to string", () => {
+    const m = loadSkillManifest(fixture("id: ops/check\nversion: 1.0\n"));
+    expect(m?.version).toBe("1");
+  });
+});
+
+describe("loadSkillManifest — contract.yaml shape (#246)", () => {
+  it("derives id as category/skill", () => {
+    const m = loadSkillManifest(fixture(
+      "skill: daily-digest\ncategory: marketing\nversion: 2.0.0\nexecution:\n  type: ai-skill\n",
+    ));
+    expect(m?.id).toBe("marketing/daily-digest");
+  });
+
+  it("keeps a pre-slashed skill id as-is (category not double-applied)", () => {
+    const m = loadSkillManifest(fixture(
+      "skill: marketing/daily-digest\ncategory: marketing\nversion: 2.0.0\n",
+    ));
+    expect(m?.id).toBe("marketing/daily-digest");
+  });
+
+  it("uses bare skill as id when category is absent", () => {
+    const m = loadSkillManifest(fixture("skill: daily-digest\nversion: 2.0.0\n"));
+    expect(m?.id).toBe("daily-digest");
+  });
+
+  it("prefers an explicit id over the skill/category derivation", () => {
+    const m = loadSkillManifest(fixture(
+      "id: ops/explicit\nskill: ignored\ncategory: nope\nversion: 1.0.0\n",
+    ));
+    expect(m?.id).toBe("ops/explicit");
+  });
+});
+
+describe("loadSkillManifest — rejection paths", () => {
+  it("returns null when neither id nor skill is present", () => {
+    expect(loadSkillManifest(fixture("version: 1.0.0\n"))).toBeNull();
+  });
+
+  it("returns null when version is missing", () => {
+    expect(loadSkillManifest(fixture("id: ops/check\n"))).toBeNull();
+  });
+
+  it("returns null for malformed yaml", () => {
+    expect(loadSkillManifest(fixture("{{ not: yaml ["))).toBeNull();
+  });
+
+  it("returns null for a nonexistent path", () => {
+    expect(loadSkillManifest(join(root, "no-such-file.yaml"))).toBeNull();
+  });
+
+  it("returns null for a scalar document", () => {
+    expect(loadSkillManifest(fixture("just a string\n"))).toBeNull();
+  });
+});
+
+describe("resolveSkillManifestPath — traversal guard + resolution order", () => {
+  const wsRoot = join(root, "ws");
+  const skillDir = join(wsRoot, "nexaas-skills", "ops", "both-manifests");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "skill.yaml"), "id: ops/both-manifests\nversion: 1.0.0\n");
+  writeFileSync(join(skillDir, "contract.yaml"), "skill: both-manifests\nversion: 1.0.0\n");
+  const contractOnly = join(wsRoot, "nexaas-skills", "ops", "contract-only");
+  mkdirSync(contractOnly, { recursive: true });
+  writeFileSync(join(contractOnly, "contract.yaml"), "skill: contract-only\nversion: 1.0.0\n");
+
+  it("rejects path traversal", () => {
+    expect(resolveSkillManifestPath("../../../etc/passwd", wsRoot)).toBeNull();
+    expect(resolveSkillManifestPath("ops/../../escape", wsRoot)).toBeNull();
+  });
+
+  it("rejects malformed ids", () => {
+    expect(resolveSkillManifestPath("/absolute", wsRoot)).toBeNull();
+    expect(resolveSkillManifestPath("ops//double", wsRoot)).toBeNull();
+    expect(resolveSkillManifestPath("ops/with space", wsRoot)).toBeNull();
+  });
+
+  it("prefers skill.yaml when both manifests exist", () => {
+    expect(resolveSkillManifestPath("ops/both-manifests", wsRoot))
+      .toBe(resolve(skillDir, "skill.yaml"));
+  });
+
+  it("falls through to contract.yaml (#246 lookup half)", () => {
+    expect(resolveSkillManifestPath("ops/contract-only", wsRoot))
+      .toBe(resolve(contractOnly, "contract.yaml"));
+  });
+
+  it("returns the conventional skill.yaml path when neither exists (404 messaging)", () => {
+    expect(resolveSkillManifestPath("ops/ghost", wsRoot))
+      .toBe(resolve(wsRoot, "nexaas-skills", "ops", "ghost", "skill.yaml"));
+  });
+});

--- a/tests/spend-day.test.ts
+++ b/tests/spend-day.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for spend-governor day-bucketing (#215 daily budget) —
+ * critical-function coverage from #257. The daily spend ledger keys on
+ * localDay(); a timezone bug here silently splits or merges budget days,
+ * which is exactly how a hard cap gets breached without an alert.
+ */
+import { describe, expect, it } from "vitest";
+import { localDay } from "../packages/runtime/src/models/spend-governor.js";
+
+describe("localDay", () => {
+  // 2026-01-02T03:00:00Z: still Jan 1 in Toronto (UTC-5), already Jan 2 in UTC.
+  const instant = new Date("2026-01-02T03:00:00Z");
+
+  it("formats YYYY-MM-DD in UTC", () => {
+    expect(localDay("UTC", instant)).toBe("2026-01-02");
+  });
+
+  it("crosses midnight boundaries per-timezone", () => {
+    expect(localDay("America/Toronto", instant)).toBe("2026-01-01");
+    expect(localDay("Australia/Sydney", instant)).toBe("2026-01-02");
+  });
+
+  it("handles DST-observing zones on a summer instant", () => {
+    // 2026-07-02T03:00:00Z: Toronto is UTC-4 in July → still July 1.
+    expect(localDay("America/Toronto", new Date("2026-07-02T03:00:00Z"))).toBe("2026-07-01");
+  });
+
+  it("falls back to the ISO date on an invalid timezone", () => {
+    expect(localDay("Not/AZone", instant)).toBe("2026-01-02");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts", "packages/*/src/**/*.test.ts"],
+    // The harness bridge (tests/harnesses.test.ts) spawns each scripts/
+    // test-*.mjs as a subprocess; generous per-test timeout because tsx
+    // cold-starts the TypeScript pipeline in every child.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
Closes #257 (H4 of the framework-hardening v2 umbrella #253) — the phased plan from the issue, delivered in one PR. **This PR's own checks are the first live run of the workflow.**

## What lands

**1. `.github/workflows/ci.yml`** — two jobs on every PR + push to main:
- **build**: `npm ci` → full workspace build (strict tsc) → `npm run typecheck`. Catches the v0.3.5 class (shipped changelog, uncommitted code) and all type drift.
- **test**: `vitest run` against `pgvector/pgvector:pg16` + `redis:7` services, with `scripts/ci-migrate.mjs` applying all 27 migrations to the scratch DB first.

**2. Real typecheck everywhere** — all 10 TS workspaces get `typecheck: tsc --noEmit`; root `npm run typecheck` was a silent no-op (nothing defined it, `--if-present` exited 0). The palace MCP server gets its first-ever tsconfig and passes. factory/ops-console-core have empty `src/` (#259's hollow packages).

**3. Harness bridge** — `tests/harnesses.test.ts` auto-discovers every `scripts/test-*.mjs` (32 today), classifies by content (`[db]`/`[redis]`), env-gates so `npm test` works on a laptop and CI runs everything. Harnesses stay standalone-runnable; new ones are picked up automatically.

**4. 43 unit tests** for critical-function gaps named in the issue: bearer-auth incl. rotation dual-accept (#217), `loadSkillManifest` contract.yaml derivation + traversal guard (the #246 regression, now 5-line-test-covered as promised), model-registry tier resolution + `estimateCost` cache multipliers + a live `model-registry.yaml` shape guard, `localDay` budget bucketing (#215).

**5. Three stale harnesses fixed** — found *by* bridging them, proving the point:
- `approval-render-93`: `eaf7b78` bolds the summary lead; harness expected unwrapped text
- `pa-delivery`: pre-#191 `status='queued'` expectations + missing urgency args (normal tier now holds `release_at` +15 min) + assumed `MAX_RETRIES=2` (default is now 3; pinned via pre-import env)
- `wal-canon-254`: ignored `applyPendingMigrations`'s `result.failed` (it returns, never throws) and hardcoded `/opt/nexaas`

## Verification
Local dress rehearsal identical to the CI test job: **75/75 green** (32 harnesses + 43 unit tests) in 37s; build + typecheck clean across all workspaces.

## Non-goals
`nexaas conformance` is untouched — it remains the *deployment* gate. Optional follow-up once this soaks: make `build`/`test` required status checks on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)