### PR TITLE
feat(core): single-source primitives — @nexaas/manifest, writeDrawerRaw, folded health (#256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ Set in `.env` (never committed):
 ├── packages/
 │   ├── palace/src/                     Palace API, WAL, embeddings, signing
 │   ├── runtime/src/                    Pipeline, gateway, TAG, CAG, RAG, worker, notifications
+│   ├── manifest/src/                   Skill-manifest schema + loader (single source of truth)
 │   ├── cli/src/                        nexaas CLI (commands listed above)
 │   └── factory/commands/               /new-skill, /new-flow, /new-mcp, /nexaasify
 ├── capabilities/

--- a/mcp/servers/palace/src/index.ts
+++ b/mcp/servers/palace/src/index.ts
@@ -23,7 +23,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import pg from "pg";
-import { appendWal } from "@nexaas/palace";
+import { appendWal, writeDrawerRaw } from "@nexaas/palace";
 
 // ── Database ────────────────────────────────────────────────────────────
 
@@ -159,15 +159,13 @@ server.tool(
     skill_id: z.string().optional().describe("Skill ID that produced this (optional)"),
   },
   async ({ wing, hall, room, content, skill_id }) => {
-    const { createHash } = await import("crypto");
-    const hash = createHash("sha256").update(content).digest("hex");
-
-    const result = await sql<{ id: string }>(
-      `INSERT INTO nexaas_memory.events
-        (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id)
-       VALUES ($1, $2, $3, $4, $5, $6, 'drawer', 'palace-mcp', $7)
-       RETURNING id::text`,
-      [WORKSPACE, wing, hall, room, content, hash, skill_id ?? "interactive"],
+    // Shared drawer primitive (#256) — same INSERT the framework's own
+    // writers use, so schema changes land here for free.
+    const drawerId = await writeDrawerRaw(
+      WORKSPACE,
+      { wing, hall, room },
+      content,
+      { agentId: "palace-mcp", skillId: skill_id ?? "interactive" },
     );
 
     // WAL entry for audit — through the canonical appendWal so the row is
@@ -181,13 +179,13 @@ server.tool(
       workspace: WORKSPACE,
       op: "palace_mcp_write",
       actor: "palace-mcp",
-      payload: { wing, hall, room, drawer_id: result[0]?.id, content_length: content.length },
+      payload: { wing, hall, room, drawer_id: drawerId, content_length: content.length },
     });
 
     return jsonResult({
       written: true,
       room: `${wing}/${hall}/${room}`,
-      drawer_id: result[0]?.id,
+      drawer_id: drawerId,
     });
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,6 +1769,10 @@
       "resolved": "packages/integration-sdk",
       "link": true
     },
+    "node_modules/@nexaas/manifest": {
+      "resolved": "packages/manifest",
+      "link": true
+    },
     "node_modules/@nexaas/mcp-email-outbound": {
       "resolved": "mcp/servers/email-outbound",
       "link": true
@@ -5830,6 +5834,7 @@
       "name": "@nexaas/cli",
       "version": "0.1.0",
       "dependencies": {
+        "@nexaas/manifest": "^0.1.0",
         "@nexaas/palace": "^0.1.0",
         "@nexaas/runtime": "^0.1.0",
         "zod": "^3.23.0"
@@ -5866,6 +5871,19 @@
         "typescript": "^5.5.0"
       }
     },
+    "packages/manifest": {
+      "name": "@nexaas/manifest",
+      "version": "0.1.0",
+      "dependencies": {
+        "js-yaml": "^4.1.1",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
     "packages/ops-console-core": {
       "name": "@nexaas/ops-console-core",
       "version": "0.1.0",
@@ -5898,6 +5916,7 @@
         "@bull-board/api": "^6.0.0",
         "@bull-board/express": "^6.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@nexaas/manifest": "^0.1.0",
         "@nexaas/palace": "^0.1.0",
         "bullmq": "^5.0.0",
         "cron-parser": "^4.9.0",

--- a/packages/cli/src/dry-run.ts
+++ b/packages/cli/src/dry-run.ts
@@ -12,24 +12,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
-import { load as yamlLoad } from "js-yaml";
-import pg from "pg";
-
-interface SkillManifest {
-  id: string;
-  version: string;
-  description?: string;
-  timezone?: string;
-  triggers?: Array<{ type: string; schedule?: string; timezone?: string }>;
-  execution?: { type: string; command?: string; timeout?: number; model_tier?: string; working_directory?: string };
-  mcp_servers?: Array<string | { id: string; tools?: string[] }>;
-  rooms?: {
-    primary?: { wing: string; hall: string; room: string };
-    retrieval_rooms?: Array<{ wing: string; hall: string; room: string }>;
-  };
-  outputs?: Array<{ id: string; routing_default?: string; overridable?: boolean }>;
-  self_reflection?: boolean;
-}
+import { loadManifest, validateManifestShape, type SkillManifest } from "@nexaas/manifest";
 
 export async function run(args: string[]) {
   const manifestPath = args.find(a => !a.startsWith("--"));
@@ -51,10 +34,12 @@ export async function run(args: string[]) {
     process.exit(1);
   }
 
-  const content = readFileSync(manifestPath, "utf-8");
+  // Shared loader (#256): contract.yaml manifests normalize to the same
+  // shape register-skill accepts, so dry-run no longer reports "missing
+  // 'id'" on a manifest the scheduler would happily register.
   let manifest: SkillManifest;
   try {
-    manifest = yamlLoad(content) as SkillManifest;
+    manifest = loadManifest(manifestPath);
   } catch (e) {
     console.error(`Invalid YAML: ${(e as Error).message}`);
     process.exit(1);
@@ -75,6 +60,9 @@ export async function run(args: string[]) {
   if (!manifest.id) issues.push("Missing 'id' field");
   if (!manifest.version) issues.push("Missing 'version' field");
   if (!manifest.execution?.type) issues.push("Missing 'execution.type' field");
+  if (manifest.id && manifest.version) {
+    issues.push(...validateManifestShape(manifest).map((i) => `Schema: ${i}`));
+  }
 
   if (manifest.execution?.type === "ai-skill") {
     const promptPath = join(skillDir, "prompt.md");
@@ -217,7 +205,10 @@ export async function run(args: string[]) {
   if (manifest.execution?.type === "shell") {
     const { execSync } = await import("child_process");
     const cwd = manifest.execution.working_directory ?? skillDir;
-    const timeout = (manifest.execution.timeout ?? 120) * 1000;
+    // execution.timeout is MILLISECONDS (docs/skill-authoring.md) — the
+    // pre-#256 `* 1000` here treated it as seconds, turning a 2-minute
+    // manifest timeout into a 33-hour one for --live runs.
+    const timeout = manifest.execution.timeout ?? 120_000;
 
     try {
       const output = execSync(manifest.execution.command!, {

--- a/packages/cli/src/health.ts
+++ b/packages/cli/src/health.ts
@@ -1,15 +1,17 @@
 /**
  * nexaas health — detailed health report.
- * Self-contained (no cross-package imports) — queries DB and services directly.
+ *
+ * Thin renderer over the runtime's `runHealthCheck` (#256) — the same
+ * checks the in-process 5-minute health monitor runs, plus a live probe
+ * of the worker's HTTP endpoint (which the in-process monitor must skip —
+ * self-curling your own event loop is the #33 deadlock class). Before the
+ * fold this file was a second, diverging implementation: #245's
+ * cadence-aware staleness never made it here, and #215's spend budget
+ * never made it into the monitor.
  */
 
-import { execSync } from "child_process";
-import pg from "pg";
-import { probeModel } from "@nexaas/runtime";
-
-function exec(cmd: string): string {
-  try { return execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim(); } catch { return ""; }
-}
+import { runHealthCheck } from "@nexaas/runtime";
+import { getPool } from "@nexaas/palace";
 
 export async function run() {
   const workspace = process.env.NEXAAS_WORKSPACE;
@@ -20,143 +22,43 @@ export async function run() {
     process.exit(1);
   }
 
-  const pool = new pg.Pool({ connectionString: dbUrl, max: 2 });
-  const alerts: Array<{ sev: string; comp: string; msg: string }> = [];
-
   console.log("\n  Running health check...\n");
 
-  // Worker
-  let uptime = 0;
-  try {
-    const h = JSON.parse(exec("curl -sf http://localhost:9090/health 2>/dev/null") || "{}");
-    uptime = h.uptime ?? 0;
-    if (h.status !== "healthy") alerts.push({ sev: "critical", comp: "worker", msg: "unhealthy" });
-  } catch { alerts.push({ sev: "critical", comp: "worker", msg: "not responding" }); }
+  const report = await runHealthCheck(workspace, { probeWorker: true });
+  const m = report.metrics;
 
-  // Redis
-  if (exec("redis-cli ping 2>/dev/null") !== "PONG") {
-    alerts.push({ sev: "critical", comp: "redis", msg: "not responding" });
-  }
+  const status = report.status.toUpperCase();
+  const icon = report.status === "healthy" ? "✓" : report.status === "degraded" ? "⚠" : "✗";
 
-  // Success rate last hour
-  const hr = await pool.query(`
-    SELECT count(*) FILTER (WHERE status = 'completed') as ok,
-           count(*) FILTER (WHERE status = 'failed') as fail
-    FROM nexaas_memory.skill_runs
-    WHERE started_at > now() - interval '1 hour' AND status IN ('completed','failed')
-  `);
-  const ok = parseInt(hr.rows[0]?.ok ?? "0", 10);
-  const fail = parseInt(hr.rows[0]?.fail ?? "0", 10);
-  const total = ok + fail;
-  const rate = total > 0 ? Math.round(100 * ok / total) : 100;
-  if (rate < 80 && total > 5) alerts.push({ sev: "warning", comp: "skills", msg: `${rate}% success rate (${fail} failures)` });
-
-  // Consecutive failures
-  const consec = await pool.query(`
-    WITH ranked AS (
-      SELECT skill_id, status, ROW_NUMBER() OVER (PARTITION BY skill_id ORDER BY started_at DESC) as rn
-      FROM nexaas_memory.skill_runs WHERE started_at > now() - interval '2 hours'
-    )
-    SELECT skill_id, count(*) as c FROM ranked WHERE rn <= 5 AND status = 'failed' GROUP BY skill_id HAVING count(*) >= 3
-  `);
-  for (const r of consec.rows) {
-    alerts.push({ sev: "critical", comp: r.skill_id, msg: `${r.c} consecutive failures` });
-  }
-
-  // API key
-  const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
-  if (!apiKey || apiKey.includes("placeholder")) {
-    alerts.push({ sev: "critical", comp: "api", msg: "not set" });
-  } else {
-    try {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
-        body: JSON.stringify({ model: probeModel(), max_tokens: 1, messages: [{ role: "user", content: "ok" }] }),
-      });
-      if (res.status === 400 && (await res.text()).includes("credit")) alerts.push({ sev: "critical", comp: "api", msg: "credits exhausted" });
-      else if (res.status === 401) alerts.push({ sev: "critical", comp: "api", msg: "key invalid" });
-    } catch { /* network error, skip */ }
-  }
-
-  // Cost today
-  const costRes = await pool.query(`
-    SELECT COALESCE(sum((payload->>'cost_usd')::numeric), 0) as cost
-    FROM nexaas_memory.wal WHERE op = 'ai_skill_completed' AND created_at > date_trunc('day', now()) AND payload->>'cost_usd' IS NOT NULL
-  `);
-  const cost = parseFloat(costRes.rows[0]?.cost ?? "0");
-  if (cost > 20) alerts.push({ sev: "warning", comp: "cost", msg: `$${cost.toFixed(2)} today` });
-
-  // Daily spend budget (#215). Tolerates a not-yet-migrated DB (the
-  // spend_daily table arrives with migration 026) — health must not break
-  // during the upgrade window.
-  let budgetLine = "(unlimited)";
-  try {
-    const budgetRes = await pool.query(
-      `SELECT c.spend_daily_budget_usd::text AS budget,
-              COALESCE(s.usd, 0)::text AS spent,
-              (SELECT value FROM nexaas_memory.workspace_kv kv
-                WHERE kv.workspace = c.workspace AND kv.key = 'spend_pause_active_day') AS paused_day
-         FROM nexaas_memory.workspace_config c
-         LEFT JOIN nexaas_memory.spend_daily s
-           ON s.workspace = c.workspace
-          AND s.day = (now() AT TIME ZONE c.timezone)::date
-        WHERE c.workspace = $1`,
-      [workspace],
-    );
-    const b = budgetRes.rows[0];
-    if (b?.budget) {
-      const budgetUsd = parseFloat(b.budget);
-      const spentUsd = parseFloat(b.spent ?? "0");
-      const pct = budgetUsd > 0 ? Math.round((100 * spentUsd) / budgetUsd) : 0;
-      budgetLine = `$${spentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)} (${pct}%)${b.paused_day ? " — QUEUE PAUSED" : ""}`;
-      if (b.paused_day) {
-        alerts.push({ sev: "critical", comp: "spend-budget", msg: `daily budget exceeded — queue paused (resumes at local midnight or via spend-override)` });
-      } else if (pct >= 80) {
-        alerts.push({ sev: "warning", comp: "spend-budget", msg: `${pct}% of daily budget spent ($${spentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)})` });
-      }
-    }
-  } catch { /* pre-026 schema — no budget machinery yet */ }
-
-  // Counts
-  const walRes = await pool.query(`SELECT count(*) FROM nexaas_memory.wal WHERE workspace = $1`, [workspace]);
-  const palaceRes = await pool.query(`SELECT count(*) FROM nexaas_memory.events WHERE workspace = $1 AND wing IS NOT NULL`, [workspace]);
-
-  // System
-  const memInfo = exec("free -g 2>/dev/null");
-  let memUsed = 0, memAvail = 0;
-  const mm = memInfo.match(/Mem:\s+\d+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+(\d+)/);
-  if (mm) { memUsed = parseInt(mm[1]!, 10); memAvail = parseInt(mm[2]!, 10); }
-  const diskPct = parseInt(exec("df -h / | tail -1").match(/(\d+)%/)?.[1] ?? "0", 10);
-  if (diskPct > 85) alerts.push({ sev: "warning", comp: "disk", msg: `${diskPct}% used` });
-  if (memAvail < 2) alerts.push({ sev: "warning", comp: "memory", msg: `${memAvail}GB available` });
-
-  // Report
-  const status = alerts.some(a => a.sev === "critical") ? "CRITICAL" : alerts.some(a => a.sev === "warning") ? "DEGRADED" : "HEALTHY";
-  const icon = status === "HEALTHY" ? "✓" : status === "DEGRADED" ? "⚠" : "✗";
+  const budgetLine = m.spend_budget
+    ? `$${m.spend_budget.spent_usd.toFixed(2)} of $${m.spend_budget.budget_usd.toFixed(2)}` +
+      ` (${m.spend_budget.budget_usd > 0 ? Math.round((100 * m.spend_budget.spent_usd) / m.spend_budget.budget_usd) : 0}%)` +
+      `${m.spend_budget.paused ? " — QUEUE PAUSED" : ""}`
+    : "(unlimited)";
 
   console.log(`  ${icon} Overall: ${status}\n`);
   console.log("  Metrics:");
-  console.log(`    Worker uptime:      ${Math.round(uptime)}s`);
-  console.log(`    Last hour:          ${ok} ok, ${fail} fail (${rate}%)`);
-  console.log(`    API cost today:     $${cost.toFixed(2)}`);
+  console.log(`    Worker uptime:      ${Math.round(m.worker_uptime_seconds)}s`);
+  console.log(`    Last hour:          ${m.completions_last_hour} ok, ${m.failures_last_hour} fail (${m.success_rate_last_hour}%)`);
+  console.log(`    Skills (4h):        ${m.skills_total} seen, ${m.skills_healthy} healthy, ${m.skills_failing} failing`);
+  console.log(`    API cost today:     $${m.api_cost_today_usd.toFixed(2)}`);
   console.log(`    Spend budget:       ${budgetLine}`);
-  console.log(`    WAL entries:        ${walRes.rows[0]?.count}`);
-  console.log(`    Palace drawers:     ${palaceRes.rows[0]?.count}`);
-  console.log(`    Memory:             ${memUsed}GB used, ${memAvail}GB available`);
-  console.log(`    Disk:               ${diskPct}% used`);
+  console.log(`    WAL entries:        ${m.wal_entries_total}`);
+  console.log(`    Palace drawers:     ${m.palace_drawers}`);
+  console.log(`    Memory:             ${m.memory_used_gb}GB used, ${m.memory_available_gb}GB available`);
+  console.log(`    Disk:               ${m.disk_used_pct}% used`);
 
-  if (alerts.length > 0) {
+  if (report.alerts.length > 0) {
     console.log("\n  Alerts:");
-    for (const a of alerts) {
-      const i = a.sev === "critical" ? "🔴" : a.sev === "warning" ? "🟡" : "🔵";
-      console.log(`    ${i} [${a.comp}] ${a.msg}`);
+    for (const a of report.alerts) {
+      const i = a.severity === "critical" ? "🔴" : a.severity === "warning" ? "🟡" : "🔵";
+      console.log(`    ${i} [${a.component}] ${a.message}`);
     }
   } else {
     console.log("\n  ✓ No alerts");
   }
   console.log("");
 
-  await pool.end();
-  process.exit(status === "CRITICAL" ? 1 : 0);
+  await getPool().end().catch(() => {});
+  process.exit(report.status === "critical" ? 1 : 0);
 }

--- a/packages/cli/src/library.ts
+++ b/packages/cli/src/library.ts
@@ -12,19 +12,12 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync, cpSync, readdirSync
 import { join, dirname, basename } from "path";
 import { createHash } from "crypto";
 import { execSync } from "child_process";
-import { load as yamlLoad } from "js-yaml";
 import pg from "pg";
-import { appendWal, getPool } from "@nexaas/palace";
+import { appendWal, getPool, writeDrawerRaw } from "@nexaas/palace";
+import { loadManifest, type SkillManifest } from "@nexaas/manifest";
 
 function exec(cmd: string): string {
   try { return execSync(cmd, { encoding: "utf-8", stdio: "pipe" }).trim(); } catch { return ""; }
-}
-
-interface SkillManifest {
-  id: string;
-  version: string;
-  description?: string;
-  execution?: { type: string };
 }
 
 export async function run(args: string[]) {
@@ -100,8 +93,7 @@ export async function run(args: string[]) {
         process.exit(1);
       }
 
-      const content = readFileSync(manifestPath, "utf-8");
-      const manifest = yamlLoad(content) as SkillManifest;
+      const manifest = loadManifest(manifestPath);
       const skillDir = dirname(manifestPath);
 
       // Read all skill files
@@ -128,26 +120,28 @@ export async function run(args: string[]) {
         break;
       }
 
-      // Register in the library
-      await pool.query(
-        `INSERT INTO nexaas_memory.events
-          (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id, metadata)
-         VALUES ($1, 'library', 'skills', $2, $3, $4, 'skill-registration', 'library', $2, $5)`,
-        [
-          workspace,
-          manifest.id,
-          JSON.stringify({
-            id: manifest.id,
-            version: manifest.version,
-            description: manifest.description,
-            execution_type: manifest.execution?.type,
-            files,
-            contributed_at: new Date().toISOString(),
-            source_path: manifestPath,
-          }),
-          hash,
-          JSON.stringify({ version: manifest.version, source: "workspace-contribute" }),
-        ],
+      // Register in the library. contentHash override: the stored hash is
+      // the dedupe key over the FILES map, not the content (which carries
+      // a fresh contributed_at every run).
+      await writeDrawerRaw(
+        workspace,
+        { wing: "library", hall: "skills", room: manifest.id },
+        JSON.stringify({
+          id: manifest.id,
+          version: manifest.version,
+          description: manifest.description,
+          execution_type: manifest.execution?.type,
+          files,
+          contributed_at: new Date().toISOString(),
+          source_path: manifestPath,
+        }),
+        {
+          eventType: "skill-registration",
+          agentId: "library",
+          skillId: manifest.id,
+          contentHash: hash,
+          metadata: { version: manifest.version, source: "workspace-contribute" },
+        },
       );
 
       // WAL entry — canonical, advisory-locked writer (#254).
@@ -289,18 +283,19 @@ export async function run(args: string[]) {
         break;
       }
 
-      // Promote: copy to canonical hall
-      await pool.query(
-        `INSERT INTO nexaas_memory.events
-          (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id, metadata)
-         VALUES ($1, 'library', 'canonical', $2, $3, $4, 'skill-promotion', 'library', $2, $5)`,
-        [
-          workspace,
+      // Promote: copy to canonical hall. contentHash carries over from the
+      // library row — it's the files-map dedupe key, not sha256(content).
+      await writeDrawerRaw(
+        workspace,
+        { wing: "library", hall: "canonical", room: skillId },
+        libResult.rows[0].content,
+        {
+          eventType: "skill-promotion",
+          agentId: "library",
           skillId,
-          libResult.rows[0].content,
-          libResult.rows[0].content_hash,
-          JSON.stringify({ version: data.version, promoted_at: new Date().toISOString(), promoted_by: "ops" }),
-        ],
+          contentHash: libResult.rows[0].content_hash,
+          metadata: { version: data.version, promoted_at: new Date().toISOString(), promoted_by: "ops" },
+        },
       );
 
       // WAL entry — canonical, advisory-locked writer (#254).
@@ -388,10 +383,9 @@ function findSkillManifests(dir: string): Array<SkillManifest & { path: string }
     for (const entry of readdirSync(d, { withFileTypes: true })) {
       if (entry.isDirectory() && entry.name !== "node_modules") {
         walk(join(d, entry.name));
-      } else if (entry.name === "skill.yaml") {
+      } else if (entry.name === "skill.yaml" || entry.name === "contract.yaml") {
         try {
-          const content = readFileSync(join(d, entry.name), "utf-8");
-          const manifest = yamlLoad(content) as SkillManifest;
+          const manifest = loadManifest(join(d, entry.name));
           if (manifest.id) {
             results.push({ ...manifest, path: join(d, entry.name) });
           }

--- a/packages/cli/src/propagate.ts
+++ b/packages/cli/src/propagate.ts
@@ -101,8 +101,8 @@ export async function run(args: string[]) {
         const localManifestPath = join(localSkillDir, "skill.yaml");
         if (!existsSync(localManifestPath)) continue;
 
-        const { load: yamlLoad } = await import("js-yaml");
-        const localManifest = yamlLoad(readFileSync(localManifestPath, "utf-8")) as { version?: string };
+        const { loadManifest } = await import("@nexaas/manifest");
+        const localManifest = loadManifest(localManifestPath);
         const localVersion = localManifest.version ?? "0.0.0";
 
         if (localVersion === libData.version) continue;

--- a/packages/cli/src/register-skill.ts
+++ b/packages/cli/src/register-skill.ts
@@ -12,10 +12,9 @@
  * is passed in by the caller so a bulk run does it once for N manifests.
  */
 
-import { existsSync, readFileSync } from "fs";
+import { existsSync } from "fs";
 import { resolve, dirname, join } from "path";
 import { execSync } from "child_process";
-import { load as yamlLoad } from "js-yaml";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 import parser from "cron-parser";
@@ -26,106 +25,14 @@ import {
   isEphemeralPath,
   type UpsertSummary,
 } from "@nexaas/runtime";
+import { loadManifest, normalizeManifest, type SkillManifest } from "@nexaas/manifest";
 
-export interface SkillManifest {
-  id: string;
-  version: string;
-  description?: string;
-  timezone?: string;
-  /**
-   * Mutex groups (#95 / #96). Skills sharing a group serialize at the
-   * worker. The CLI also uses the list at registration time to flag
-   * cron-overlap with already-registered skills (#99).
-   */
-  concurrency_groups?: string[];
-  triggers?: Array<{
-    type: string;
-    schedule?: string;
-    timezone?: string;
-    channel_role?: string;            // for type=inbound-message; e.g. "pa_reply_<user>"
-  }>;
-  execution?: {
-    type: string;
-    command?: string;
-    timeout?: number;
-    working_directory?: string;
-  };
-}
-
-/**
- * Normalize a YAML-parsed manifest into the framework's `SkillManifest`
- * shape (#139). Accepts both:
- *
- *   1. The framework's `skill.yaml` format — `id:`, `version:`, `triggers:[]`,
- *      `execution.timeout` (ms). Pass-through.
- *
- *   2. The richer `contract.yaml` format used by some adopters (Nexmatic
- *      skill packages, for instance) — `skill:` + `category:` instead of
- *      `id:`, top-level `schedule:` instead of `triggers:[]`,
- *      `execution.timeout_seconds:` instead of `execution.timeout` (ms).
- *      Plus product-level fields (`produces:`, `outputs:`, `tag_defaults:`,
- *      `client_must_configure:`, etc.) the framework already ignores as
- *      unknown fields.
- *
- * Detection heuristic: missing `id` AND present `skill` → contract shape.
- * Otherwise treated as native skill.yaml.
- *
- * Pure helper: no I/O, no side effects. Tested in
- * `scripts/test-manifest-normalize-139.mjs`.
- */
-export function normalizeManifest(raw: Record<string, unknown> | null): SkillManifest {
-  if (!raw || typeof raw !== "object") {
-    return {} as SkillManifest;
-  }
-  const r = raw as Record<string, unknown>;
-  const isContract = typeof r.id !== "string" && typeof r.skill === "string";
-  if (!isContract) {
-    return r as unknown as SkillManifest;
-  }
-
-  // ── contract.yaml → skill.yaml translation ────────────────────────
-  const skill = String(r.skill);
-  // If `skill:` already contains a slash, skip the category prefix.
-  // Otherwise, prepend `category:` when present.
-  const id = skill.includes("/")
-    ? skill
-    : typeof r.category === "string" && r.category.length > 0
-      ? `${r.category}/${skill}`
-      : skill;
-
-  // Triggers: prefer explicit `triggers:[]` when present; otherwise lift
-  // top-level `schedule:` into a cron trigger.
-  let triggers = Array.isArray(r.triggers) ? (r.triggers as SkillManifest["triggers"]) : undefined;
-  if (!triggers && typeof r.schedule === "string" && r.schedule.length > 0) {
-    triggers = [{ type: "cron", schedule: r.schedule }];
-  }
-
-  // Execution: prefer `execution.timeout` (ms) when present; otherwise
-  // convert `execution.timeout_seconds` (s) → ms.
-  const execIn = (r.execution as Record<string, unknown> | undefined) ?? undefined;
-  let execution: SkillManifest["execution"] | undefined;
-  if (execIn) {
-    const timeoutMs = typeof execIn.timeout === "number"
-      ? (execIn.timeout as number)
-      : typeof execIn.timeout_seconds === "number"
-        ? Math.floor((execIn.timeout_seconds as number) * 1000)
-        : undefined;
-    execution = {
-      type: typeof execIn.type === "string" ? (execIn.type as string) : "shell",
-      ...(typeof execIn.command === "string" ? { command: execIn.command as string } : {}),
-      ...(typeof timeoutMs === "number" ? { timeout: timeoutMs } : {}),
-      ...(typeof execIn.working_directory === "string" ? { working_directory: execIn.working_directory as string } : {}),
-    };
-  }
-
-  return {
-    ...r,
-    id,
-    version: typeof r.version === "string" ? r.version : "0",
-    ...(triggers ? { triggers } : {}),
-    ...(execution ? { execution } : {}),
-  } as unknown as SkillManifest;
-}
+// The manifest schema + contract.yaml normalization moved to
+// @nexaas/manifest (#256) so registration, triggering, and BullMQ
+// execution all parse the same shape. Re-exported here because
+// register-skills.ts and scripts/test-manifest-normalize-139.mjs
+// import them from this module.
+export { normalizeManifest, type SkillManifest };
 
 export interface RegisterContext {
   queue: Queue;
@@ -372,9 +279,7 @@ export async function registerOneSkill(
 
   let manifest: SkillManifest;
   try {
-    const content = readFileSync(manifestPath, "utf-8");
-    const raw = yamlLoad(content) as Record<string, unknown> | null;
-    manifest = normalizeManifest(raw);
+    manifest = loadManifest(manifestPath);
     if (!manifest?.id || !manifest?.version) {
       return {
         skillId: manifestPath,

--- a/packages/cli/src/seed-palace.ts
+++ b/packages/cli/src/seed-palace.ts
@@ -14,7 +14,7 @@ import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { join, basename, relative } from "path";
 import { createHash } from "crypto";
 import pg from "pg";
-import { appendWal, getPool } from "@nexaas/palace";
+import { appendWal, getPool, writeDrawerRaw } from "@nexaas/palace";
 
 interface SeedEntry {
   filePath: string;
@@ -233,16 +233,17 @@ export async function run(args: string[]) {
         continue;
       }
 
-      // Write drawer
-      await pool.query(
-        `INSERT INTO nexaas_memory.events (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id, metadata)
-         VALUES ($1, $2, $3, $4, $5, $6, 'seed', 'palace-seed', $7, $8)`,
-        [
-          workspace, entry.wing, entry.hall, entry.room,
-          content, hash,
-          `seed/${entry.contentType}`,
-          JSON.stringify({ source_file: relPath, priority: entry.priority, content_type: entry.contentType }),
-        ],
+      // Write drawer via the shared primitive (#256)
+      await writeDrawerRaw(
+        workspace,
+        { wing: entry.wing, hall: entry.hall, room: entry.room },
+        content,
+        {
+          eventType: "seed",
+          agentId: "palace-seed",
+          skillId: `seed/${entry.contentType}`,
+          metadata: { source_file: relPath, priority: entry.priority, content_type: entry.contentType },
+        },
       );
 
       console.log(`  ✓ ${entry.wing}/${entry.hall}/${entry.room} ← ${relPath}`);

--- a/packages/cli/src/trigger-skill.ts
+++ b/packages/cli/src/trigger-skill.ts
@@ -5,8 +5,7 @@
  *   nexaas trigger-skill <path-to-skill.yaml>
  */
 
-import { readFileSync } from "fs";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest } from "@nexaas/manifest";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 import { randomUUID } from "crypto";
@@ -24,8 +23,13 @@ export async function run(args: string[]) {
     process.exit(1);
   }
 
-  const content = readFileSync(manifestPath, "utf-8");
-  const manifest = yamlLoad(content) as { id: string; version: string; execution?: { type: string } };
+  // Shared loader (#256) — a contract.yaml skill triggers with its derived
+  // `category/skill` id instead of `undefined`.
+  const manifest = loadManifest(manifestPath);
+  if (!manifest.id || !manifest.version) {
+    console.error(`Manifest at ${manifestPath} is missing required 'id' or 'version'`);
+    process.exit(1);
+  }
 
   const connection = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
     maxRetriesPerRequest: null,

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@nexaas/cli",
+  "name": "@nexaas/manifest",
   "version": "0.1.0",
-  "description": "Nexaas CLI tools \u2014 verify-wal, validate-skill, install-agent, rebuild-skill-runs, dry-run",
+  "description": "Skill-manifest single source of truth — schema, contract.yaml normalization, and loader shared by registration, triggering, and execution (#256)",
   "type": "module",
   "exports": {
     ".": {
@@ -10,20 +10,16 @@
     },
     "./package.json": "./package.json"
   },
-  "bin": {
-    "nexaas": "src/index.ts"
-  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@nexaas/manifest": "^0.1.0",
-    "@nexaas/palace": "^0.1.0",
-    "@nexaas/runtime": "^0.1.0",
+    "js-yaml": "^4.1.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "typescript": "^5.5.0"
   }

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -1,0 +1,345 @@
+/**
+ * @nexaas/manifest — the skill manifest's single source of truth (#256).
+ *
+ * Registration (`nexaas register-skill`), validation (`dry-run`), library
+ * packaging, HTTP triggering (`/api/skills/trigger`), and BullMQ execution
+ * all consume THIS module, so a manifest accepted at registration time is
+ * guaranteed to mean the same thing at execution time. Before the
+ * extraction, five-plus independent parsers each re-derived a subset of the
+ * shape — #246 (registered contract.yaml skills 404'd on trigger) was one
+ * instance of that class, and the BullMQ worker executing contract.yaml
+ * skills with `manifest.id = undefined` was the next one waiting.
+ *
+ * Leaf package: depends only on js-yaml + zod. Both @nexaas/cli and
+ * @nexaas/runtime import it; it must never import them.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join, resolve, sep } from "path";
+import { load as yamlLoad } from "js-yaml";
+import { z } from "zod";
+
+// ── Shape ────────────────────────────────────────────────────────────────
+
+export interface RoomRef {
+  wing: string;
+  hall: string;
+  room: string;
+}
+
+export interface SkillTrigger {
+  type: string;
+  schedule?: string;
+  timezone?: string;
+  /** for type=inbound-message; e.g. "pa_reply_<user>" */
+  channel_role?: string;
+  /** for type=batch */
+  bucket?: string;
+  fire_when?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface SkillExecution {
+  type: string;
+  command?: string;
+  /** MILLISECONDS (contract.yaml's `timeout_seconds` is converted on load). */
+  timeout?: number;
+  working_directory?: string;
+  model_tier?: string;
+  preflight?: {
+    command: string;
+    timeout?: number;
+    working_directory?: string;
+  };
+  primary_output?: string;
+  [key: string]: unknown;
+}
+
+export interface SkillLimits {
+  max_turns?: number;
+  max_spend_usd?: number;
+  max_input_tokens?: number;
+  max_output_tokens?: number;
+  max_output_tokens_per_turn?: number;
+  max_consecutive_identical_tool_calls?: number;
+  max_consecutive_errors?: number;
+}
+
+export interface SkillOutput {
+  id: string;
+  kind?: string;
+  routing_default?: string;
+  approval?: Record<string, unknown>;
+  notify?: { channel_role: string; timeout?: string };
+  verify?: Record<string, unknown>;
+  required?: boolean;
+  parse_mode?: "plain" | "markdown" | "html";
+  overridable?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * The normalized manifest. Executors keep their own richer views
+ * (`AiSkillManifest`, `ShellSkillManifest` in @nexaas/runtime) — this is
+ * the shared superset every consumer can rely on after `normalizeManifest`.
+ * Unknown adopter/product fields (`produces:`, `tag_defaults:`, …) pass
+ * through untouched.
+ */
+export interface SkillManifest {
+  id: string;
+  version: string;
+  description?: string;
+  timezone?: string;
+  concurrency_groups?: string[];
+  triggers?: SkillTrigger[];
+  execution?: SkillExecution;
+  mcp_servers?: Array<string | { id: string; tools?: string[] }>;
+  rooms?: {
+    primary?: RoomRef;
+    retrieval_rooms?: RoomRef[];
+  };
+  outputs?: SkillOutput[];
+  limits?: SkillLimits;
+  self_reflection?: boolean;
+  [key: string]: unknown;
+}
+
+// ── Zod schema ───────────────────────────────────────────────────────────
+
+const roomRefSchema = z.object({
+  wing: z.string(),
+  hall: z.string(),
+  room: z.string(),
+});
+
+/**
+ * Structural validation for a NORMALIZED manifest. Everything beyond
+ * id/version is optional — presence requirements (execution.type, prompt.md
+ * for ai-skills, …) are caller policy (`dry-run` enforces the strictest
+ * set). `.passthrough()` at every level: adopters ship extra fields.
+ */
+export const skillManifestSchema = z
+  .object({
+    id: z.string().min(1),
+    version: z.string().min(1),
+    description: z.string().optional(),
+    timezone: z.string().optional(),
+    concurrency_groups: z.array(z.string()).optional(),
+    triggers: z
+      .array(z.object({ type: z.string() }).passthrough())
+      .optional(),
+    execution: z
+      .object({
+        type: z.string(),
+        command: z.string().optional(),
+        timeout: z.number().optional(),
+        working_directory: z.string().optional(),
+        model_tier: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    mcp_servers: z
+      .array(
+        z.union([
+          z.string(),
+          z.object({ id: z.string(), tools: z.array(z.string()).optional() }).passthrough(),
+        ]),
+      )
+      .optional(),
+    rooms: z
+      .object({
+        primary: roomRefSchema.optional(),
+        retrieval_rooms: z.array(roomRefSchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+    outputs: z.array(z.object({ id: z.string() }).passthrough()).optional(),
+    limits: z
+      .object({
+        max_turns: z.number().optional(),
+        max_spend_usd: z.number().optional(),
+        max_input_tokens: z.number().optional(),
+        max_output_tokens: z.number().optional(),
+        max_output_tokens_per_turn: z.number().optional(),
+        max_consecutive_identical_tool_calls: z.number().optional(),
+        max_consecutive_errors: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    self_reflection: z.boolean().optional(),
+  })
+  .passthrough();
+
+/**
+ * Validate a normalized manifest's structure. Returns human-readable
+ * issues ("triggers.0.type: Required"), empty when valid.
+ */
+export function validateManifestShape(manifest: unknown): string[] {
+  const result = skillManifestSchema.safeParse(manifest);
+  if (result.success) return [];
+  return result.error.issues.map((i) =>
+    i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message,
+  );
+}
+
+// ── Normalization (moved verbatim from cli/register-skill.ts, #139) ─────
+
+/**
+ * Normalize a YAML-parsed manifest into the framework's `SkillManifest`
+ * shape (#139). Accepts both:
+ *
+ *   1. The framework's `skill.yaml` format — `id:`, `version:`, `triggers:[]`,
+ *      `execution.timeout` (ms). Pass-through.
+ *
+ *   2. The richer `contract.yaml` format used by some adopters (Nexmatic
+ *      skill packages, for instance) — `skill:` + `category:` instead of
+ *      `id:`, top-level `schedule:` instead of `triggers:[]`,
+ *      `execution.timeout_seconds:` instead of `execution.timeout` (ms).
+ *      Plus product-level fields (`produces:`, `outputs:`, `tag_defaults:`,
+ *      `client_must_configure:`, etc.) the framework already ignores as
+ *      unknown fields.
+ *
+ * Detection heuristic: missing `id` AND present `skill` → contract shape.
+ * Otherwise treated as native skill.yaml.
+ *
+ * Pure helper: no I/O, no side effects.
+ */
+export function normalizeManifest(raw: Record<string, unknown> | null): SkillManifest {
+  if (!raw || typeof raw !== "object") {
+    return {} as SkillManifest;
+  }
+  const r = raw as Record<string, unknown>;
+  const isContract = typeof r.id !== "string" && typeof r.skill === "string";
+  if (!isContract) {
+    return r as unknown as SkillManifest;
+  }
+
+  // ── contract.yaml → skill.yaml translation ────────────────────────
+  const skill = String(r.skill);
+  // If `skill:` already contains a slash, skip the category prefix.
+  // Otherwise, prepend `category:` when present.
+  const id = skill.includes("/")
+    ? skill
+    : typeof r.category === "string" && r.category.length > 0
+      ? `${r.category}/${skill}`
+      : skill;
+
+  // Triggers: prefer explicit `triggers:[]` when present; otherwise lift
+  // top-level `schedule:` into a cron trigger.
+  let triggers = Array.isArray(r.triggers) ? (r.triggers as SkillManifest["triggers"]) : undefined;
+  if (!triggers && typeof r.schedule === "string" && r.schedule.length > 0) {
+    triggers = [{ type: "cron", schedule: r.schedule }];
+  }
+
+  // Execution: prefer `execution.timeout` (ms) when present; otherwise
+  // convert `execution.timeout_seconds` (s) → ms.
+  const execIn = (r.execution as Record<string, unknown> | undefined) ?? undefined;
+  let execution: SkillManifest["execution"] | undefined;
+  if (execIn) {
+    const timeoutMs = typeof execIn.timeout === "number"
+      ? (execIn.timeout as number)
+      : typeof execIn.timeout_seconds === "number"
+        ? Math.floor((execIn.timeout_seconds as number) * 1000)
+        : undefined;
+    execution = {
+      ...execIn,
+      type: typeof execIn.type === "string" ? (execIn.type as string) : "shell",
+      ...(typeof execIn.command === "string" ? { command: execIn.command as string } : {}),
+      ...(typeof timeoutMs === "number" ? { timeout: timeoutMs } : {}),
+      ...(typeof execIn.working_directory === "string" ? { working_directory: execIn.working_directory as string } : {}),
+    };
+  }
+
+  return {
+    ...r,
+    id,
+    version: typeof r.version === "string" ? r.version : "0",
+    ...(triggers ? { triggers } : {}),
+    ...(execution ? { execution } : {}),
+  } as unknown as SkillManifest;
+}
+
+// ── Loader ───────────────────────────────────────────────────────────────
+
+/**
+ * Read + parse + normalize a manifest file. THE way to get a manifest off
+ * disk — every consumer sees identical id/trigger/timeout semantics
+ * regardless of whether the author shipped skill.yaml or contract.yaml.
+ *
+ * Throws on unreadable files and invalid YAML (same surface as the raw
+ * `yamlLoad(readFileSync(...))` it replaces — callers keep their existing
+ * error handling). Returns `{}`-shaped manifest for empty/non-object
+ * documents, matching `normalizeManifest(null)`.
+ */
+export function loadManifest(path: string): SkillManifest {
+  const raw = yamlLoad(readFileSync(path, "utf-8"));
+  return normalizeManifest(
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null,
+  );
+}
+
+/** Canonical manifest filenames in resolution order. `skill.yaml` is the
+ *  legacy framework name; `contract.yaml` is the format register-skill
+ *  accepts natively as of #139/#141. */
+export const MANIFEST_FILENAMES = ["skill.yaml", "contract.yaml"] as const;
+
+/**
+ * Resolve a skill_id into an absolute manifest path under the workspace's
+ * skills root, rejecting any input that would escape the root.
+ *
+ * Returns the first existing manifest file from MANIFEST_FILENAMES at
+ * `<root>/nexaas-skills/<category>/<name>/`. Falls back to the first
+ * candidate (skill.yaml) if neither exists so the caller's 404 message
+ * names a sensible path. Returns null only for path-traversal attempts
+ * (caller surfaces a 400).
+ */
+/**
+ * Walk `<skillsRoot>/<category>/<name>/` two levels deep and return one
+ * manifest path per skill directory, preferring skill.yaml over
+ * contract.yaml (same order as MANIFEST_FILENAMES / the trigger path).
+ * Replaces five near-identical private walkers (scheduler reconcile,
+ * manifest index, inbound/batch dispatchers, staleness watchdog) that
+ * had each hardcoded skill.yaml only.
+ */
+export function findManifestPaths(skillsRoot: string): string[] {
+  if (!existsSync(skillsRoot)) return [];
+  const out: string[] = [];
+  for (const category of readdirSync(skillsRoot)) {
+    const catPath = join(skillsRoot, category);
+    try { if (!statSync(catPath).isDirectory()) continue; } catch { continue; }
+    for (const name of readdirSync(catPath)) {
+      const skillPath = join(catPath, name);
+      try { if (!statSync(skillPath).isDirectory()) continue; } catch { continue; }
+      for (const filename of MANIFEST_FILENAMES) {
+        const candidate = join(skillPath, filename);
+        if (existsSync(candidate)) { out.push(candidate); break; }
+      }
+    }
+  }
+  return out;
+}
+
+export function resolveSkillManifestPath(
+  skillId: string,
+  workspaceRoot: string,
+): string | null {
+  // Tighten input shape — alphanumeric segments separated by `/`, no `..`,
+  // no leading slash, no embedded NULs.
+  if (!/^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/.test(skillId)) return null;
+
+  const skillsRoot = resolve(workspaceRoot, "nexaas-skills");
+  const skillDir = resolve(skillsRoot, skillId);
+
+  // Defense in depth — even though the regex above blocks `..`, verify
+  // the resolved path is genuinely under the skills root before touching
+  // the filesystem. Catches e.g. symlinked categories.
+  if (!skillDir.startsWith(skillsRoot + sep)) return null;
+
+  for (const filename of MANIFEST_FILENAMES) {
+    const candidate = resolve(skillDir, filename);
+    if (existsSync(candidate)) return candidate;
+  }
+  // Neither variant exists — return the legacy name so the 404 message
+  // points operators at the conventional location.
+  return resolve(skillDir, MANIFEST_FILENAMES[0]);
+}

--- a/packages/manifest/tsconfig.json
+++ b/packages/manifest/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/palace/src/index.ts
+++ b/packages/palace/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Core palace API
-export { palace, resolveWaitpoint, type PalaceSession, type PalaceContext } from "./palace.js";
+export { palace, resolveWaitpoint, writeDrawerRaw, type RawDrawerOpts, type PalaceSession, type PalaceContext } from "./palace.js";
 
 // Types
 export { type Drawer, type DrawerId, type DrawerMeta, type RoomPath, type WalkOpts } from "./types.js";

--- a/packages/palace/src/palace.ts
+++ b/packages/palace/src/palace.ts
@@ -33,6 +33,76 @@ function contentHash(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 
+/**
+ * Options for `writeDrawerRaw`. Everything defaults to the neutral system
+ * writer; sites override only what they mean.
+ */
+export interface RawDrawerOpts {
+  /** Semantic row type — 'drawer' (default), 'alert', 'seed', 'health-check', … */
+  eventType?: string;
+  /** Who wrote it (default "system"). */
+  agentId?: string;
+  skillId?: string | null;
+  runId?: string | null;
+  stepId?: string | null;
+  subAgentId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  /**
+   * Override the stored content_hash. Default sha256(content). Only for
+   * writers that use the column as a dedupe key over something other than
+   * the content itself (cli/library hashes the skill FILES map so that
+   * re-contributing unchanged files dedupes despite a fresh timestamp
+   * inside `content`).
+   */
+  contentHash?: string;
+  dormantSignal?: string | null;
+  dormantUntil?: Date | null;
+  reminderAt?: Date | null;
+  normalizeVersion?: number;
+}
+
+/**
+ * THE drawer INSERT (#256). Every write into `nexaas_memory.events` goes
+ * through here — `PalaceSession.writeDrawer` for run-scoped skill writes,
+ * and system writers (notifications, PA endpoints, health monitor, seeding,
+ * library, ingest chunker, palace MCP) directly. Before this primitive
+ * existed, seven call sites carried their own INSERT statements because the
+ * only write surface required a full run-shaped PalaceContext; they drifted
+ * on defaults (normalize_version, metadata) and would each have needed
+ * separate patching for any schema change.
+ *
+ * Deliberately NOT WAL-logged: audit semantics differ per caller (some WAL
+ * per write, some per batch, some route through markers). Callers keep
+ * their own `appendWal` calls.
+ */
+export async function writeDrawerRaw(
+  workspace: string,
+  room: RoomPath,
+  content: string,
+  opts: RawDrawerOpts = {},
+): Promise<DrawerId> {
+  const row = await sqlOne<{ id: string }>(
+    `INSERT INTO nexaas_memory.events
+      (workspace, wing, hall, room, content, content_hash, event_type, agent_id,
+       skill_id, run_id, step_id, sub_agent_id, metadata,
+       dormant_signal, dormant_until, reminder_at, normalize_version)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+     RETURNING id`,
+    [
+      workspace, room.wing, room.hall, room.room,
+      content, opts.contentHash ?? contentHash(content),
+      opts.eventType ?? "drawer", opts.agentId ?? "system",
+      opts.skillId ?? null, opts.runId ?? null, opts.stepId ?? null, opts.subAgentId ?? null,
+      opts.metadata != null ? JSON.stringify(opts.metadata) : null,
+      opts.dormantSignal ?? null,
+      opts.dormantUntil ?? null,
+      opts.reminderAt ?? null,
+      opts.normalizeVersion ?? 1,
+    ],
+  );
+  return row!.id;
+}
+
 function parseDuration(dur: string): number {
   const match = dur.match(/^(\d+(?:\.\d+)?)\s*(s|m|h|d)$/);
   if (!match) throw new Error(`Invalid duration: ${dur}`);
@@ -52,27 +122,21 @@ function createSession(ctx: PalaceContext): PalaceSession {
     ctx,
 
     async writeDrawer(room: RoomPath, content: string, meta?: DrawerMeta): Promise<DrawerId> {
-      const hash = contentHash(content);
       // Cross-workspace write: use target workspace if declared, otherwise own workspace
       const targetWorkspace = room.workspace ?? meta?.target_workspace as string ?? ctx.workspace;
-      const row = await sqlOne<{ id: string }>(
-        `INSERT INTO nexaas_memory.events
-          (workspace, wing, hall, room, content, content_hash, event_type, agent_id,
-           skill_id, run_id, step_id, sub_agent_id, metadata,
-           dormant_signal, dormant_until, reminder_at, normalize_version)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-         RETURNING id`,
-        [
-          targetWorkspace, room.wing, room.hall, room.room,
-          content, hash, "drawer", ctx.skillId ?? "system",
-          ctx.skillId, ctx.runId, ctx.stepId, ctx.subAgentId,
-          JSON.stringify({ ...meta, source_workspace: ctx.workspace }),
-          meta?.dormant_signal ?? null,
-          meta?.dormant_until ?? null,
-          meta?.reminder_at ?? null,
-          meta?.normalize_version ?? 1,
-        ],
-      );
+      const drawerId = await writeDrawerRaw(targetWorkspace, room, content, {
+        eventType: "drawer",
+        agentId: ctx.skillId ?? "system",
+        skillId: ctx.skillId,
+        runId: ctx.runId,
+        stepId: ctx.stepId,
+        subAgentId: ctx.subAgentId,
+        metadata: { ...meta, source_workspace: ctx.workspace },
+        dormantSignal: meta?.dormant_signal ?? null,
+        dormantUntil: meta?.dormant_until ?? null,
+        reminderAt: meta?.reminder_at ?? null,
+        normalizeVersion: meta?.normalize_version ?? 1,
+      });
 
       // WAL audit for cross-workspace writes
       if (targetWorkspace !== ctx.workspace) {
@@ -83,13 +147,13 @@ function createSession(ctx: PalaceContext): PalaceSession {
           payload: {
             target_workspace: targetWorkspace,
             wing: room.wing, hall: room.hall, room: room.room,
-            drawer_id: row!.id,
+            drawer_id: drawerId,
             run_id: ctx.runId,
           },
         });
       }
 
-      return row!.id;
+      return drawerId;
     },
 
     async walkRoom(room: RoomPath, opts?: WalkOpts): Promise<Drawer[]> {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -19,6 +19,7 @@
     "@bull-board/api": "^6.0.0",
     "@bull-board/express": "^6.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@nexaas/manifest": "^0.1.0",
     "@nexaas/palace": "^0.1.0",
     "bullmq": "^5.0.0",
     "cron-parser": "^4.9.0",

--- a/packages/runtime/src/api/pa-notify.ts
+++ b/packages/runtime/src/api/pa-notify.ts
@@ -27,7 +27,7 @@
  */
 
 import { randomUUID } from "crypto";
-import { sql, appendWal } from "@nexaas/palace";
+import { sql, appendWal, writeDrawerRaw } from "@nexaas/palace";
 import { enqueueDelivery } from "../pa/delivery.js";
 
 export type Urgency = "immediate" | "normal" | "low";
@@ -472,38 +472,29 @@ export function defaultPaNotifyDeps(workspace: string): ExecuteDeps {
       }
     },
     writePendingDrawer: async (entry) => {
-      const rows = await sql<{ id: string }>(
-        `INSERT INTO nexaas_memory.events
-           (workspace, wing, hall, room, content, content_hash, event_type, agent_id, metadata, normalize_version)
-         VALUES ($1, 'notifications', 'pending', $2, $3,
-                 encode(digest($3, 'sha256'), 'hex'), 'drawer', 'pa-notify-endpoint',
-                 $4, 1)
-         RETURNING id`,
-        [
-          entry.workspace,
-          `pa-routed.${entry.threadId}`,
-          JSON.stringify(entry.payload),
-          JSON.stringify({ user: entry.user, thread_id: entry.threadId, notification_id: entry.notificationId }),
-        ],
+      const drawerId = await writeDrawerRaw(
+        entry.workspace,
+        { wing: "notifications", hall: "pending", room: `pa-routed.${entry.threadId}` },
+        JSON.stringify(entry.payload),
+        {
+          agentId: "pa-notify-endpoint",
+          metadata: { user: entry.user, thread_id: entry.threadId, notification_id: entry.notificationId },
+        },
       );
-      return { drawer_id: rows[0]!.id };
+      return { drawer_id: drawerId };
     },
     enqueueDeliveryMarker: async (entry) => {
       await enqueueDelivery(entry.workspace, entry.drawerId, entry.user, entry.threadId, entry.urgency);
     },
     writeAuditDrawer: async (entry) => {
-      await sql(
-        `INSERT INTO nexaas_memory.events
-           (workspace, wing, hall, room, content, content_hash, event_type, agent_id, metadata, normalize_version)
-         VALUES ($1, 'inbox', $2, 'notifications-emitted', $3,
-                 encode(digest($3, 'sha256'), 'hex'), 'drawer', 'pa-notify-endpoint',
-                 $4, 1)`,
-        [
-          entry.workspace,
-          entry.user,
-          JSON.stringify(entry.payload),
-          JSON.stringify({ notification_id: entry.notificationId, thread_id: entry.threadId }),
-        ],
+      await writeDrawerRaw(
+        entry.workspace,
+        { wing: "inbox", hall: entry.user, room: "notifications-emitted" },
+        JSON.stringify(entry.payload),
+        {
+          agentId: "pa-notify-endpoint",
+          metadata: { notification_id: entry.notificationId, thread_id: entry.threadId },
+        },
       );
       await appendWal({
         workspace: entry.workspace,

--- a/packages/runtime/src/api/skills-trigger.ts
+++ b/packages/runtime/src/api/skills-trigger.ts
@@ -21,10 +21,13 @@
  * the actual queue.add() so the route handler stays a thin shim.
  */
 
-import { existsSync, readFileSync } from "fs";
-import { resolve, sep } from "path";
-import { load as yamlLoad } from "js-yaml";
+import { existsSync } from "fs";
 import { randomUUID } from "crypto";
+import { loadManifest, resolveSkillManifestPath } from "@nexaas/manifest";
+
+// Path resolution moved to @nexaas/manifest (#256); re-exported because the
+// worker route and tests/skills-trigger-manifest.test.ts import it from here.
+export { resolveSkillManifestPath };
 
 export interface TriggerInput {
   skillId: string;
@@ -57,79 +60,28 @@ export interface ManifestSlim {
   execution?: { type?: string };
 }
 
-/** Canonical manifest filenames in resolution order. `skill.yaml` is the
- *  legacy framework name; `contract.yaml` is the format register-skill
- *  accepts natively as of #139/#141. Both are valid storage shapes — the
- *  trigger lookup needs to find whichever one the skill author ships. */
-const MANIFEST_FILENAMES = ["skill.yaml", "contract.yaml"] as const;
-
 /**
- * Resolve a skill_id into an absolute manifest path under the workspace's
- * skills root, rejecting any input that would escape the root.
- *
- * Returns the first existing manifest file from MANIFEST_FILENAMES at
- * `<root>/nexaas-skills/<category>/<name>/`. Falls back to the first
- * candidate (skill.yaml) if neither exists so the caller's 404 message
- * names a sensible path. Returns null only for path-traversal attempts
- * (caller surfaces a 400).
+ * Load the manifest for the trigger path via the shared loader (#256) —
+ * the hand-copied contract.yaml id-derivation this function carried after
+ * #246 now lives in `@nexaas/manifest.normalizeManifest`, shared with
+ * register-skill AND the executing BullMQ worker. Returns the slim view
+ * the trigger flow needs; null when the file is missing, unparseable, or
+ * lacks id/version (caller surfaces a 404).
  */
-export function resolveSkillManifestPath(
-  skillId: string,
-  workspaceRoot: string,
-): string | null {
-  // Tighten input shape — alphanumeric segments separated by `/`, no `..`,
-  // no leading slash, no embedded NULs.
-  if (!/^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/.test(skillId)) return null;
-
-  const skillsRoot = resolve(workspaceRoot, "nexaas-skills");
-  const skillDir = resolve(skillsRoot, skillId);
-
-  // Defense in depth — even though the regex above blocks `..`, verify
-  // the resolved path is genuinely under the skills root before touching
-  // the filesystem. Catches e.g. symlinked categories.
-  if (!skillDir.startsWith(skillsRoot + sep)) return null;
-
-  for (const filename of MANIFEST_FILENAMES) {
-    const candidate = resolve(skillDir, filename);
-    if (existsSync(candidate)) return candidate;
-  }
-  // Neither variant exists — return the legacy name so the 404 message
-  // points operators at the conventional location.
-  return resolve(skillDir, MANIFEST_FILENAMES[0]);
-}
-
 export function loadSkillManifest(path: string): ManifestSlim | null {
   if (!existsSync(path)) return null;
   try {
-    const raw = yamlLoad(readFileSync(path, "utf-8")) as Record<string, unknown>;
-    if (!raw || typeof raw !== "object") return null;
-
-    // contract.yaml shape (#246): declares `skill:` instead of `id:`. Derive
-    // the id the same way register-skill.ts:normalizeManifest does — `skill`,
-    // with a `category/` prefix when `skill` has no slash — so the trigger
-    // path accepts exactly the manifests register-skill already accepts. PR
-    // #170 made contract.yaml *resolvable* but left this validation
-    // native-only, so registered contract skills 404'd on trigger. The slim
-    // trigger path only needs id/version/execution.type; register-skill's
-    // normalizeManifest stays the canonical full translation.
-    let id = typeof raw.id === "string" ? raw.id : undefined;
-    if (!id && typeof raw.skill === "string") {
-      const skill = raw.skill;
-      const category = typeof raw.category === "string" ? raw.category : "";
-      id = skill.includes("/") || !category ? skill : `${category}/${skill}`;
-    }
-
-    const version = typeof raw.version === "string"
-      ? raw.version
-      : raw.version != null ? String(raw.version) : undefined;
+    const manifest = loadManifest(path);
+    const id = typeof manifest.id === "string" ? manifest.id : undefined;
+    const version = typeof manifest.version === "string"
+      ? manifest.version
+      : manifest.version != null ? String(manifest.version) : undefined;
     if (!id || !version) return null;
-
-    const execIn = raw.execution as Record<string, unknown> | undefined;
-    const execution = execIn && typeof execIn === "object"
-      ? { type: typeof execIn.type === "string" ? execIn.type : undefined }
-      : undefined;
-
-    return { id, version, execution };
+    return {
+      id,
+      version,
+      execution: manifest.execution ? { type: manifest.execution.type } : undefined,
+    };
   } catch {
     return null;
   }

--- a/packages/runtime/src/bullmq/worker.ts
+++ b/packages/runtime/src/bullmq/worker.ts
@@ -18,8 +18,8 @@ import { isRateLimitError, extractCooldownMs, pauseQueueFor } from "./rate-limit
 import { startHeartbeatLoop, stopHeartbeatLoop } from "../fleet/heartbeat.js";
 import { shutdownMcpPool } from "../mcp/pool.js";
 import { withGroups, resolveConcurrencyGroups } from "../concurrency-groups.js";
-import { readFileSync, existsSync } from "fs";
-import { load as yamlLoad } from "js-yaml";
+import { existsSync } from "fs";
+import { loadManifest } from "@nexaas/manifest";
 import { randomUUID } from "crypto";
 import { buildTerminalDrawerPayload, isEphemeralPath } from "../skill-terminal.js";
 
@@ -68,9 +68,13 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
           // will append its own WAL row.
           throw new Error(`manifest_missing: ${jobData.manifestPath}`);
         }
-        const manifestContent = readFileSync(jobData.manifestPath, "utf-8");
-        const manifest = yamlLoad(manifestContent) as Record<string, unknown>;
-        const execType = (manifest.execution as Record<string, unknown>)?.type;
+        // Shared loader (#256): normalizes contract.yaml at EXECUTION time,
+        // not just registration time. The raw yamlLoad this replaces ran a
+        // registered contract.yaml skill with `manifest.id = undefined` in
+        // its run records and silently ignored `timeout_seconds` — the same
+        // class as #246, one hop later in the pipeline.
+        const manifest = loadManifest(jobData.manifestPath);
+        const execType = manifest.execution?.type;
 
         // Forward BullMQ job context so the executor reuses the
         // dispatcher's runId and sees triggerType / triggerPayload (#47).
@@ -89,8 +93,7 @@ export function startWorker(workspaceId: string, concurrency: number = 5): Worke
         // #135 — `{field}` placeholders in group names are substituted
         // from trigger payload at dispatch time, letting a manifest
         // declare per-payload isolation like `pa-notify:{user}:{thread_id}`.
-        const rawGroups = (manifest as { concurrency_groups?: string[] })
-          .concurrency_groups;
+        const rawGroups = manifest.concurrency_groups;
         const groups = resolveConcurrencyGroups(
           rawGroups,
           data.triggerPayload as Record<string, unknown> | undefined,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -41,6 +41,14 @@ export {
   type SkillJobData,
 } from "./bullmq/index.js";
 export { runCompaction } from "./tasks/closet-compaction.js";
+export {
+  runHealthCheck,
+  runAndRecord as runHealthCheckAndRecord,
+  sendAlerts as sendHealthAlerts,
+  type HealthReport,
+  type HealthAlert,
+  type HealthCheckOpts,
+} from "./tasks/health-monitor.js";
 export { reapExpiredWaitpoints, sendPendingReminders } from "./tasks/waitpoint-reaper.js";
 export {
   recordSpend,

--- a/packages/runtime/src/ingest/chunker.ts
+++ b/packages/runtime/src/ingest/chunker.ts
@@ -6,7 +6,7 @@
  * optimal embedding and retrieval (800-1500 chars).
  */
 
-import { sql } from "@nexaas/palace";
+import { sql, writeDrawerRaw } from "@nexaas/palace";
 
 export interface ChunkResult {
   parentId: string;
@@ -86,19 +86,13 @@ export async function chunkAndStore(
       chunk_type: "document-chunk",
     };
 
-    const result = await sql<{ id: string }>(
-      `INSERT INTO nexaas_memory.events
-        (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id, metadata)
-       VALUES ($1, $2, $3, $4, $5, encode(digest($5, 'sha256'), 'hex'), 'document-chunk', 'chunker', 'document-vault', $6::jsonb)
-       RETURNING id::text`,
-      [workspace, parentRoom.wing, parentRoom.hall,
-       `${parentRoom.room}__chunk_${i}`,
-       chunk, JSON.stringify(chunkMeta)],
+    const drawerId = await writeDrawerRaw(
+      workspace,
+      { wing: parentRoom.wing, hall: parentRoom.hall, room: `${parentRoom.room}__chunk_${i}` },
+      chunk,
+      { eventType: "document-chunk", agentId: "chunker", skillId: "document-vault", metadata: chunkMeta },
     );
-
-    if (result.length > 0) {
-      drawerIds.push(result[0].id);
-    }
+    drawerIds.push(drawerId);
   }
 
   // Update parent metadata with chunk info

--- a/packages/runtime/src/notifications.ts
+++ b/packages/runtime/src/notifications.ts
@@ -5,7 +5,7 @@
  * Supports severity-based routing, rate limiting, and ack/snooze.
  */
 
-import { sql, appendWal } from "@nexaas/palace";
+import { sql, appendWal, writeDrawerRaw } from "@nexaas/palace";
 
 export type NotificationSeverity = "critical" | "warning" | "info";
 export type NotificationChannel = "telegram" | "email" | "palace";
@@ -72,22 +72,17 @@ export async function notify(payload: NotificationPayload): Promise<{ sent: Noti
 
   // Palace — always record
   try {
-    await sql(
-      `INSERT INTO nexaas_memory.events
-        (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id)
-       VALUES ($1, 'notifications', 'alerts', $2, $3, encode(digest($3, 'sha256'), 'hex'), 'alert', 'notifications', $4)`,
-      [
-        payload.workspace,
-        payload.severity,
-        JSON.stringify({
-          title: payload.title,
-          body: payload.body,
-          severity: payload.severity,
-          component: payload.component,
-          timestamp: new Date().toISOString(),
-        }),
-        payload.skillId ?? "system",
-      ],
+    await writeDrawerRaw(
+      payload.workspace,
+      { wing: "notifications", hall: "alerts", room: payload.severity },
+      JSON.stringify({
+        title: payload.title,
+        body: payload.body,
+        severity: payload.severity,
+        component: payload.component,
+        timestamp: new Date().toISOString(),
+      }),
+      { eventType: "alert", agentId: "notifications", skillId: payload.skillId ?? "system" },
     );
     sent.push("palace");
   } catch { /* palace write failure shouldn't block notifications */ }

--- a/packages/runtime/src/skill-manifest-index.ts
+++ b/packages/runtime/src/skill-manifest-index.ts
@@ -1,16 +1,14 @@
 /**
  * Skill manifest lookup helper (shared by inbound-dispatcher, approval-resolver,
- * and any future caller that needs to resolve a skill_id to a manifest path
- * without duplicating the filesystem walker).
+ * and any future caller that needs to resolve a skill_id to a manifest path).
  *
- * Walks `${NEXAAS_WORKSPACE_ROOT}/nexaas-skills/<category>/<name>/skill.yaml`
- * and caches the (id → path, execType) map with a short TTL. Both dispatchers
- * previously had their own copies; this module consolidates the pattern.
+ * Walks `${NEXAAS_WORKSPACE_ROOT}/nexaas-skills/` via the shared
+ * @nexaas/manifest walker and caches the (id → path, execType) map with a
+ * short TTL.
  */
 
-import { readdirSync, readFileSync, existsSync, statSync } from "fs";
 import { join } from "path";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest, findManifestPaths } from "@nexaas/manifest";
 
 interface SkillIndexEntry {
   skillId: string;
@@ -26,32 +24,11 @@ interface CachedIndex {
 let _cached: CachedIndex | null = null;
 const INDEX_TTL_MS = 30_000;
 
-function findManifestPaths(skillsRoot: string): string[] {
-  if (!existsSync(skillsRoot)) return [];
-  const out: string[] = [];
-  for (const category of readdirSync(skillsRoot)) {
-    const catPath = join(skillsRoot, category);
-    try { if (!statSync(catPath).isDirectory()) continue; } catch { continue; }
-    for (const name of readdirSync(catPath)) {
-      const skillPath = join(catPath, name);
-      try { if (!statSync(skillPath).isDirectory()) continue; } catch { continue; }
-      const manifestPath = join(skillPath, "skill.yaml");
-      if (existsSync(manifestPath)) out.push(manifestPath);
-    }
-  }
-  return out;
-}
-
-interface MinimalManifest {
-  id?: string;
-  execution?: { type?: string };
-}
-
 function buildIndex(skillsRoot: string): CachedIndex {
   const byId = new Map<string, SkillIndexEntry>();
   for (const manifestPath of findManifestPaths(skillsRoot)) {
     try {
-      const manifest = yamlLoad(readFileSync(manifestPath, "utf-8")) as MinimalManifest;
+      const manifest = loadManifest(manifestPath);
       if (typeof manifest.id !== "string") continue;
       const execType = manifest.execution?.type === "ai-skill" ? "ai-exec" : "shell-exec";
       byId.set(manifest.id, { skillId: manifest.id, manifestPath, execType });

--- a/packages/runtime/src/tasks/batch-dispatcher.ts
+++ b/packages/runtime/src/tasks/batch-dispatcher.ts
@@ -36,10 +36,9 @@
  *      on the next poll. (Item-level dedup falls out of using drawer_id arrays.)
  */
 
-import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest, findManifestPaths } from "@nexaas/manifest";
 import { sql, appendWal } from "@nexaas/palace";
 import cronParser from "cron-parser";
 import { enqueueSkillStep, type SkillJobData } from "../bullmq/queues.js";
@@ -169,28 +168,12 @@ export function extractItemDeadlineMs(content: string, field: string): number | 
   return Number.isFinite(ms) ? ms : null;
 }
 
-function findSkillManifests(skillsRoot: string): string[] {
-  if (!existsSync(skillsRoot)) return [];
-  const out: string[] = [];
-  for (const category of readdirSync(skillsRoot)) {
-    const catPath = join(skillsRoot, category);
-    try { if (!statSync(catPath).isDirectory()) continue; } catch { continue; }
-    for (const name of readdirSync(catPath)) {
-      const skillPath = join(catPath, name);
-      try { if (!statSync(skillPath).isDirectory()) continue; } catch { continue; }
-      const manifestPath = join(skillPath, "skill.yaml");
-      if (existsSync(manifestPath)) out.push(manifestPath);
-    }
-  }
-  return out;
-}
-
 function buildBatchIndex(skillsRoot: string): BatchIndex {
   const index: BatchIndex = new Map();
-  for (const manifestPath of findSkillManifests(skillsRoot)) {
+  for (const manifestPath of findManifestPaths(skillsRoot)) {
     let manifest: BatchManifest;
     try {
-      manifest = yamlLoad(readFileSync(manifestPath, "utf-8")) as BatchManifest;
+      manifest = loadManifest(manifestPath) as unknown as BatchManifest;
     } catch {
       continue;
     }

--- a/packages/runtime/src/tasks/health-monitor.ts
+++ b/packages/runtime/src/tasks/health-monitor.ts
@@ -17,7 +17,7 @@
  * 10. Disk and memory usage
  */
 
-import { sql, appendWal } from "@nexaas/palace";
+import { sql, appendWal, writeDrawerRaw } from "@nexaas/palace";
 import { exec as execCb } from "child_process";
 import { promisify } from "util";
 import { notify } from "../notifications.js";
@@ -36,13 +36,13 @@ async function exec(cmd: string): Promise<string> {
   } catch { return ""; }
 }
 
-interface HealthAlert {
+export interface HealthAlert {
   severity: "critical" | "warning" | "info";
   component: string;
   message: string;
 }
 
-interface HealthReport {
+export interface HealthReport {
   timestamp: string;
   workspace: string;
   status: "healthy" | "degraded" | "critical";
@@ -56,6 +56,8 @@ interface HealthReport {
     failures_last_hour: number;
     success_rate_last_hour: number;
     api_cost_today_usd: number;
+    /** Daily spend budget (#215). null = no budget configured / pre-026 schema. */
+    spend_budget: { budget_usd: number; spent_usd: number; paused: boolean } | null;
     wal_entries_total: number;
     palace_drawers: number;
     memory_used_gb: number;
@@ -64,13 +66,43 @@ interface HealthReport {
   };
 }
 
-export async function runHealthCheck(workspace: string): Promise<HealthReport> {
+export interface HealthCheckOpts {
+  /**
+   * Probe the worker's HTTP /health endpoint instead of trusting
+   * process.uptime(). Out-of-process callers (`nexaas health`) set this;
+   * the in-process monitor must NOT — a self-request from inside the
+   * worker's own event loop is the #33 deadlock class.
+   */
+  probeWorker?: boolean;
+}
+
+/**
+ * THE health check (#256). One set of checks shared by the in-process
+ * 5-minute monitor and `nexaas health` — before the fold, the CLI carried
+ * its own diverging copy (#245's cadence-aware staleness only landed in
+ * the monitor; #215's spend budget only in the CLI).
+ */
+export async function runHealthCheck(workspace: string, opts: HealthCheckOpts = {}): Promise<HealthReport> {
   const alerts: HealthAlert[] = [];
   const now = new Date().toISOString();
 
-  // 1. Worker health — use process.uptime() directly when running in-process
-  // to avoid deadlocking the event loop with a synchronous self-curl
+  // 1. Worker health — in-process, use process.uptime() directly (see
+  // HealthCheckOpts.probeWorker); out-of-process, ask the worker itself.
   let workerUptime = process.uptime();
+  if (opts.probeWorker) {
+    const port = process.env.NEXAAS_WORKER_PORT ?? "9090";
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(5000) });
+      const h = (await res.json()) as { status?: string; uptime?: number };
+      workerUptime = h.uptime ?? 0;
+      if (h.status !== "healthy") {
+        alerts.push({ severity: "critical", component: "worker", message: "Worker reports unhealthy" });
+      }
+    } catch {
+      workerUptime = 0;
+      alerts.push({ severity: "critical", component: "worker", message: `Worker not responding on :${port}` });
+    }
+  }
 
   // 2. Skill success rates (last hour)
   const hourlyStats = await sql<{ completed: string; failed: string }>(`
@@ -209,6 +241,45 @@ export async function runHealthCheck(workspace: string): Promise<HealthReport> {
     alerts.push({ severity: "warning", component: "cost", message: `Daily API spend: $${apiCostToday.toFixed(2)} (above $20 threshold)` });
   }
 
+  // 8b. Daily spend budget (#215). Tolerates a not-yet-migrated DB (the
+  // spend_daily table arrives with migration 026) — health must not break
+  // during the upgrade window.
+  let spendBudget: HealthReport["metrics"]["spend_budget"] = null;
+  try {
+    const budgetRes = await sql<{ budget: string | null; spent: string | null; paused_day: string | null }>(
+      `SELECT c.spend_daily_budget_usd::text AS budget,
+              COALESCE(s.usd, 0)::text AS spent,
+              (SELECT value FROM nexaas_memory.workspace_kv kv
+                WHERE kv.workspace = c.workspace AND kv.key = 'spend_pause_active_day') AS paused_day
+         FROM nexaas_memory.workspace_config c
+         LEFT JOIN nexaas_memory.spend_daily s
+           ON s.workspace = c.workspace
+          AND s.day = (now() AT TIME ZONE c.timezone)::date
+        WHERE c.workspace = $1`,
+      [workspace],
+    );
+    const b = budgetRes[0];
+    if (b?.budget) {
+      const budgetUsd = parseFloat(b.budget);
+      const spentUsd = parseFloat(b.spent ?? "0");
+      const pct = budgetUsd > 0 ? Math.round((100 * spentUsd) / budgetUsd) : 0;
+      spendBudget = { budget_usd: budgetUsd, spent_usd: spentUsd, paused: !!b.paused_day };
+      if (b.paused_day) {
+        alerts.push({
+          severity: "critical",
+          component: "spend-budget",
+          message: "daily budget exceeded — queue paused (resumes at local midnight or via spend-override)",
+        });
+      } else if (pct >= 80) {
+        alerts.push({
+          severity: "warning",
+          component: "spend-budget",
+          message: `${pct}% of daily budget spent ($${spentUsd.toFixed(2)} of $${budgetUsd.toFixed(2)})`,
+        });
+      }
+    }
+  } catch { /* pre-026 schema — no budget machinery yet */ }
+
   // 9. WAL count
   const walCount = await sql<{ count: string }>(
     `SELECT count(*) FROM nexaas_memory.wal WHERE workspace = $1`, [workspace],
@@ -268,6 +339,7 @@ export async function runHealthCheck(workspace: string): Promise<HealthReport> {
       failures_last_hour: failuresLastHour,
       success_rate_last_hour: successRate,
       api_cost_today_usd: apiCostToday,
+      spend_budget: spendBudget,
       wal_entries_total: parseInt(walCount[0]?.count ?? "0", 10),
       palace_drawers: palaceDrawers,
       memory_used_gb: memUsed,
@@ -283,11 +355,11 @@ export async function runAndRecord(workspace: string): Promise<HealthReport> {
   const report = await runHealthCheck(workspace);
 
   // Record as palace drawer
-  await sql(
-    `INSERT INTO nexaas_memory.events
-      (workspace, wing, hall, room, content, content_hash, event_type, agent_id, skill_id)
-     VALUES ($1, 'ops', 'health', 'monitor', $2, encode(digest($2, 'sha256'), 'hex'), 'health-check', 'health-monitor', 'system/health-monitor')`,
-    [workspace, JSON.stringify(report)],
+  await writeDrawerRaw(
+    workspace,
+    { wing: "ops", hall: "health", room: "monitor" },
+    JSON.stringify(report),
+    { eventType: "health-check", agentId: "health-monitor", skillId: "system/health-monitor" },
   );
 
   // WAL entry

--- a/packages/runtime/src/tasks/inbound-dispatcher.ts
+++ b/packages/runtime/src/tasks/inbound-dispatcher.ts
@@ -35,10 +35,9 @@
  *   task is orthogonal to this dispatcher and will land in Stage 1b.
  */
 
-import { readFileSync, existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest, findManifestPaths } from "@nexaas/manifest";
 import { sql, appendWal } from "@nexaas/palace";
 import { enqueueSkillStep, type SkillJobData } from "../bullmq/queues.js";
 import { matchDrawerAgainstWaitpoints, selectOpenWaitpoints } from "./inbound-match-waitpoint.js";
@@ -71,28 +70,12 @@ let _cached: CachedIndex | null = null;
 let _polling = false;
 let _interval: NodeJS.Timeout | null = null;
 
-function findSkillManifests(skillsRoot: string): string[] {
-  if (!existsSync(skillsRoot)) return [];
-  const out: string[] = [];
-  for (const category of readdirSync(skillsRoot)) {
-    const catPath = join(skillsRoot, category);
-    try { if (!statSync(catPath).isDirectory()) continue; } catch { continue; }
-    for (const name of readdirSync(catPath)) {
-      const skillPath = join(catPath, name);
-      try { if (!statSync(skillPath).isDirectory()) continue; } catch { continue; }
-      const manifestPath = join(skillPath, "skill.yaml");
-      if (existsSync(manifestPath)) out.push(manifestPath);
-    }
-  }
-  return out;
-}
-
 function buildInboundIndex(skillsRoot: string): InboundIndex {
   const index: InboundIndex = new Map();
-  for (const manifestPath of findSkillManifests(skillsRoot)) {
+  for (const manifestPath of findManifestPaths(skillsRoot)) {
     let manifest: InboundManifest;
     try {
-      manifest = yamlLoad(readFileSync(manifestPath, "utf-8")) as InboundManifest;
+      manifest = loadManifest(manifestPath) as InboundManifest;
     } catch {
       continue; // malformed manifest — skip silently, scheduler self-heal logs these
     }

--- a/packages/runtime/src/tasks/output-staleness-watchdog.ts
+++ b/packages/runtime/src/tasks/output-staleness-watchdog.ts
@@ -46,9 +46,8 @@
  * tree.
  */
 
-import { readdirSync, readFileSync, existsSync, statSync } from "fs";
 import { join } from "path";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest as loadSharedManifest, findManifestPaths } from "@nexaas/manifest";
 import { sql, palace, appendWal } from "@nexaas/palace";
 
 const DEFAULT_INTERVAL_MS = 6 * 60 * 60 * 1000;
@@ -105,26 +104,10 @@ export function parseDuration(s: string): number {
 
 function loadManifest(path: string): ManifestForStaleness | null {
   try {
-    const m = yamlLoad(readFileSync(path, "utf-8")) as ManifestForStaleness;
+    const m = loadSharedManifest(path) as unknown as ManifestForStaleness;
     if (!m?.id || !Array.isArray(m.outputs)) return null;
     return m;
   } catch { return null; }
-}
-
-function findManifests(skillsRoot: string): string[] {
-  if (!existsSync(skillsRoot)) return [];
-  const out: string[] = [];
-  for (const category of readdirSync(skillsRoot)) {
-    const catPath = join(skillsRoot, category);
-    let catStat;
-    try { catStat = statSync(catPath); } catch { continue; }
-    if (!catStat.isDirectory()) continue;
-    for (const skillName of readdirSync(catPath)) {
-      const skillPath = join(catPath, skillName, "skill.yaml");
-      if (existsSync(skillPath)) out.push(skillPath);
-    }
-  }
-  return out;
 }
 
 /**
@@ -217,7 +200,7 @@ export async function checkOutputStaleness(
   workspace: string,
   skillsRoot: string,
 ): Promise<{ stale: number; alerted: number }> {
-  const manifests = findManifests(skillsRoot);
+  const manifests = findManifestPaths(skillsRoot);
   const stale = await findStaleOutputs(workspace, manifests);
   if (stale.length === 0) return { stale: 0, alerted: 0 };
 

--- a/packages/runtime/src/worker.ts
+++ b/packages/runtime/src/worker.ts
@@ -25,7 +25,7 @@ import {
 import { join } from "path";
 import { promisify } from "util";
 import { exec as execCallback, spawn } from "child_process";
-import { load as yamlLoad } from "js-yaml";
+import { loadManifest, findManifestPaths, type SkillManifest } from "@nexaas/manifest";
 // IMPORTANT: static imports only. `await import(...)` inside an HTTP
 // handler round-trips through tsx/esbuild's IPC (epoll fd 62), which
 // blocks the main thread from draining the HTTP listener on libuv's
@@ -235,32 +235,6 @@ async function reconcileOrphanedRuns(workspace: string): Promise<number> {
  * (stale catch-up — BullMQ's scheduler handles post-downtime next-fire
  * on its own; no manual re-add needed).
  */
-interface SkillManifestForSchedule {
-  id: string;
-  version?: string;
-  timezone?: string;
-  triggers?: Array<{ type: string; schedule?: string; timezone?: string }>;
-  execution?: { type?: string };
-}
-
-function findSkillManifests(skillsRoot: string): string[] {
-  if (!existsSync(skillsRoot)) return [];
-  const out: string[] = [];
-
-  // Structure: nexaas-skills/{category}/{name}/skill.yaml
-  // Walk two levels deep; ignore non-directories and anything deeper.
-  for (const category of readdirSync(skillsRoot)) {
-    const catPath = join(skillsRoot, category);
-    try { if (!statSync(catPath).isDirectory()) continue; } catch { continue; }
-    for (const name of readdirSync(catPath)) {
-      const skillPath = join(catPath, name);
-      try { if (!statSync(skillPath).isDirectory()) continue; } catch { continue; }
-      const manifestPath = join(skillPath, "skill.yaml");
-      if (existsSync(manifestPath)) out.push(manifestPath);
-    }
-  }
-  return out;
-}
 
 async function reconcileSkillSchedulers(workspace: string): Promise<{
   registered: number;
@@ -291,12 +265,17 @@ async function reconcileSkillSchedulers(workspace: string): Promise<{
   let errors = 0;
 
   try {
-    const manifestPaths = findSkillManifests(skillsRoot);
+    const manifestPaths = findManifestPaths(skillsRoot);
 
     for (const manifestPath of manifestPaths) {
-      let manifest: SkillManifestForSchedule;
+      let manifest: SkillManifest;
       try {
-        manifest = yamlLoad(readFileSync(manifestPath, "utf-8")) as SkillManifestForSchedule;
+        manifest = loadManifest(manifestPath);
+        if (typeof manifest.id !== "string" || manifest.id.length === 0) {
+          console.warn(`[nexaas] skipping manifest without id: ${manifestPath}`);
+          errors++;
+          continue;
+        }
       } catch (err) {
         console.warn(`[nexaas] skipping malformed manifest ${manifestPath}: ${(err as Error).message}`);
         errors++;

--- a/tests/contract-docs.test.ts
+++ b/tests/contract-docs.test.ts
@@ -21,7 +21,8 @@ const ONTOLOGY = readFileSync(join(ROOT, "palace/ontology.yaml"), "utf-8");
 function sources(): string[] {
   const roots = [
     "packages/palace/src", "packages/runtime/src", "packages/cli/src",
-    "packages/integration-sdk/src", "mcp/servers/palace/src",
+    "packages/manifest/src", "packages/integration-sdk/src",
+    "mcp/servers/palace/src",
     "mcp/servers/email-outbound/src", "mcp/servers/webstudio/src",
   ];
   const files: string[] = [];

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @nexaas/manifest unit tests (#256) — the single shared schema/loader
+ * that register-skill, dry-run, library, trigger-skill, the trigger API,
+ * and the BullMQ worker all consume. The normalize cases mirror
+ * scripts/test-manifest-normalize-139.mjs and add the #256 fixes
+ * (execution field passthrough, walker filename preference).
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  findManifestPaths,
+  loadManifest,
+  normalizeManifest,
+  resolveSkillManifestPath,
+  validateManifestShape,
+} from "../packages/manifest/src/index.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "nexaas-manifest-test-"));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe("normalizeManifest", () => {
+  it("passes native skill.yaml through untouched", () => {
+    const raw = {
+      id: "ops/report", version: "1.2.0",
+      triggers: [{ type: "cron", schedule: "0 9 * * *" }],
+      execution: { type: "shell", command: "true", timeout: 5000 },
+    };
+    expect(normalizeManifest(raw)).toBe(raw as never);
+  });
+
+  it("derives id from category/skill on contract.yaml", () => {
+    const m = normalizeManifest({ skill: "invoice-chaser", category: "accounting", version: "2.0.0" });
+    expect(m.id).toBe("accounting/invoice-chaser");
+  });
+
+  it("skips the category prefix when skill already has a slash", () => {
+    const m = normalizeManifest({ skill: "ops/nightly", category: "ignored", version: "1" });
+    expect(m.id).toBe("ops/nightly");
+  });
+
+  it("lifts top-level schedule into a cron trigger", () => {
+    const m = normalizeManifest({ skill: "s", category: "c", version: "1", schedule: "*/5 * * * *" });
+    expect(m.triggers).toEqual([{ type: "cron", schedule: "*/5 * * * *" }]);
+  });
+
+  it("converts timeout_seconds to milliseconds", () => {
+    const m = normalizeManifest({
+      skill: "s", category: "c", version: "1",
+      execution: { type: "shell", command: "true", timeout_seconds: 90 },
+    });
+    expect(m.execution?.timeout).toBe(90_000);
+  });
+
+  it("prefers explicit timeout (ms) over timeout_seconds", () => {
+    const m = normalizeManifest({
+      skill: "s", category: "c", version: "1",
+      execution: { type: "shell", timeout: 1234, timeout_seconds: 90 },
+    });
+    expect(m.execution?.timeout).toBe(1234);
+  });
+
+  it("preserves unknown execution fields on the contract path (pre-#256 dropped them)", () => {
+    const m = normalizeManifest({
+      skill: "s", category: "c", version: "1",
+      execution: { type: "ai-skill", model_tier: "good", primary_output: "digest" },
+    });
+    expect(m.execution?.model_tier).toBe("good");
+    expect(m.execution?.primary_output).toBe("digest");
+  });
+
+  it("returns an empty manifest for null/non-object input", () => {
+    expect(normalizeManifest(null)).toEqual({});
+  });
+});
+
+describe("loadManifest", () => {
+  it("loads and normalizes a contract.yaml from disk", () => {
+    const dir = join(tmp, "load");
+    mkdirSync(dir, { recursive: true });
+    const p = join(dir, "contract.yaml");
+    writeFileSync(p, [
+      "skill: chaser", "category: accounting", "version: '1.0.0'",
+      "schedule: '0 8 * * *'",
+      "execution:", "  type: shell", "  command: 'true'", "  timeout_seconds: 60",
+    ].join("\n"));
+    const m = loadManifest(p);
+    expect(m.id).toBe("accounting/chaser");
+    expect(m.triggers?.[0]).toEqual({ type: "cron", schedule: "0 8 * * *" });
+    expect(m.execution?.timeout).toBe(60_000);
+  });
+
+  it("throws on invalid YAML (callers keep their own error handling)", () => {
+    const p = join(tmp, "bad.yaml");
+    writeFileSync(p, "id: [unclosed");
+    expect(() => loadManifest(p)).toThrow();
+  });
+});
+
+describe("validateManifestShape", () => {
+  it("accepts a normalized manifest with extra adopter fields", () => {
+    expect(validateManifestShape({
+      id: "a/b", version: "1", produces: ["x"], tag_defaults: { y: 1 },
+      execution: { type: "ai-skill", model_tier: "good" },
+    })).toEqual([]);
+  });
+
+  it("reports path-qualified issues", () => {
+    const issues = validateManifestShape({ id: "a/b", version: "1", triggers: [{ schedule: "x" }] });
+    expect(issues.some((i) => i.includes("triggers.0.type"))).toBe(true);
+  });
+});
+
+describe("findManifestPaths", () => {
+  it("walks category/skill dirs and prefers skill.yaml over contract.yaml", () => {
+    const root = join(tmp, "skills-root");
+    mkdirSync(join(root, "ops", "both"), { recursive: true });
+    mkdirSync(join(root, "ops", "contract-only"), { recursive: true });
+    mkdirSync(join(root, "ops", "empty"), { recursive: true });
+    writeFileSync(join(root, "ops", "both", "skill.yaml"), "id: ops/both\nversion: '1'\n");
+    writeFileSync(join(root, "ops", "both", "contract.yaml"), "skill: both\nversion: '9'\n");
+    writeFileSync(join(root, "ops", "contract-only", "contract.yaml"), "skill: contract-only\ncategory: ops\nversion: '1'\n");
+
+    const found = findManifestPaths(root).sort();
+    expect(found).toEqual([
+      join(root, "ops", "both", "skill.yaml"),
+      join(root, "ops", "contract-only", "contract.yaml"),
+    ]);
+  });
+
+  it("returns [] for a missing root", () => {
+    expect(findManifestPaths(join(tmp, "nope"))).toEqual([]);
+  });
+});
+
+describe("resolveSkillManifestPath", () => {
+  it("rejects traversal and resolves under nexaas-skills", () => {
+    const wsRoot = join(tmp, "ws");
+    mkdirSync(join(wsRoot, "nexaas-skills", "ops", "x"), { recursive: true });
+    writeFileSync(join(wsRoot, "nexaas-skills", "ops", "x", "contract.yaml"), "skill: x\nversion: '1'\n");
+    expect(resolveSkillManifestPath("../etc/passwd", wsRoot)).toBeNull();
+    expect(resolveSkillManifestPath("ops/x", wsRoot))
+      .toBe(join(wsRoot, "nexaas-skills", "ops", "x", "contract.yaml"));
+  });
+});

--- a/tests/write-drawer-raw.test.ts
+++ b/tests/write-drawer-raw.test.ts
@@ -1,0 +1,60 @@
+/**
+ * writeDrawerRaw (#256) — the single drawer INSERT all system writers
+ * share. DB-gated like the [db] harnesses: skips without DATABASE_URL.
+ * Uses a throwaway workspace id and deletes its own rows.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { getPool, palace, sql, writeDrawerRaw } from "../packages/palace/src/index.js";
+
+const hasDb = !!process.env.DATABASE_URL;
+const WS = `vitest-256-${process.pid}`;
+
+afterAll(async () => {
+  if (!hasDb) return;
+  await sql(`DELETE FROM nexaas_memory.events WHERE workspace = $1`, [WS]);
+  await getPool().end().catch(() => {});
+});
+
+describe.skipIf(!hasDb)("writeDrawerRaw", () => {
+  it("writes a drawer with defaults (event_type drawer, agent system, normalize_version 1)", async () => {
+    const id = await writeDrawerRaw(WS, { wing: "ops", hall: "test", room: "raw" }, "hello");
+    const [row] = await sql<Record<string, unknown>>(
+      `SELECT * FROM nexaas_memory.events WHERE id = $1::uuid`, [id],
+    );
+    expect(row).toBeDefined();
+    expect(row!.event_type).toBe("drawer");
+    expect(row!.agent_id).toBe("system");
+    expect(row!.normalize_version).toBe(1);
+    expect(row!.content).toBe("hello");
+    // default content_hash = sha256(content)
+    expect(row!.content_hash).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+
+  it("honors the contentHash override (library files-map dedupe key)", async () => {
+    const id = await writeDrawerRaw(
+      WS, { wing: "library", hall: "test", room: "dedupe" }, "content-with-timestamp",
+      { eventType: "skill-registration", agentId: "library", contentHash: "feed".repeat(16) },
+    );
+    const [row] = await sql<Record<string, unknown>>(
+      `SELECT event_type, content_hash FROM nexaas_memory.events WHERE id = $1::uuid`, [id],
+    );
+    expect(row!.event_type).toBe("skill-registration");
+    expect(row!.content_hash).toBe("feed".repeat(16));
+  });
+
+  it("backs PalaceSession.writeDrawer with identical row shape", async () => {
+    const session = palace.enter({ workspace: WS, skillId: "ops/tester", runId: undefined });
+    const id = await session.writeDrawer({ wing: "ops", hall: "test", room: "session" }, "via-session", { foo: "bar" } as never);
+    const [row] = await sql<Record<string, unknown>>(
+      `SELECT * FROM nexaas_memory.events WHERE id = $1::uuid`, [id],
+    );
+    expect(row!.event_type).toBe("drawer");
+    expect(row!.agent_id).toBe("ops/tester");
+    expect(row!.skill_id).toBe("ops/tester");
+    const meta = row!.metadata as Record<string, unknown>;
+    expect(meta.foo).toBe("bar");
+    expect(meta.source_workspace).toBe(WS);
+  });
+});


### PR DESCRIPTION
## Summary

H3 of framework-hardening v2 (#253). Three consolidations that close the single-source-of-truth failure class every recent regression belonged to (#234 second WAL writer, #246 second manifest parser, #206 code/schema drift, #245's second health impl):

### 1. `@nexaas/manifest` — one manifest schema/loader (new leaf package)
- `SkillManifest` type + zod shape schema + `normalizeManifest` (moved verbatim from `cli/register-skill.ts`) + `loadManifest` + `findManifestPaths` + `resolveSkillManifestPath`.
- Consumed by **register-skill, dry-run, library, trigger-skill, propagate, `/api/skills/trigger`, scheduler reconciler, manifest index, inbound/batch dispatchers, staleness watchdog, and the executing BullMQ worker** — registration and execution now parse the identical shape, killing the #246 class permanently.
- Bugs fixed on the way:
  - **BullMQ worker raw-loaded manifests** → a registered contract.yaml skill executed with `id=undefined` in run records and `timeout_seconds` silently ignored (the latent next-#246).
  - **dry-run `--live` multiplied the ms timeout by 1000** (2-min manifest timeout → 33 hours).
  - **dry-run rejected valid contract.yaml** ("missing id") that register-skill accepted.
  - **normalizeManifest dropped unknown `execution.*` fields** (e.g. `model_tier`) on the contract path.
  - All five filesystem walkers hardcoded `skill.yaml` — contract.yaml-only skills were invisible to schedule self-heal, the id index, and the dispatchers. One shared walker with the trigger path's filename preference.

### 2. `writeDrawerRaw` — THE drawer INSERT
- New primitive in `@nexaas/palace`; `PalaceSession.writeDrawer` is now a thin wrapper over it.
- The nine bypass writers (notifications, pa-notify ×2, health-monitor, ingest chunker, seed-palace, library ×2, palace MCP server) all route through it — schema changes now land in one statement.
- `contentHash` override preserves library's deliberate files-map dedupe semantics.
- Only remaining raw INSERTs are in `mcp/servers/memory` — the #260 orphan slated for deletion.

### 3. Health folded
- `runHealthCheck` is the single check set: monitor gains the **#215 spend-budget check**, CLI gains the **#245 cadence-aware staleness check**; new `probeWorker` option does the out-of-process worker check (`nexaas health`) while in-process keeps `process.uptime()` (the #33 self-curl deadlock class).
- `cli/health.ts` is now a ~60-line renderer + exit code.

## Verification
- Full vitest suite **280/280 green** against a freshly migrated scratch DB + Redis (includes the 32 bridged harnesses).
- New tests: `tests/manifest.test.ts` (normalize/loader/walker/traversal), `tests/write-drawer-raw.test.ts` (db-gated: defaults, hash override, writeDrawer parity).
- Live drives on testlab: `dry-run` on a contract.yaml (now normalizes + PASSes), `nexaas health` (worker probe, spend-budget line, alerts all render).
- `packages/manifest/src` added to the #258 contract-docs guard roots.

No migrations. No new env vars, WAL ops, or routes.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized skill manifest loading, normalization, validation, and discovery.
  * Added support for both `skill.yaml` and `contract.yaml` manifests.
  * Added enhanced health checks, including worker availability and spend-budget alerts.
  * Improved drawer creation consistency across CLI, runtime, notifications, and Palace workflows.
  * Added drawer IDs to write responses and audit records.

* **Bug Fixes**
  * Corrected shell execution timeout handling to use milliseconds.
  * Added safeguards against invalid manifest paths and path traversal.

* **Tests**
  * Added coverage for manifest processing, path resolution, drawer persistence, and health-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->