### PR TITLE
fix(dispatcher): self-heal against malformed (non-JSON) notification drawers

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -83,6 +83,7 @@ Every `op:` string the framework writes to `nexaas_memory.wal`. Query shape:
 | `notification_sent` / `notification_delivered` / `notification_failed` | dispatcher outcomes |
 | `notification_delivered_via_pa` | delivery routed through a PA persona (#123) |
 | `notification_skipped` / `notification_misconfigured` / `notification_reaped` | dispatcher edge outcomes |
+| `notification_malformed_quarantined` | non-JSON pending drawer auto-quarantined before it can stall the dispatcher (poison-row self-heal, PG ≥ 16) |
 | `pa_message_handled` | PA persona handled an inbound message |
 | `pa_notify_received` | POST /api/pa/:user/notify accepted |
 | `pa_delivery_dead` | delivery marker exhausted retries (#94) |

--- a/packages/runtime/src/tasks/notification-dispatcher.ts
+++ b/packages/runtime/src/tasks/notification-dispatcher.ts
@@ -205,21 +205,50 @@ async function reapStaleClaims(workspace: string): Promise<number> {
   return reaped.length;
 }
 
+async function quarantineMalformed(
+  workspace: string,
+): Promise<{ id: string; room: string }[]> {
+  // Guardrail (#poison-row): selectPending casts e.content::jsonb. A single
+  // pending drawer whose content is not valid JSON makes that cast throw and
+  // stalls the WHOLE dispatcher — silently, indefinitely (one such row once
+  // stalled all notifications for 7 days). Sweep such rows into dormant_signal
+  // each tick so they self-heal within one interval instead of poisoning the
+  // batch forever. pg_input_is_valid requires Postgres >= 16.
+  return await sql<{ id: string; room: string }>(
+    `UPDATE nexaas_memory.events
+        SET dormant_signal = 'auto-quarantine:malformed-content'
+      WHERE workspace = $1
+        AND wing = 'notifications'
+        AND hall = 'pending'
+        AND dormant_signal IS NULL
+        AND NOT pg_input_is_valid(content, 'jsonb')
+      RETURNING id, room`,
+    [workspace],
+  );
+}
+
 async function selectPending(workspace: string): Promise<PendingDrawer[]> {
   // Pick pending drawers whose idempotency_key hasn't successfully
   // delivered yet. We LEFT JOIN on notification_dispatches so drawers
   // with a 'delivered' row are filtered out, and ones with a 'failed'
   // row below MAX_ATTEMPTS come back into the batch for retry.
+  //
+  // The pg_input_is_valid guard + CASE around the ::jsonb cast make this
+  // query resilient to a malformed drawer that quarantineMalformed hasn't
+  // swept yet — a bad row is skipped, never throws (see that function).
   return await sql<PendingDrawer>(
     `SELECT e.id, e.workspace, e.wing, e.hall, e.room, e.content, e.created_at
        FROM nexaas_memory.events e
        LEFT JOIN nexaas_memory.notification_dispatches d
               ON d.workspace = e.workspace
-             AND d.idempotency_key = (e.content::jsonb ->> 'idempotency_key')
+             AND d.idempotency_key =
+                 (CASE WHEN pg_input_is_valid(e.content, 'jsonb')
+                       THEN e.content::jsonb ->> 'idempotency_key' END)
       WHERE e.workspace = $1
         AND e.wing = 'notifications'
         AND e.hall = 'pending'
         AND e.dormant_signal IS NULL
+        AND pg_input_is_valid(e.content, 'jsonb')
         AND (d.status IS NULL OR (d.status = 'failed' AND d.attempts < $2))
       ORDER BY e.created_at ASC
       LIMIT $3`,
@@ -605,6 +634,22 @@ export async function dispatchPendingNotifications(
         op: "pa_delivery_reaped",
         actor: "notification-dispatcher",
         payload: { count: paReaped },
+      });
+    }
+    // Malformed-drawer guardrail: quarantine any non-JSON pending drawer
+    // before it can poison selectPending's ::jsonb cast (#poison-row).
+    const malformed = await quarantineMalformed(workspace);
+    if (malformed.length > 0) {
+      console.error(
+        `[nexaas] notification dispatcher: quarantined ${malformed.length} ` +
+          `malformed drawer(s) [${malformed.map((m) => `${m.room}:${m.id}`).join(", ")}] ` +
+          `— content was not valid JSON; would have stalled the queue`,
+      );
+      await appendWal({
+        workspace,
+        op: "notification_malformed_quarantined",
+        actor: "notification-dispatcher",
+        payload: { count: malformed.length, drawers: malformed },
       });
     }
   } catch (err) {


### PR DESCRIPTION
Recovers Phoenix local hotfix `c60b06c` — the fourth local-drift incident, discovered (and reverted) by today's v0.4.1 upgrade. Unlike #269 this one was an ACTIVE production guard: a single non-JSON pending drawer once stalled **all** notifications for 7 days because `selectPending`'s `content::jsonb` cast threw on it, silently, every tick.

Landed verbatim (it was already workspace-agnostic): per-tick quarantine sweep (`dormant_signal='auto-quarantine:malformed-content'` + `notification_malformed_quarantined` WAL op, registered in contracts.md) plus `pg_input_is_valid`-guarded selection. PG ≥ 16 is the framework floor.

Phoenix state verified post-revert before landing: 1 already-quarantined row (dormant → excluded by `dormant_signal IS NULL`, dispatcher healthy, delivery confirmed in last 2h), 0 live poison rows — so no active incident; this restores the guard for the next poison row.

Suite 317/317. Intended for immediate v0.4.2 so production regains the protection today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)