### PR TITLE
fix(health-monitor): schedule-aware stale-skill alerts (#269)

### DIFF
--- a/packages/runtime/src/tasks/health-monitor.ts
+++ b/packages/runtime/src/tasks/health-monitor.ts
@@ -20,8 +20,12 @@
 import { sql, appendWal, writeDrawerRaw } from "@nexaas/palace";
 import { exec as execCb } from "child_process";
 import { promisify } from "util";
+import cronParser from "cron-parser";
+import { loadManifest } from "@nexaas/manifest";
 import { notify } from "../notifications.js";
 import { probeModel } from "../models/probe.js";
+import { findSkillManifest } from "../skill-manifest-index.js";
+import { workspaceTimezone } from "../workspace-timezone.js";
 
 // Async exec — health monitor runs every 5 min inside the worker. Using
 // execSync here (as before) blocked the event loop for each shell check,
@@ -40,6 +44,62 @@ export interface HealthAlert {
   severity: "critical" | "warning" | "info";
   component: string;
   message: string;
+}
+
+export type StaleVerdict =
+  | { kind: "retired" }        // no manifest on disk — scheduler/orphan tooling owns this
+  | { kind: "event-driven" }   // inbound/batch triggers only — idle ≠ stale
+  | { kind: "cron"; missed: number; schedules: string[] }
+  | { kind: "unknown" };       // manifest unreadable / cron unparseable — keep legacy alert
+
+/**
+ * Resolve a stale-skill candidate against its manifest's actual triggers
+ * (#269 — recovered Phoenix hotfix 5072c96, generalized). The median-gap
+ * heuristic (#245) can't see schedules, so business-hours crons
+ * (`*​/30 8-19 * * 1-5`) false-alarm every night/weekend and event-driven
+ * skills false-alarm whenever their signal is quiet. A cron skill is only
+ * genuinely stale once ≥3 *scheduled* fire times have passed unrun.
+ *
+ * Timezone: per-trigger → manifest → workspace config → NEXAAS_TIMEZONE →
+ * UTC — the framework's canonical resolution (the Phoenix patch fell back
+ * to America/Toronto; that client-ism is why it couldn't land as-is).
+ *
+ * `now` is injectable for tests.
+ */
+export async function classifyStaleSkill(
+  workspace: string,
+  skillId: string,
+  minutesSince: number,
+  now: Date = new Date(),
+): Promise<StaleVerdict> {
+  try {
+    const entry = findSkillManifest(skillId);
+    if (!entry) return { kind: "retired" };
+    const manifest = loadManifest(entry.manifestPath);
+    const crons = (manifest.triggers ?? []).filter(
+      (t) => t?.type === "cron" && typeof t.schedule === "string",
+    );
+    if (crons.length === 0) return { kind: "event-driven" };
+    const workspaceTz = await workspaceTimezone(workspace);
+    const lastRun = new Date(now.getTime() - minutesSince * 60_000);
+    let missed = 0;
+    for (const t of crons) {
+      const tz = t.timezone ?? manifest.timezone ?? workspaceTz;
+      try {
+        const it = cronParser.parseExpression(t.schedule as string, { currentDate: lastRun, tz });
+        for (let i = 0; i < 500 && missed < 3; i++) {
+          if (it.next().toDate().getTime() > now.getTime()) break;
+          missed++;
+        }
+      } catch {
+        return { kind: "unknown" };
+      }
+      if (missed >= 3) break;
+    }
+    return { kind: "cron", missed, schedules: crons.map((t) => t.schedule as string) };
+  } catch {
+    return { kind: "unknown" };
+  }
 }
 
 export interface HealthReport {
@@ -187,10 +247,20 @@ export async function runHealthCheck(workspace: string, opts: HealthCheckOpts = 
   for (const row of staleSkills) {
     const mins = Math.round(parseFloat(row.minutes_since));
     const cadence = Math.round(parseFloat(row.median_gap));
+    // #269: check the schedule before alerting — retired and event-driven
+    // skills are exempt, and a cron skill isn't stale until it actually
+    // missed ≥3 scheduled fires (a business-hours cron is silent all
+    // weekend by design).
+    const verdict = await classifyStaleSkill(workspace, row.skill_id, parseFloat(row.minutes_since));
+    if (verdict.kind === "retired" || verdict.kind === "event-driven") continue;
+    if (verdict.kind === "cron" && verdict.missed < 3) continue;
     alerts.push({
       severity: "warning",
       component: `skill:${row.skill_id}`,
-      message: `Hasn't run in ${mins} minutes (typical cadence ~${cadence} min)`,
+      message:
+        verdict.kind === "cron"
+          ? `Missed ${verdict.missed}+ scheduled runs — silent ${mins} min (schedule: ${verdict.schedules.join(" | ")})`
+          : `Hasn't run in ${mins} minutes (typical cadence ~${cadence} min)`,
     });
   }
 

--- a/tests/stale-skill-classify.test.ts
+++ b/tests/stale-skill-classify.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #269 — schedule-aware stale-skill classification (recovered Phoenix
+ * hotfix 5072c96, generalized). Pure tests: fixture manifests under a tmp
+ * NEXAAS_WORKSPACE_ROOT, injectable `now`, no DB (workspaceTimezone falls
+ * back to NEXAAS_TIMEZONE/UTC when the pool is unreachable; fixtures pin
+ * their own timezone anyway so verdicts are deterministic).
+ *
+ * Fixed dates: 2026-07-24 = Friday, 07-25 = Saturday, 07-27 = Monday.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { classifyStaleSkill } from "../packages/runtime/src/tasks/health-monitor.js";
+import { invalidateSkillManifestIndex } from "../packages/runtime/src/skill-manifest-index.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "nexaas-269-"));
+const WS = "vitest-269";
+let prevRoot: string | undefined;
+let prevTz: string | undefined;
+
+function writeSkill(id: string, yaml: string) {
+  const dir = join(tmp, "nexaas-skills", ...id.split("/"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "skill.yaml"), yaml);
+}
+
+beforeAll(() => {
+  prevRoot = process.env.NEXAAS_WORKSPACE_ROOT;
+  prevTz = process.env.NEXAAS_TIMEZONE;
+  process.env.NEXAAS_WORKSPACE_ROOT = tmp;
+  process.env.NEXAAS_TIMEZONE = "UTC";
+
+  writeSkill("ops/business-hours", [
+    "id: ops/business-hours",
+    "version: '1'",
+    "timezone: UTC",
+    "triggers:",
+    "  - type: cron",
+    "    schedule: '*/30 8-19 * * 1-5'",
+    "execution: { type: shell, command: 'true' }",
+  ].join("\n"));
+
+  writeSkill("ops/event-driven", [
+    "id: ops/event-driven",
+    "version: '1'",
+    "triggers:",
+    "  - type: inbound-message",
+    "    channel_role: some_channel",
+    "execution: { type: ai-skill }",
+  ].join("\n"));
+
+  invalidateSkillManifestIndex();
+});
+
+afterAll(() => {
+  process.env.NEXAAS_WORKSPACE_ROOT = prevRoot;
+  process.env.NEXAAS_TIMEZONE = prevTz;
+  invalidateSkillManifestIndex();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const minutesBetween = (a: Date, b: Date) => (b.getTime() - a.getTime()) / 60_000;
+
+describe("classifyStaleSkill (#269)", () => {
+  it("skips retired skills (no manifest on disk)", async () => {
+    const v = await classifyStaleSkill(WS, "ops/deleted-long-ago", 999);
+    expect(v.kind).toBe("retired");
+  });
+
+  it("exempts event-driven skills — idle is not stale", async () => {
+    const v = await classifyStaleSkill(WS, "ops/event-driven", 10_000);
+    expect(v.kind).toBe("event-driven");
+  });
+
+  it("business-hours cron silent over the weekend: zero missed fires", async () => {
+    const lastRun = new Date("2026-07-24T19:30:00Z"); // Friday 19:30 — last scheduled fire (8-19 includes 19:30)
+    const now = new Date("2026-07-25T03:00:00Z");     // Saturday 03:00
+    const v = await classifyStaleSkill(WS, "ops/business-hours", minutesBetween(lastRun, now), now);
+    expect(v).toEqual({ kind: "cron", missed: 0, schedules: ["*/30 8-19 * * 1-5"] });
+  });
+
+  it("same skill genuinely stale Monday mid-morning: ≥3 missed fires", async () => {
+    const lastRun = new Date("2026-07-24T19:00:00Z"); // Friday 19:00
+    const now = new Date("2026-07-27T10:05:00Z");     // Monday 10:05 — missed 8:00/8:30/9:00…
+    const v = await classifyStaleSkill(WS, "ops/business-hours", minutesBetween(lastRun, now), now);
+    expect(v.kind).toBe("cron");
+    expect((v as { missed: number }).missed).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the recovered Phoenix hotfix `5072c96` (authored on the production box 2026-07-04, reverted by the v0.3.9 channel upgrade, preserved as #269) — now workspace-agnostic on top of the #260 `workspaceTimezone()` helper.

**What it fixes**: #245's median-gap staleness heuristic can't see schedules, so it false-alarmed on (a) event-driven skills that are idle simply because no signal arrived, and (b) business-hours crons — a `*/30 8-19 * * 1-5` skill got flagged every night and all weekend, keeping the monitor stuck in `degraded`.

**How**: each stale candidate resolves against its manifest triggers via the shared index — retired (no manifest) and event-driven skills are exempt; a cron skill alerts only after **≥3 scheduled fire times** passed unrun, with the missed count + schedule in the alert message. Unreadable manifests keep the legacy alert (fail toward noise, not silence).

**De-Phoenixed vs the original patch**:
- Timezone: per-trigger → manifest → `workspaceTimezone()` (workspace config → `NEXAAS_TIMEZONE` → UTC). The original fell back to `America/Toronto` — the client-ism that blocked landing it as-is.
- Manifest loads via `@nexaas/manifest` (#256), so contract.yaml skills classify correctly too.
- `now` injectable → deterministic tests.

## Tests
`tests/stale-skill-classify.test.ts` (pure, fixture manifests, fixed dates): retired skip, event-driven exempt, Friday-19:30-to-Saturday-3am business-hours cron → 0 missed (no alert), Friday-to-Monday-10:05 → ≥3 missed (alerts). Full suite **316/316**.

Phoenix has been back on #245 noise since v0.3.9 — this restores the quieter behavior fleet-wide at the next release.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale skill detection based on skill type, schedule, missed runs, and workspace timezone.
  * Retired and event-driven skills are no longer incorrectly flagged as stale.
  * Cron-based skills are flagged only after multiple scheduled runs are missed.
  * Stale alerts now include missed-run counts and schedules when applicable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->