### PR TITLE
fix(palace): atomic workspace-scoped waitpoint resolution + real embedding upsert (#261)

### DIFF
--- a/database/migrations/030_embeddings_unique_drawer.sql
+++ b/database/migrations/030_embeddings_unique_drawer.sql
@@ -1,0 +1,26 @@
+-- 030: one embedding per drawer (#261)
+--
+-- upsertEmbedding declared `ON CONFLICT (id) DO UPDATE` where id defaults
+-- to gen_random_uuid() — the conflict could never fire and there was no
+-- unique constraint on drawer_id, so re-embedding a drawer accumulated
+-- duplicate rows (skewed RAG similarity, bloated the HNSW index). Dedupe
+-- (keep the newest embedding per drawer), then enforce uniqueness so the
+-- code's corrected `ON CONFLICT (drawer_id)` target works.
+--
+-- Rollback compatibility (one release, per docs/releases.md): prior-release
+-- code only writes embeddings through the Voyage-gated ingest embedder,
+-- which has never run in production (embeddings is empty fleet-wide at
+-- migration time — verified on Phoenix 2026-07-21). A rolled-back writer
+-- re-embedding the same drawer would now error instead of silently
+-- duplicating; with zero live writers this is theoretical, and the write
+-- it would block is precisely the bug.
+
+-- Dedupe: keep the newest row per drawer_id.
+DELETE FROM nexaas_memory.embeddings e
+ USING nexaas_memory.embeddings newer
+ WHERE newer.drawer_id = e.drawer_id
+   AND (newer.created_at > e.created_at
+        OR (newer.created_at = e.created_at AND newer.id > e.id));
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_embeddings_drawer
+  ON nexaas_memory.embeddings (drawer_id);

--- a/packages/palace/src/embeddings.ts
+++ b/packages/palace/src/embeddings.ts
@@ -18,11 +18,22 @@ export async function upsertEmbedding(
   model: string = "voyage-3",
 ): Promise<void> {
   const vectorStr = `[${embedding.join(",")}]`;
+  // ON CONFLICT (drawer_id) — backed by ux_embeddings_drawer (migration
+  // 030, #261). The original target was (id), whose gen_random_uuid()
+  // default could never conflict: this function INSERTED on every call
+  // and "upsert" was a lie — re-embedding accumulated duplicates.
   await sql(
     `INSERT INTO nexaas_memory.embeddings
       (workspace, drawer_id, wing, hall, room, embedding, model)
      VALUES ($1, $2, $3, $4, $5, $6::vector, $7)
-     ON CONFLICT (id) DO UPDATE SET embedding = $6::vector, model = $7`,
+     ON CONFLICT (drawer_id) DO UPDATE
+       SET embedding = EXCLUDED.embedding,
+           model = EXCLUDED.model,
+           workspace = EXCLUDED.workspace,
+           wing = EXCLUDED.wing,
+           hall = EXCLUDED.hall,
+           room = EXCLUDED.room,
+           created_at = now()`,
     [workspace, drawerId, room.wing, room.hall, room.room, vectorStr, model],
   );
 }

--- a/packages/palace/src/palace.ts
+++ b/packages/palace/src/palace.ts
@@ -235,24 +235,43 @@ export async function resolveWaitpoint(
   signal: string,
   resolution: Record<string, unknown>,
   actor: string,
+  workspace?: string,
 ): Promise<{ runId: string; skillId: string; stepId: string }> {
+  // Atomic claim (#261) — the same CTE + FOR UPDATE SKIP LOCKED pattern as
+  // pa/delivery.ts. The pre-#261 SELECT-then-UPDATE let the timeout
+  // reaper's auto_approve race a human approval: both read the row while
+  // dormant_signal was still set, both "resolved", and the business action
+  // executed twice. Now exactly one resolver gets the row back — the loser
+  // sees zero rows and throws the same "not found" error callers already
+  // treat as already-resolved.
+  //
+  // `workspace` scopes the lookup — without it, a signal collision in a
+  // shared-DB deployment resolved ANOTHER workspace's waitpoint. Optional
+  // only for library callers that genuinely don't know it (framework call
+  // sites all pass it).
+  const params: unknown[] = [signal];
+  let scope = "";
+  if (workspace !== undefined) {
+    params.push(workspace);
+    scope = " AND workspace = $2";
+  }
   const drawer = await sqlOne<Drawer>(
-    `SELECT * FROM nexaas_memory.events
-     WHERE dormant_signal = $1
-     LIMIT 1`,
-    [signal],
+    `UPDATE nexaas_memory.events
+        SET dormant_signal = NULL, dormant_until = NULL
+      WHERE id = (
+        SELECT id FROM nexaas_memory.events
+         WHERE dormant_signal = $1${scope}
+         ORDER BY created_at
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *`,
+    params,
   );
 
   if (!drawer) {
     throw new Error(`Waitpoint not found: ${signal}`);
   }
-
-  await sql(
-    `UPDATE nexaas_memory.events
-     SET dormant_signal = NULL, dormant_until = NULL
-     WHERE id = $1`,
-    [drawer.id],
-  );
 
   const session = createSession({
     workspace: drawer.workspace,

--- a/packages/runtime/src/tasks/approval-resolver.ts
+++ b/packages/runtime/src/tasks/approval-resolver.ts
@@ -298,6 +298,7 @@ export async function resolvePendingApprovals(workspace: string): Promise<{
           inbox_drawer_id: drawer.id,
         },
         `approval-callback:${drawer.id}`,
+        workspace,
       );
 
       // Fire resumption. If the approval declared a handler skill (#53),
@@ -429,6 +430,7 @@ export async function resolveApprovalBySignal(
       signal,
       { decision, output_id: approval.output_id, resolved_via: "api-direct" },
       actor,
+      workspace,
     );
     const resumption = await enqueueResumption(workspace, approval, decision, actor, payloadOverride);
 

--- a/packages/runtime/src/tasks/inbound-match-waitpoint.ts
+++ b/packages/runtime/src/tasks/inbound-match-waitpoint.ts
@@ -531,6 +531,7 @@ export async function matchDrawerAgainstWaitpoints(
           channel_role: drawer.room,
         },
         `inbound-match:${drawer.id}`,
+        workspace,
       );
       await appendWal({
         workspace,

--- a/packages/runtime/src/tasks/waitpoint-reaper.ts
+++ b/packages/runtime/src/tasks/waitpoint-reaper.ts
@@ -61,6 +61,7 @@ export async function reapExpiredWaitpoints(): Promise<number> {
             wp.dormant_signal,
             { decision: "approved", source: "timeout_auto_approve", authorized: false },
             "system:timeout-reaper",
+            wp.workspace,
           );
           break;
 
@@ -69,14 +70,22 @@ export async function reapExpiredWaitpoints(): Promise<number> {
             wp.dormant_signal,
             { decision: "rejected", source: "timeout_auto_reject", authorized: false },
             "system:timeout-reaper",
+            wp.workspace,
           );
           break;
 
-        case "auto_cancel":
-          await sql(
-            `UPDATE nexaas_memory.events SET dormant_signal = NULL WHERE id = $1`,
+        case "auto_cancel": {
+          // Claim guard (#261): only cancel if the waitpoint is still open.
+          // Without `dormant_signal IS NOT NULL ... RETURNING`, a human
+          // approval landing a moment earlier still got its freshly-resumed
+          // run marked cancelled by this path.
+          const claimed = await sql<{ id: string }>(
+            `UPDATE nexaas_memory.events SET dormant_signal = NULL
+              WHERE id = $1 AND dormant_signal IS NOT NULL
+              RETURNING id`,
             [wp.id],
           );
+          if (claimed.length === 0) break;
           if (wp.run_id) await runTracker.markCancelled(wp.run_id);
           await appendWal({
             workspace: wp.workspace,
@@ -85,6 +94,7 @@ export async function reapExpiredWaitpoints(): Promise<number> {
             payload: { signal: wp.dormant_signal, run_id: wp.run_id, skill_id: wp.skill_id },
           });
           break;
+        }
 
         case "escalate":
         default:

--- a/tests/concurrency-correctness.test.ts
+++ b/tests/concurrency-correctness.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #261 regression tests — the two concurrency-correctness fixes.
+ *
+ * 1. resolveWaitpoint is atomic: the timeout reaper's auto_approve racing a
+ *    human approval must produce exactly ONE successful resolution (the
+ *    pre-#261 SELECT-then-UPDATE let both succeed → business action ran
+ *    twice). Also workspace-scoped: a signal collision must not resolve
+ *    another workspace's waitpoint.
+ *
+ * 2. upsertEmbedding actually upserts: re-embedding a drawer updates the
+ *    one row instead of accumulating duplicates (conflict target was (id),
+ *    a gen_random_uuid() that could never conflict).
+ *
+ * DB-gated like the other [db] suites; uses throwaway workspaces and
+ * cleans up after itself.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  getPool, resolveWaitpoint, sql, upsertEmbedding, writeDrawerRaw,
+} from "../packages/palace/src/index.js";
+
+const hasDb = !!process.env.DATABASE_URL;
+const WS_A = `vitest-261a-${process.pid}`;
+const WS_B = `vitest-261b-${process.pid}`;
+
+async function openWaitpoint(workspace: string, signal: string): Promise<string> {
+  return writeDrawerRaw(
+    workspace,
+    { wing: "ops", hall: "test", room: "waitpoints" },
+    JSON.stringify({ purpose: "261-race-test" }),
+    { dormantSignal: signal, dormantUntil: new Date(Date.now() + 3600_000), runId: randomUUID() },
+  );
+}
+
+afterAll(async () => {
+  if (!hasDb) return;
+  await sql(`DELETE FROM nexaas_memory.embeddings WHERE workspace IN ($1, $2)`, [WS_A, WS_B]);
+  await sql(`DELETE FROM nexaas_memory.wal WHERE workspace IN ($1, $2)`, [WS_A, WS_B]);
+  await sql(`DELETE FROM nexaas_memory.events WHERE workspace IN ($1, $2)`, [WS_A, WS_B]);
+  await getPool().end().catch(() => {});
+});
+
+describe.skipIf(!hasDb)("resolveWaitpoint atomicity (#261)", () => {
+  it("exactly one of N concurrent resolvers wins", async () => {
+    const signal = `race-${randomUUID()}`;
+    await openWaitpoint(WS_A, signal);
+
+    // The reaper's auto_approve and a human approval, plus stragglers,
+    // all firing at once.
+    const outcomes = await Promise.allSettled([
+      resolveWaitpoint(signal, { decision: "approved", source: "human" }, "human:al", WS_A),
+      resolveWaitpoint(signal, { decision: "approved", source: "timeout_auto_approve" }, "system:timeout-reaper", WS_A),
+      resolveWaitpoint(signal, { decision: "rejected", source: "human" }, "human:other", WS_A),
+      resolveWaitpoint(signal, { decision: "approved", source: "retry" }, "human:al", WS_A),
+    ]);
+
+    const wins = outcomes.filter((o) => o.status === "fulfilled");
+    const losses = outcomes.filter((o) => o.status === "rejected");
+    expect(wins.length).toBe(1);
+    expect(losses.length).toBe(3);
+    for (const loss of losses) {
+      expect(String((loss as PromiseRejectedResult).reason)).toContain("Waitpoint not found");
+    }
+
+    // Exactly one waitpoint_resolved WAL row — the double-execution signal
+    // the pre-#261 race produced was two of these.
+    const walRows = await sql<{ n: string }>(
+      `SELECT count(*) AS n FROM nexaas_memory.wal
+        WHERE workspace = $1 AND op = 'waitpoint_resolved'
+          AND payload->>'signal' = $2`,
+      [WS_A, signal],
+    );
+    expect(Number(walRows[0]!.n)).toBe(1);
+  });
+
+  it("workspace-scoped: does not resolve another workspace's waitpoint", async () => {
+    const signal = `collide-${randomUUID()}`;
+    const idA = await openWaitpoint(WS_A, signal);
+    const idB = await openWaitpoint(WS_B, signal);
+
+    await resolveWaitpoint(signal, { decision: "approved" }, "human:al", WS_A);
+
+    const rows = await sql<{ id: string; dormant_signal: string | null }>(
+      `SELECT id, dormant_signal FROM nexaas_memory.events WHERE id IN ($1::uuid, $2::uuid)`,
+      [idA, idB],
+    );
+    const byId = new Map(rows.map((r) => [r.id, r.dormant_signal]));
+    expect(byId.get(idA)).toBeNull();          // A resolved
+    expect(byId.get(idB)).toBe(signal);        // B untouched
+
+    // B can still be resolved in its own workspace.
+    await resolveWaitpoint(signal, { decision: "approved" }, "human:al", WS_B);
+  });
+
+  it("unscoped call (no workspace arg) still resolves — library compatibility", async () => {
+    const signal = `unscoped-${randomUUID()}`;
+    await openWaitpoint(WS_A, signal);
+    const result = await resolveWaitpoint(signal, { decision: "approved" }, "human:al");
+    expect(result).toBeDefined();
+  });
+});
+
+describe.skipIf(!hasDb)("upsertEmbedding actually upserts (#261)", () => {
+  it("re-embedding a drawer updates the single row", async () => {
+    const drawerId = await writeDrawerRaw(
+      WS_A, { wing: "knowledge", hall: "test", room: "embed" }, "embed me",
+    );
+    const room = { wing: "knowledge", hall: "test", room: "embed" };
+    const vec = (fill: number) => Array.from({ length: 1024 }, () => fill);
+
+    await upsertEmbedding(WS_A, drawerId, room, vec(0.1), "voyage-3");
+    await upsertEmbedding(WS_A, drawerId, room, vec(0.2), "voyage-3-large");
+    await upsertEmbedding(WS_A, drawerId, room, vec(0.3), "voyage-3-large");
+
+    const rows = await sql<{ n: string; model: string }>(
+      `SELECT count(*) AS n, max(model) AS model FROM nexaas_memory.embeddings WHERE drawer_id = $1::uuid`,
+      [drawerId],
+    );
+    expect(Number(rows[0]!.n)).toBe(1);
+    expect(rows[0]!.model).toBe("voyage-3-large");
+  });
+});


### PR DESCRIPTION
## Summary

H8 — the **last track of framework-hardening v2 (#253)**. Two correctness bugs at the exact point an automation framework must be trustworthy: the approval gate.

### resolveWaitpoint: atomic + workspace-scoped
- **The race**: SELECT-then-UPDATE with no locking meant the timeout reaper's `auto_approve` and a human approval could both read the still-dormant row and both "resolve" it — **the business action behind the approval executed twice**. Now a single `UPDATE … WHERE id = (SELECT … FOR UPDATE SKIP LOCKED) RETURNING *` — the `pa/delivery.ts` claim pattern applied at the more critical site. Exactly one resolver wins; losers throw the same "Waitpoint not found" error every caller already treats as already-resolved (no caller changes needed for error handling).
- **The scoping**: lookup was `WHERE dormant_signal = $1 LIMIT 1` with no workspace filter — in any shared-DB deployment, a signal collision resolved *another workspace's* waitpoint. New optional `workspace` param; all five framework call sites (reaper ×2, approval-resolver ×2, inbound-match) pass it.
- **Same race, third site**: the reaper's `auto_cancel` branch did its own raw UPDATE with no still-dormant guard — a human approval landing a moment earlier still got its freshly-resumed run marked cancelled. Now claim-guarded (`AND dormant_signal IS NOT NULL … RETURNING`); loses cleanly.

### upsertEmbedding: the upsert that couldn't
`ON CONFLICT (id)` where `id` defaults to `gen_random_uuid()` — the conflict could never fire, and migration 012 has no unique constraint on `drawer_id`. Every call INSERTED; re-embedding a drawer accumulated duplicates (skewed RAG similarity, bloated HNSW).

- **Migration 030**: dedupe (keep newest per drawer) + `ux_embeddings_drawer` unique index.
- Code: `ON CONFLICT (drawer_id) DO UPDATE`.
- **Rollback note** (docs/releases.md rule): the only writer is the Voyage-gated ingest embedder, which has never run in production — `embeddings` is empty fleet-wide (verified on Phoenix before writing the migration). A rolled-back writer re-embedding the same drawer would error instead of silently duplicating; with zero live writers that's theoretical, and the write it would block is precisely the bug.

## Tests
New `tests/concurrency-correctness.test.ts` (db-gated):
- 4 concurrent resolvers (human + reaper + stragglers) → exactly 1 fulfilled, 3 rejected, exactly **one** `waitpoint_resolved` WAL row (the double-execution signature was two).
- Same signal in two workspaces → resolving in A leaves B dormant and still resolvable.
- Unscoped call still works (library compatibility).
- Embed-thrice-one-drawer → 1 row, latest model.

Full suite **312/312** against a scratch DB with migration 030 applied.

**Contains migration 030** — release section must list it when this ships.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)