### PR TITLE
feat(gateway): route all agentic model calls through ModelGateway (#255)

### DIFF
--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -5,6 +5,7 @@
 
 import { execSync } from "child_process";
 import pg from "pg";
+import { probeModel } from "@nexaas/runtime";
 
 function exec(cmd: string): string {
   try { return execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim(); } catch { return ""; }
@@ -71,7 +72,7 @@ export async function run() {
       const res = await fetch("https://api.anthropic.com/v1/messages", {
         method: "POST",
         headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
-        body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 1, messages: [{ role: "user", content: "ok" }] }),
+        body: JSON.stringify({ model: probeModel(), max_tokens: 1, messages: [{ role: "user", content: "ok" }] }),
       });
       if (res.status === 400 && (await res.text()).includes("credit")) alerts.push({ sev: "critical", comp: "api", msg: "credits exhausted" });
       else if (res.status === 401) alerts.push({ sev: "critical", comp: "api", msg: "key invalid" });

--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -3,6 +3,7 @@
  */
 
 import { execSync } from "child_process";
+import { probeModel } from "@nexaas/runtime";
 
 function exec(cmd: string): string {
   try {
@@ -27,7 +28,7 @@ async function testAnthropicKey(): Promise<{ valid: boolean; error?: string }> {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "claude-haiku-4-5-20251001",
+        model: probeModel(),
         max_tokens: 1,
         messages: [{ role: "user", content: "hi" }],
       }),

--- a/packages/runtime/src/ai-skill.ts
+++ b/packages/runtime/src/ai-skill.ts
@@ -19,10 +19,10 @@ import { palace, appendWal, sqlOne } from "@nexaas/palace";
 import { runTracker } from "./run-tracker.js";
 import { McpClient, loadMcpConfigs } from "./mcp/client.js";
 import { acquireMcpClient, releaseMcpClient } from "./mcp/pool.js";
-import { runAgenticLoop, type McpTool, type AgenticLimits } from "./models/agentic-loop.js";
+import type { McpTool, AgenticLimits, AgenticResult } from "./models/agentic-loop.js";
+import { ModelGateway } from "./models/gateway.js";
 import { getBudgetState } from "./models/spend-governor.js";
 import { pauseForBudgetBreach } from "./tasks/spend-budget-monitor.js";
-import { resolveTier, estimateCost, type ModelEntry } from "./models/registry.js";
 import { verifyOutputs, summarizeFailures, type OutputVerification } from "./ai-skill-verify.js";
 import type { OutputKind, ManifestApproval, RoutingDecision } from "./tag/route.js";
 import { apply as applyRoutedAction } from "./engine/apply.js";
@@ -135,13 +135,6 @@ const DEFAULT_LIMITS: Required<Pick<AiSkillManifest, "limits">>["limits"] = {
   max_output_tokens_per_turn: 16000,
   max_consecutive_identical_tool_calls: 3,
   max_consecutive_errors: 3,
-};
-
-const TIER_MAP: Record<string, string> = {
-  cheap: "claude-haiku-4-5-20251001",
-  good: "claude-sonnet-4-6",
-  better: "claude-sonnet-4-6",
-  best: "claude-opus-4-6",
 };
 
 export interface AiSkillExecutionContext {
@@ -293,9 +286,9 @@ export async function runAiSkill(
     systemPrompt = manifest.description ?? `Execute skill: ${manifest.id}`;
   }
 
-  // Resolve the model
+  // Model selection is the gateway's job (#255): the tier resolves to a
+  // registry-driven Anthropic chain inside ModelGateway.executeAgentic.
   const tier = manifest.execution.model_tier ?? "good";
-  const model = TIER_MAP[tier] ?? "claude-sonnet-4-6";
 
   // Connect to MCP servers
   // Look for .mcp.json in these locations (in order):
@@ -478,20 +471,6 @@ export async function runAiSkill(
       ? `${parts.join("\n\n")}\n\n${taskLine}`
       : "Proceed with the task.";
 
-    // Resolve pricing from the model registry for real spend-cap enforcement.
-    let modelPricing: { inputCostPerM: number; outputCostPerM: number } | undefined;
-    let pricedModelEntry: ModelEntry | undefined;
-    try {
-      const resolved = resolveTier(tier);
-      pricedModelEntry = resolved.primary;
-      if (resolved.primary.input_cost_per_m != null && resolved.primary.output_cost_per_m != null) {
-        modelPricing = {
-          inputCostPerM: resolved.primary.input_cost_per_m,
-          outputCostPerM: resolved.primary.output_cost_per_m,
-        };
-      }
-    } catch { /* registry not available — spend cap will be skipped */ }
-
     // Bind framework tool context now that session + manifest loader are
     // ready. Loaded once per run so the same workspaceManifest is available
     // both during the agentic loop (via framework__produce_output) and
@@ -521,7 +500,7 @@ export async function runAiSkill(
     };
 
     // Run the agentic loop
-    console.log(`[nexaas] Running AI skill '${manifest.id}' with ${allTools.length} tools, model: ${model}`);
+    console.log(`[nexaas] Running AI skill '${manifest.id}' with ${allTools.length} tools, tier: ${tier}`);
     // Tool-bloat early warning (#196). >75 tool defs ≈ 20-30K prompt tokens
     // before CAG context — the silent first-call-timeout zone (#197 RCA).
     // Use per-MCP `tools:` allowlists to trim. Warn, don't block.
@@ -543,10 +522,10 @@ export async function runAiSkill(
       });
     }, 30_000);
 
-    let result: Awaited<ReturnType<typeof runAgenticLoop>>;
+    let result: AgenticResult;
     try {
-      result = await runAgenticLoop({
-        model,
+      result = await ModelGateway.executeAgentic({
+        tier,
         system: systemPrompt,
         messages: [{ role: "user", content: userMessage }],
         tools: allTools,
@@ -555,7 +534,6 @@ export async function runAiSkill(
         runId,
         skillId: manifest.id,
         limits: agenticLimits,
-        modelPricing,
       });
     } finally {
       clearInterval(heartbeat);
@@ -664,19 +642,9 @@ export async function runAiSkill(
       await session.writeDrawer(primaryRoom, JSON.stringify(primaryDrawerPayload));
     }
 
-    // Update token usage — prefer registry-sourced pricing, fall back to previous guess.
-    const cost = pricedModelEntry
-      ? estimateCost(
-          pricedModelEntry, result.inputTokens, result.outputTokens,
-          result.cacheCreationTokens, result.cacheReadTokens,
-        )
-      : estimateCost(
-          { provider: "anthropic", model, input_cost_per_m: tier === "good" ? 3 : 1, output_cost_per_m: tier === "good" ? 15 : 5 } as ModelEntry,
-          result.inputTokens,
-          result.outputTokens,
-          result.cacheCreationTokens,
-          result.cacheReadTokens,
-        );
+    // Cost is accrued per-turn inside the loop under registry pricing —
+    // correct across mid-run model fallbacks (#255).
+    const cost = result.costUsd;
 
     await runTracker.updateTokenUsage(runId, {
       input: result.inputTokens,
@@ -692,7 +660,8 @@ export async function runAiSkill(
       actor: `skill:${manifest.id}`,
       payload: {
         run_id: runId,
-        model,
+        model: result.model,
+        model_fallback: result.usedFallback,
         turns: result.turns,
         tool_calls: result.toolCalls.length,
         input_tokens: result.inputTokens,
@@ -711,7 +680,7 @@ export async function runAiSkill(
       await sql(
         `INSERT INTO token_usage (workspace, agent, session_id, source, model, input_tokens, output_tokens, cost_usd, created_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())`,
-        [workspace, manifest.id, runId, "ai-skill", model, result.inputTokens, result.outputTokens, cost],
+        [workspace, manifest.id, runId, "ai-skill", result.model, result.inputTokens, result.outputTokens, cost],
       );
     } catch { /* non-fatal — billing table may not exist on all installs */ }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -24,7 +24,9 @@ export {
   type ShellSkillManifest,
   type SkillExecutionContext,
 } from "./shell-skill.js";
-export { ModelGateway } from "./models/gateway.js";
+export { ModelGateway, resolveAgenticChain } from "./models/gateway.js";
+export { resolveTier, loadRegistry, estimateCost } from "./models/registry.js";
+export { probeModel } from "./models/probe.js";
 export { route as tagRoute } from "./tag/route.js";
 export { assemble as cagAssemble } from "./cag/assemble.js";
 export { retrieve as ragRetrieve } from "./rag/retrieve.js";

--- a/packages/runtime/src/models/agentic-loop.ts
+++ b/packages/runtime/src/models/agentic-loop.ts
@@ -215,6 +215,12 @@ export interface AgenticModelPricing {
   outputCostPerM: number;
 }
 
+/** One entry in the model chain the loop may walk on provider failure. */
+export interface AgenticModelChoice {
+  model: string;
+  pricing?: AgenticModelPricing;
+}
+
 export interface AgenticResult {
   content: string;
   toolCalls: Array<{ name: string; input: Record<string, unknown>; result: string }>;
@@ -229,6 +235,10 @@ export interface AgenticResult {
   turns: number;
   stopReason: AgenticStopReason;
   aborted: boolean;
+  /** The model that served the final turn (differs from the requested model after fallback). */
+  model: string;
+  /** True if any turn was served by a fallbackModels entry (#255). */
+  usedFallback: boolean;
 }
 
 const DEFAULT_MAX_TURNS = 10;
@@ -296,8 +306,17 @@ export async function runAgenticLoop(params: {
   skillId: string;
   limits?: AgenticLimits;
   modelPricing?: AgenticModelPricing;
+  /**
+   * Same-API-shape fallback models (#255) walked in order when a turn's
+   * request fails terminally (retries exhausted or non-retryable). The
+   * conversation so far carries over — Anthropic-to-Anthropic switches are
+   * seamless. 429s NEVER trigger fallback: they propagate so the worker's
+   * queue-pause path (#27) reacts, and a rate-limited account would
+   * rate-limit the fallback model too.
+   */
+  fallbackModels?: AgenticModelChoice[];
 }): Promise<AgenticResult> {
-  const { model, system, tools, executeTool, workspace, runId, skillId, modelPricing } = params;
+  const { system, tools, executeTool, workspace, runId, skillId } = params;
   const limits: AgenticLimits = params.limits ?? {};
   const maxTurns = limits.maxTurns ?? DEFAULT_MAX_TURNS;
   const maxIdentical = limits.maxConsecutiveIdenticalToolCalls ?? DEFAULT_MAX_CONSECUTIVE_IDENTICAL;
@@ -343,10 +362,21 @@ export async function runAgenticLoop(params: {
   let stopReason: AgenticStopReason = "max_turns";
   let aborted = true;
 
+  // Model chain (#255): the requested model plus registry fallbacks. Cost
+  // accrues per turn under the model that SERVED it, so a mid-run switch
+  // bills each segment at its own rate (the old end-of-run
+  // costOf(pricing, totals) also silently ignored cache tokens in the
+  // spend-cap check — per-turn accrual fixes both).
+  const chain: AgenticModelChoice[] = [
+    { model: params.model, pricing: params.modelPricing },
+    ...(params.fallbackModels ?? []),
+  ];
+  let chainIdx = 0;
+  let usedFallback = false;
+  let costAccrued = 0;
+
   const overSpendCap = () =>
-    limits.maxSpendUsd != null
-      && modelPricing != null
-      && costOf(modelPricing, totalInputTokens, totalOutputTokens) >= limits.maxSpendUsd;
+    limits.maxSpendUsd != null && costAccrued >= limits.maxSpendUsd;
   const overInputCap = () =>
     limits.maxInputTokens != null && totalInputTokens >= limits.maxInputTokens;
   const overOutputCap = () =>
@@ -355,24 +385,61 @@ export async function runAgenticLoop(params: {
   while (turns < maxTurns) {
     turns++;
 
-    const response = await retryMessagesCreate(() =>
-      streamWithChunkIdleTimeout(
-        client,
-        {
-          model,
-          max_tokens: maxTokensPerTurn,
-          system: systemParam,
-          messages,
-          tools: anthropicTools,
-        },
-        chunkIdleMs(),
-      ),
-    );
+    let response: Anthropic.Message;
+    for (;;) {
+      const current = chain[chainIdx]!;
+      try {
+        response = await retryMessagesCreate(() =>
+          streamWithChunkIdleTimeout(
+            client,
+            {
+              model: current.model,
+              max_tokens: maxTokensPerTurn,
+              system: systemParam,
+              messages,
+              tools: anthropicTools,
+            },
+            chunkIdleMs(),
+          ),
+        );
+        break;
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        // 429 → queue-pause path, never fallback (see fallbackModels doc).
+        if (status === 429 || chainIdx >= chain.length - 1) throw err;
+        const next = chain[chainIdx + 1]!;
+        console.warn(
+          `[nexaas] agentic-loop turn ${turns}: ${current.model} failed terminally — ` +
+          `falling back to ${next.model} (#255)`,
+        );
+        await appendWal({
+          workspace,
+          op: "model_fallback",
+          actor: `skill:${skillId}`,
+          payload: {
+            run_id: runId,
+            turn: turns,
+            from_model: current.model,
+            to_model: next.model,
+            error: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300),
+          },
+        });
+        chainIdx++;
+        usedFallback = true;
+      }
+    }
 
     totalInputTokens += response.usage.input_tokens;
     totalOutputTokens += response.usage.output_tokens;
     totalCacheCreationTokens += response.usage.cache_creation_input_tokens ?? 0;
     totalCacheReadTokens += response.usage.cache_read_input_tokens ?? 0;
+    costAccrued += costOf(
+      chain[chainIdx]!.pricing,
+      response.usage.input_tokens,
+      response.usage.output_tokens,
+      response.usage.cache_creation_input_tokens ?? 0,
+      response.usage.cache_read_input_tokens ?? 0,
+    );
 
     let turnText = "";
     const toolUseBlocks: Anthropic.ToolUseBlock[] = [];
@@ -520,6 +587,8 @@ export async function runAgenticLoop(params: {
     aborted = true;
   }
 
+  const totalCostUsd = Math.round(costAccrued * 10000) / 10000;
+
   if (stopReason !== "end_turn") {
     await appendWal({
       workspace,
@@ -533,18 +602,10 @@ export async function runAgenticLoop(params: {
         output_tokens: totalOutputTokens,
         cache_creation_input_tokens: totalCacheCreationTokens,
         cache_read_input_tokens: totalCacheReadTokens,
-        cost_usd: costOf(
-          modelPricing, totalInputTokens, totalOutputTokens,
-          totalCacheCreationTokens, totalCacheReadTokens,
-        ),
+        cost_usd: totalCostUsd,
       },
     });
   }
-
-  const totalCostUsd = costOf(
-    modelPricing, totalInputTokens, totalOutputTokens,
-    totalCacheCreationTokens, totalCacheReadTokens,
-  );
 
   // Daily spend accounting (#215). This is the single chokepoint covering
   // every agentic caller (ai-skill, PA service, future surfaces). Never
@@ -563,5 +624,7 @@ export async function runAgenticLoop(params: {
     turns,
     stopReason,
     aborted,
+    model: chain[chainIdx]!.model,
+    usedFallback,
   };
 }

--- a/packages/runtime/src/models/gateway.ts
+++ b/packages/runtime/src/models/gateway.ts
@@ -12,11 +12,21 @@ import {
   getProviderConfig,
   estimateCost,
   type ModelEntry,
+  type ModelRegistry,
 } from "./registry.js";
 import * as anthropicProvider from "./providers/anthropic.js";
 import * as openaiProvider from "./providers/openai.js";
 import { appendWal } from "@nexaas/palace";
 import { assertWithinBudget, recordSpend } from "./spend-governor.js";
+import {
+  runAgenticLoop,
+  type AgenticLimits,
+  type AgenticModelChoice,
+  type AgenticResult,
+  type McpTool,
+  type ToolExecutor,
+} from "./agentic-loop.js";
+import type Anthropic from "@anthropic-ai/sdk";
 
 export type ModelTier = "cheap" | "good" | "better" | "best";
 
@@ -66,6 +76,46 @@ export interface ExecuteResult {
 export interface ModelAction {
   kind: string;
   payload: Record<string, unknown>;
+}
+
+/**
+ * Resolve a tier to the model chain the AGENTIC path can walk (#255).
+ *
+ * The agentic loop speaks the Anthropic Messages API natively (streaming,
+ * tool_use blocks, cache_control) — non-Anthropic registry fallbacks are
+ * filtered out because switching wire formats mid-conversation would
+ * require a full tool-loop translation layer. Cross-provider fallback
+ * remains available on the single-shot execute() path below. Registry
+ * invariant guarded by tests: every tier's PRIMARY is Anthropic, so this
+ * never returns an empty chain for a declared tier.
+ */
+export function resolveAgenticChain(
+  tier: string,
+  registry?: ModelRegistry,
+): AgenticModelChoice[] {
+  const { primary, fallbacks } = resolveTier(tier, registry);
+  return [primary, ...fallbacks]
+    .filter((e) => e.provider === "anthropic")
+    .map((e) => ({
+      model: e.model,
+      pricing:
+        e.input_cost_per_m != null && e.output_cost_per_m != null
+          ? { inputCostPerM: e.input_cost_per_m, outputCostPerM: e.output_cost_per_m }
+          : undefined,
+    }));
+}
+
+export interface ExecuteAgenticParams {
+  /** Manifest/persona model_tier — resolution happens HERE, not at call sites. */
+  tier: string;
+  system: string;
+  messages: Anthropic.MessageParam[];
+  tools: McpTool[];
+  executeTool: ToolExecutor;
+  workspace: string;
+  runId: string;
+  skillId: string;
+  limits?: AgenticLimits;
 }
 
 const RETRY_DELAYS = [100, 400, 1000];
@@ -156,6 +206,43 @@ async function tryWithRetries(
 }
 
 export const ModelGateway = {
+  /**
+   * The live execution path (#255): every agentic caller (ai-skill, PA
+   * service, subagent, webstudio edit) routes model runs through here.
+   * Gains over the previous direct-SDK call sites, all in one place:
+   *   - registry-driven model selection (no hardcoded TIER_MAPs anywhere)
+   *   - pre-call daily budget gate (#215) — SpendBudgetExceededError is a
+   *     policy stop, never "recovered" by a still-billable fallback
+   *   - same-API model fallback chain, walked per-turn inside the loop
+   *   - registry pricing for real spend-cap enforcement + accounting
+   * WAL (per-turn) + recordSpend stay inside runAgenticLoop — the loop is
+   * the accounting chokepoint; this wrapper is the policy + resolution one.
+   */
+  async executeAgentic(params: ExecuteAgenticParams): Promise<AgenticResult> {
+    await assertWithinBudget(params.workspace);
+
+    const chain = resolveAgenticChain(params.tier);
+    if (chain.length === 0) {
+      throw new Error(
+        `No Anthropic-capable model in registry for tier '${params.tier}' — the agentic path requires one`,
+      );
+    }
+
+    return runAgenticLoop({
+      model: chain[0]!.model,
+      modelPricing: chain[0]!.pricing,
+      fallbackModels: chain.slice(1),
+      system: params.system,
+      messages: params.messages,
+      tools: params.tools,
+      executeTool: params.executeTool,
+      workspace: params.workspace,
+      runId: params.runId,
+      skillId: params.skillId,
+      limits: params.limits,
+    });
+  },
+
   async execute(params: ExecuteParams): Promise<ExecuteResult> {
     const { tier, messages, system, tools, workspaceId, runId, stepId } = params;
 

--- a/packages/runtime/src/models/probe.ts
+++ b/packages/runtime/src/models/probe.ts
@@ -1,0 +1,18 @@
+/**
+ * Cheapest registry model for 1-token API-key/credit probes (#255).
+ *
+ * status/health/health-monitor previously hardcoded a haiku model id —
+ * when that id ages out, every health probe starts failing with
+ * model_not_found and reads as an API outage. The registry is the single
+ * source of truth; the static fallback exists only so a probe can still
+ * run (and report) when the registry file itself is unreadable.
+ */
+import { resolveTier } from "./registry.js";
+
+export function probeModel(): string {
+  try {
+    return resolveTier("cheap").primary.model;
+  } catch {
+    return "claude-haiku-4-5-20251001";
+  }
+}

--- a/packages/runtime/src/pa/service.ts
+++ b/packages/runtime/src/pa/service.ts
@@ -14,9 +14,9 @@
 
 import { randomUUID } from "crypto";
 import { palace, appendWal, sql } from "@nexaas/palace";
-import { runAgenticLoop, type McpTool } from "../models/agentic-loop.js";
+import type { McpTool } from "../models/agentic-loop.js";
+import { ModelGateway } from "../models/gateway.js";
 import { getBudgetState } from "../models/spend-governor.js";
-import { resolveTier } from "../models/registry.js";
 import { McpClient, loadMcpConfigs } from "../mcp/client.js";
 import { runTracker } from "../run-tracker.js";
 
@@ -45,20 +45,12 @@ export interface InboundMessage {
   attachments?: Array<{ type: string; url: string }>;
 }
 
-const TIER_MAP: Record<string, string> = {
-  cheap: "claude-haiku-4-5-20251001",
-  good: "claude-sonnet-4-6",
-  better: "claude-sonnet-4-6",
-  best: "claude-opus-4-6",
-};
-
 export async function handlePaMessage(
   workspace: string,
   persona: PersonaConfig,
   message: InboundMessage,
 ): Promise<{ response: string; turns: number; toolCalls: number }> {
   const runId = randomUUID();
-  const model = TIER_MAP[persona.modelTier] ?? "claude-sonnet-4-6";
 
   // Daily spend budget gate (#215) — checked before run tracking, MCP
   // spawn, or any model cost. PA requests arrive over HTTP, so the queue
@@ -310,29 +302,17 @@ Be helpful, context-aware, and follow the brand voice.`;
     // Default 2 min; override via NEXAAS_PA_TIMEOUT_MS.
     const paTimeoutMs = parseInt(process.env.NEXAAS_PA_TIMEOUT_MS ?? "120000", 10);
 
-    // Resolve pricing so PA conversations land in daily spend accounting
-    // (#215) — without it the agentic loop computes costUsd=0 and PA usage
-    // is invisible to the budget. Mirrors ai-skill.ts.
-    let modelPricing: { inputCostPerM: number; outputCostPerM: number } | undefined;
-    try {
-      const resolved = resolveTier(persona.modelTier);
-      if (resolved.primary.input_cost_per_m != null && resolved.primary.output_cost_per_m != null) {
-        modelPricing = {
-          inputCostPerM: resolved.primary.input_cost_per_m,
-          outputCostPerM: resolved.primary.output_cost_per_m,
-        };
-      }
-    } catch { /* registry not available — spend goes unrecorded, as before */ }
-
+    // Model resolution, registry pricing, and the budget backstop all live
+    // in the gateway now (#255); the friendly budget refusal above stays as
+    // PA's primary gate.
     const result = await Promise.race([
-      runAgenticLoop({
-        model,
+      ModelGateway.executeAgentic({
+        tier: persona.modelTier,
         system: systemPrompt,
         messages: [{ role: "user", content: message.content }],
         tools: allTools,
         executeTool,
         limits: { maxTurns: persona.maxTurns ?? 15 },
-        modelPricing,
         workspace,
         runId,
         skillId: `pa/${persona.id}`,

--- a/packages/runtime/src/subagent.ts
+++ b/packages/runtime/src/subagent.ts
@@ -7,17 +7,11 @@
  */
 
 import { palace, appendWal } from "@nexaas/palace";
-import { runAgenticLoop, type McpTool } from "./models/agentic-loop.js";
+import type { McpTool } from "./models/agentic-loop.js";
+import { ModelGateway } from "./models/gateway.js";
 import { McpClient, loadMcpConfigs } from "./mcp/client.js";
 import type { ModelTier } from "./models/gateway.js";
 import { randomUUID } from "crypto";
-
-const TIER_MAP: Record<string, string> = {
-  cheap: "claude-haiku-4-5-20251001",
-  good: "claude-sonnet-4-6",
-  better: "claude-sonnet-4-6",
-  best: "claude-opus-4-6",
-};
 
 export interface SubAgentConfig {
   id: string;
@@ -39,7 +33,6 @@ export async function subagent(params: {
 }): Promise<{ content: string; toolCalls: number; turns: number }> {
   const { workspace, parentRunId, parentStepId, config, input } = params;
   const subRunId = randomUUID();
-  const model = TIER_MAP[config.modelTier] ?? "claude-sonnet-4-6";
 
   // Connect to MCP servers if declared
   const mcpClients: McpClient[] = [];
@@ -96,8 +89,8 @@ export async function subagent(params: {
     : input;
 
   try {
-    const result = await runAgenticLoop({
-      model,
+    const result = await ModelGateway.executeAgentic({
+      tier: config.modelTier,
       system: config.systemPrompt,
       messages: [{ role: "user", content: userMessage }],
       tools: allTools,

--- a/packages/runtime/src/tasks/health-monitor.ts
+++ b/packages/runtime/src/tasks/health-monitor.ts
@@ -21,6 +21,7 @@ import { sql, appendWal } from "@nexaas/palace";
 import { exec as execCb } from "child_process";
 import { promisify } from "util";
 import { notify } from "../notifications.js";
+import { probeModel } from "../models/probe.js";
 
 // Async exec — health monitor runs every 5 min inside the worker. Using
 // execSync here (as before) blocked the event loop for each shell check,
@@ -170,7 +171,7 @@ export async function runHealthCheck(workspace: string): Promise<HealthReport> {
       const res = await fetch("https://api.anthropic.com/v1/messages", {
         method: "POST",
         headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
-        body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 1, messages: [{ role: "user", content: "ok" }] }),
+        body: JSON.stringify({ model: probeModel(), max_tokens: 1, messages: [{ role: "user", content: "ok" }] }),
       });
       if (res.status === 400 && (await res.text()).includes("credit balance")) {
         alerts.push({ severity: "critical", component: "api", message: "API credits exhausted" });

--- a/packages/runtime/src/webstudio/edit.ts
+++ b/packages/runtime/src/webstudio/edit.ts
@@ -16,7 +16,8 @@
 import { randomUUID } from "crypto";
 import { join } from "path";
 import { existsSync } from "fs";
-import { runAgenticLoop, type McpTool } from "../models/agentic-loop.js";
+import type { McpTool } from "../models/agentic-loop.js";
+import { ModelGateway } from "../models/gateway.js";
 import { McpClient } from "../mcp/client.js";
 import { runTracker } from "../run-tracker.js";
 
@@ -37,13 +38,6 @@ export interface WebstudioEditResult {
   filesRead: string[];
   applied: boolean;
 }
-
-const TIER_MAP: Record<string, string> = {
-  cheap: "claude-haiku-4-5-20251001",
-  good: "claude-sonnet-4-6",
-  better: "claude-sonnet-4-6",
-  best: "claude-opus-4-6",
-};
 
 const EDIT_SYSTEM_PROMPT = (instruction: string, senderName: string) => `You are a web developer assistant editing a real project for ${senderName}. The user's instruction:
 
@@ -87,7 +81,6 @@ export async function runWebstudioEdit(
 
   const runId = randomUUID();
   const modelTier = options?.modelTier ?? "good";
-  const model = TIER_MAP[modelTier] ?? "claude-sonnet-4-6";
   const senderName = input.senderName ?? "user";
 
   await runTracker.createRun({
@@ -141,8 +134,8 @@ export async function runWebstudioEdit(
 
     const editTimeoutMs = parseInt(process.env.NEXAAS_WEBSTUDIO_EDIT_TIMEOUT_MS ?? "180000", 10);
     const result = await Promise.race([
-      runAgenticLoop({
-        model,
+      ModelGateway.executeAgentic({
+        tier: modelTier,
         system: EDIT_SYSTEM_PROMPT(input.instruction, senderName),
         messages: [{ role: "user", content: input.instruction }],
         tools,

--- a/tests/gateway-chain.test.ts
+++ b/tests/gateway-chain.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for resolveAgenticChain (#255) — the registry→model-chain
+ * resolution behind ModelGateway.executeAgentic. Every live agentic caller
+ * (ai-skill, PA, subagent, webstudio edit) selects models through this;
+ * a regression here changes what model every skill in the fleet runs on.
+ */
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveAgenticChain } from "../packages/runtime/src/models/gateway.js";
+import { loadRegistry, type ModelRegistry } from "../packages/runtime/src/models/registry.js";
+import { probeModel } from "../packages/runtime/src/models/probe.js";
+
+const REPO_ROOT = join(__dirname, "..");
+
+const fakeRegistry = {
+  tiers: {
+    mixed: {
+      description: "anthropic primary with mixed fallbacks",
+      primary: { provider: "anthropic", model: "claude-a", input_cost_per_m: 3, output_cost_per_m: 15 },
+      fallbacks: [
+        { provider: "openai", model: "gpt-x", input_cost_per_m: 2, output_cost_per_m: 10 },
+        { provider: "anthropic", model: "claude-b", input_cost_per_m: 15, output_cost_per_m: 75 },
+        { provider: "openrouter", model: "gemini-y" },
+      ],
+    },
+    unpriced: {
+      description: "entry without cost fields",
+      default_for_undeclared: true,
+      primary: { provider: "anthropic", model: "claude-c" },
+      fallbacks: [],
+    },
+  },
+  providers: { anthropic: { auth_env: "ANTHROPIC_API_KEY" } },
+} as unknown as ModelRegistry;
+
+describe("resolveAgenticChain", () => {
+  it("keeps only anthropic entries, preserving order", () => {
+    const chain = resolveAgenticChain("mixed", fakeRegistry);
+    expect(chain.map((c) => c.model)).toEqual(["claude-a", "claude-b"]);
+  });
+
+  it("maps registry costs to loop pricing", () => {
+    const chain = resolveAgenticChain("mixed", fakeRegistry);
+    expect(chain[0]!.pricing).toEqual({ inputCostPerM: 3, outputCostPerM: 15 });
+    expect(chain[1]!.pricing).toEqual({ inputCostPerM: 15, outputCostPerM: 75 });
+  });
+
+  it("leaves pricing undefined when the registry entry has no costs", () => {
+    const chain = resolveAgenticChain("unpriced", fakeRegistry);
+    expect(chain[0]!.model).toBe("claude-c");
+    expect(chain[0]!.pricing).toBeUndefined();
+  });
+
+  it("falls through to default_for_undeclared for unknown tiers", () => {
+    const chain = resolveAgenticChain("no-such-tier", fakeRegistry);
+    expect(chain[0]!.model).toBe("claude-c");
+  });
+});
+
+describe("real registry — agentic-path invariants (#255)", () => {
+  const real = loadRegistry(REPO_ROOT);
+
+  it("every tier resolves to a non-empty anthropic chain", () => {
+    for (const tier of Object.keys(real.tiers)) {
+      const chain = resolveAgenticChain(tier, real);
+      expect(chain.length, `tier '${tier}' has no anthropic-capable model`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every tier's PRIMARY is anthropic (agentic loop speaks its wire format)", () => {
+    for (const [name, tier] of Object.entries(real.tiers)) {
+      expect(tier.primary.provider, `tier '${name}' primary is not anthropic`).toBe("anthropic");
+    }
+  });
+
+  it("every anthropic chain entry carries pricing (spend caps depend on it)", () => {
+    for (const tier of Object.keys(real.tiers)) {
+      for (const entry of resolveAgenticChain(tier, real)) {
+        expect(entry.pricing, `tier '${tier}' model '${entry.model}' has no pricing`).toBeDefined();
+      }
+    }
+  });
+});
+
+describe("probeModel", () => {
+  it("resolves the cheap tier's primary from the registry", () => {
+    const real = loadRegistry(REPO_ROOT);
+    expect(probeModel()).toBe(real.tiers.cheap!.primary.model);
+  });
+});


### PR DESCRIPTION
Closes #255 (H2 of #253) — **Decision A: make the gateway real.**

## The problem
The framework's documented identity ("provider-agnostic ModelGateway, tier-based selection") was dead code. Every live caller — ai-skill, PA service, subagent, webstudio edit — hit the Anthropic SDK directly through its own copy-pasted `TIER_MAP` of hardcoded model IDs, violating CLAUDE.md's own rule in four places. `resolveTier()` was called for pricing, then the resolved model was thrown away.

## What changes
- **`ModelGateway.executeAgentic()`** — the single entry for the live agentic path: pre-call daily budget gate (#215) → `resolveAgenticChain(tier)` → `runAgenticLoop`. `SpendBudgetExceededError` is a policy stop and is never "recovered" by a still-billable fallback.
- **`resolveAgenticChain`** — tier → `[primary, ...fallbacks]` filtered to Anthropic entries with registry pricing attached. The loop speaks the Anthropic wire format (streaming, tool_use, cache_control); cross-provider agentic fallback would need a full tool-loop translation layer and stays **out of scope** (cross-provider fallback remains on the single-shot `execute()` path). The invariant this depends on — every tier's primary is Anthropic — is now test-guarded.
- **Per-turn model fallback** in `runAgenticLoop` — on terminal request failure, advance the chain and continue the conversation (Anthropic→Anthropic is seamless). **429 never falls back**: it propagates for the worker queue-pause path (#27). WAL `model_fallback` on switch.
- **Per-segment cost accrual** — cost is now accumulated per turn under the model that served it. Also fixes a latent bug: the spend-cap guardrail previously ignored cache tokens.
- **All four TIER_MAPs deleted.** Callers pass `tier`; WAL/token_usage rows record the model that actually served the run (`result.model`, `usedFallback`).
- **Probe sites** (cli status/health, health-monitor) resolve their 1-token key-probe model from the registry via `probeModel()` — a hardcoded model ID aging out would have read as a fleet-wide API outage.

## Verification
- Full `nexaas conformance` **10/10** on a scratch worker — ai-pillar reaches the mock model *through the gateway*; WAL records the registry-resolved model + fallback flag.
- vitest **83/83** (8 new chain tests incl. real-registry invariants). Build + typecheck clean.

## Out of scope (unchanged)
RAG/CAG wiring into ai-skill, workspace behavioral-contract enforcement in the live path, `extended_thinking`, and the single-shot pipeline path's status — H5 (#258) reconciles the docs to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI tasks now select models dynamically based on configured performance tiers.
  - Supported AI operations can automatically fall back to another model when a request fails.
  - Health and API key checks use the currently configured model instead of a fixed model.

- **Improvements**
  - AI usage costs and token consumption are tracked using the model that actually handled each request.
  - Budget limits are applied consistently across AI-powered workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->