### PR TITLE
feat(upgrade): local-drift guard — refuse to strand on-box hotfix commits (#287)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ nexaas library list|contribute|install|diff|promote|feedback
 nexaas propagate check|push|accept|reject
 nexaas alerts [list|test|config]       Notification management
 nexaas backup [run|list|test|schedule] Database backup/restore
-nexaas upgrade [--check|--migrate|--channel <c>|--to <tag>|--rollback]  Framework updates
+nexaas upgrade [--check|--migrate|--channel <c>|--to <tag>|--rollback|--discard-local]  Framework updates (drift guard #287)
 nexaas create-mcp <name>              Scaffold MCP server
 nexaas gdpr export|delete|redact|subjects|audit
 nexaas verify-wal [--full]            WAL chain integrity

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -115,6 +115,7 @@ Every `op:` string the framework writes to `nexaas_memory.wal`. Query shape:
 | `silent_failure_alerted` | consecutive-failure threshold hit (#69) |
 | `framework_upgraded` / `framework_rolled_back` | nexaas upgrade outcomes |
 | `upgrade_conformance_failed` | post-upgrade gate failed → auto-rollback |
+| `upgrade_drift_blocked` / `upgrade_drift_discarded` | local-drift guard (#287): HEAD carried commits not in the target release — upgrade refused, or proceeded via --discard-local (patch bundle preserved either way) |
 | `framework_consistency_warning` | doctor/startup consistency finding |
 | `lock_acquired` / `lock_released` | concurrency-group mutex (#95) |
 | `workspace_genesis` | chain root anchor written by init (linkage-only) |

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -39,10 +39,14 @@
  *   nexaas upgrade --to v0.3.1           Pin directly to a tag (hotfix push)
  *   nexaas upgrade --rollback            Return to the previously-running ref (code only)
  *   nexaas upgrade --no-verify           Skip the post-upgrade conformance gate
+ *   nexaas upgrade --discard-local       Proceed past the local-drift guard (#287) —
+ *                                        local-only commits leave HEAD; a patch
+ *                                        bundle is preserved either way
  */
 
 import { execSync, spawnSync } from "child_process";
-import { chmodSync, existsSync, readdirSync, readFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import pg from "pg";
 import { appendWal, getPool } from "@nexaas/palace";
@@ -88,6 +92,7 @@ export async function run(args: string[]) {
   const migrateOnly = args.includes("--migrate");
   const rollback = args.includes("--rollback");
   const noVerify = args.includes("--no-verify");
+  const discardLocal = args.includes("--discard-local");
   const channelFlag = argValue(args, "--channel");
   const toTag = argValue(args, "--to");
   const workspace = process.env.NEXAAS_WORKSPACE ?? "";
@@ -226,6 +231,36 @@ export async function run(args: string[]) {
       }
 
       if (targetSha !== headSha) {
+        // Local-drift guard (#287): refuse to strand on-box hotfix commits.
+        const drift = checkLocalDrift(nexaasRoot, targetSha);
+        if (drift.drifted) {
+          console.log(`\n  ⚠ LOCAL DRIFT: HEAD carries ${drift.localCommits.length} commit(s) not in ${label}:`);
+          for (const line of drift.localCommits) console.log(`      ${line}`);
+          console.log(drift.patchPath
+            ? `    Preserved as: ${drift.patchPath}`
+            : `    ⚠ Could not write a patch bundle — commits remain recoverable by SHA until git gc.`);
+          try {
+            await appendWal({
+              workspace,
+              op: discardLocal ? "upgrade_drift_discarded" : "upgrade_drift_blocked",
+              actor: "nexaas-cli",
+              payload: {
+                target: targetSha, head: headSha,
+                local_commits: drift.localCommits,
+                patch_path: drift.patchPath,
+              },
+            });
+          } catch { /* WAL is best-effort here — the guard must still act */ }
+          if (!discardLocal) {
+            console.error(`\n  ✗ Upgrade refused. These commits would be silently reverted (this has`);
+            console.error(`    clobbered production hotfixes 4 times — see #269/#277/#285).`);
+            console.error(`    Either upstream them (branch + PR to main, then release), or re-run`);
+            console.error(`    with --discard-local to proceed anyway (patch bundle kept).`);
+            await pool.end();
+            process.exit(1);
+          }
+          console.log(`    --discard-local: proceeding; local commits leave HEAD (patch kept).`);
+        }
         await recordPreviousRef(pool, workspace, nexaasRoot);
         console.log(`\n  Checking out ${label} (${targetDescribe})...`);
         exec(`git -C ${nexaasRoot} checkout --detach ${targetSha} --quiet`, { timeout: 120_000 });
@@ -468,6 +503,62 @@ export async function run(args: string[]) {
  * via `node --conditions=production dist/worker.js`. Build is fast (<10s on
  * a warm cache) and skipped only when no source files changed.
  */
+export interface DriftCheck {
+  drifted: boolean;
+  localCommits: string[];
+  patchPath: string | null;
+}
+
+/**
+ * Local-drift guard (#287). Four production incidents share one shape: a
+ * hotfix committed directly on a workspace VPS, then silently stranded by
+ * the next channel upgrade's `checkout --detach` (the #245-era
+ * health-monitor fix, 5072c96/#269, 55e33ed/#277, c60b06c/#285). HEAD not
+ * being an ancestor of the target is exactly that condition.
+ *
+ * The guard (a) always preserves the local-only commits as a format-patch
+ * bundle under $NEXAAS_BACKUP_DIR/drift/ (fallback ~/.nexaas/drift/ —
+ * never /tmp, #172), and (b) reports drift so the caller can refuse the
+ * upgrade unless `--discard-local` was passed. Preservation happens even
+ * when discarding — recovery becomes a file read, not commit-object
+ * archaeology.
+ */
+export function checkLocalDrift(nexaasRoot: string, targetSha: string): DriftCheck {
+  const ancestor = spawnSync(
+    "git", ["-C", nexaasRoot, "merge-base", "--is-ancestor", "HEAD", targetSha],
+    { stdio: "pipe" },
+  );
+  if (ancestor.status === 0) return { drifted: false, localCommits: [], patchPath: null };
+
+  const localCommits = exec(
+    `git -C ${nexaasRoot} log --oneline ${targetSha}..HEAD | head -20`,
+    { silent: true },
+  ).split("\n").filter(Boolean);
+
+  let patchPath: string | null = null;
+  const patch = exec(
+    `git -C ${nexaasRoot} format-patch ${targetSha}..HEAD --stdout`,
+    { silent: true, timeout: 60_000 },
+  );
+  if (patch) {
+    const headShort = exec(`git -C ${nexaasRoot} rev-parse --short HEAD`, { silent: true }) || "head";
+    const stamp = new Date().toISOString().slice(0, 10);
+    for (const dir of [
+      join(process.env.NEXAAS_BACKUP_DIR ?? "/var/backups/nexaas", "drift"),
+      join(homedir(), ".nexaas", "drift"),
+    ]) {
+      try {
+        mkdirSync(dir, { recursive: true });
+        patchPath = join(dir, `${stamp}-${headShort}.patch`);
+        writeFileSync(patchPath, patch);
+        break;
+      } catch { patchPath = null; }
+    }
+  }
+
+  return { drifted: true, localCommits, patchPath };
+}
+
 function postCheckoutSteps(nexaasRoot: string, fromCommit: string): void {
   const changedFiles = exec(
     `git -C ${nexaasRoot} diff --name-only ${fromCommit}..HEAD`,

--- a/tests/upgrade-drift-guard.test.ts
+++ b/tests/upgrade-drift-guard.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #287 — local-drift guard for `nexaas upgrade`. Pure git tests against a
+ * throwaway repo: no DB, no network. The WAL emit and refuse/exit live at
+ * the call site; this covers the detection + preservation primitive.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { checkLocalDrift } from "../packages/cli/src/upgrade.js";
+
+const tmp = mkdtempSync(join(tmpdir(), "nexaas-287-"));
+const repo = join(tmp, "repo");
+let releaseSha = "";
+let prevBackupDir: string | undefined;
+
+function git(...args: string[]): string {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf-8" }).trim();
+}
+
+beforeAll(() => {
+  prevBackupDir = process.env.NEXAAS_BACKUP_DIR;
+  // Patch bundles land under the test's own dir, not /var/backups.
+  process.env.NEXAAS_BACKUP_DIR = join(tmp, "backups");
+
+  execFileSync("git", ["init", "-q", repo]);
+  git("config", "user.email", "t@t");
+  git("config", "user.name", "t");
+  git("commit", "--allow-empty", "-q", "-m", "base");
+  git("commit", "--allow-empty", "-q", "-m", "release: vX");
+  releaseSha = git("rev-parse", "HEAD");
+});
+
+afterAll(() => {
+  process.env.NEXAAS_BACKUP_DIR = prevBackupDir;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("checkLocalDrift (#287)", () => {
+  it("clean HEAD at the release: no drift", () => {
+    expect(checkLocalDrift(repo, releaseSha)).toEqual({
+      drifted: false, localCommits: [], patchPath: null,
+    });
+  });
+
+  it("HEAD behind a newer target: still no drift (normal upgrade)", () => {
+    // Simulate the target being AHEAD of HEAD: add the "next release" and
+    // point HEAD back at the previous one.
+    git("commit", "--allow-empty", "-q", "-m", "release: vX+1");
+    const newer = git("rev-parse", "HEAD");
+    git("checkout", "-q", "--detach", releaseSha);
+    expect(checkLocalDrift(repo, newer).drifted).toBe(false);
+    git("checkout", "-q", "--detach", newer);
+    git("update-ref", "-d", "refs/heads/master");
+  });
+
+  it("local hotfix commit on top: drift detected, listed, and preserved", () => {
+    const target = git("rev-parse", "HEAD");
+    execFileSync("bash", ["-c", `echo hotfix > ${join(repo, "hotfix.txt")}`]);
+    git("add", "hotfix.txt");
+    git("commit", "-q", "-m", "fix(prod): the 3am hotfix");
+
+    const drift = checkLocalDrift(repo, target);
+    expect(drift.drifted).toBe(true);
+    expect(drift.localCommits.length).toBe(1);
+    expect(drift.localCommits[0]).toContain("fix(prod): the 3am hotfix");
+    expect(drift.patchPath).toBeTruthy();
+    const bundle = readFileSync(drift.patchPath!, "utf-8");
+    expect(bundle).toContain("fix(prod): the 3am hotfix");
+    expect(bundle).toContain("+hotfix");
+    // Landed under NEXAAS_BACKUP_DIR/drift, not /tmp or /var.
+    expect(drift.patchPath!).toContain(join(tmp, "backups", "drift"));
+  });
+});


### PR DESCRIPTION
## Summary

Automates the drift check the release ritual keeps fumbling by hand (4 clobbered production hotfixes; the 4th slipped through because the manual check was piped into the same command as the upgrade).

**Behavior** (channel/pin path only; rollback and legacy `git pull` tracking exempt):
- HEAD not an ancestor of the target → list local-only commits, **write a format-patch bundle** to `$NEXAAS_BACKUP_DIR/drift/` (fallback `~/.nexaas/drift/`, never /tmp per #172), WAL `upgrade_drift_blocked`, **refuse with exit 1** and instructions.
- `nexaas upgrade --discard-local` → proceeds; bundle still written; WAL `upgrade_drift_discarded` with the patch path. Recovery becomes a file read instead of commit-object archaeology.
- Both WAL ops registered in `docs/contracts.md` (the #258 guard enforces this).

## Verification
- **Live on testlab**: simulated on-box commit → upgrade refused (repo untouched, patch at `~/.nexaas/drift/2026-08-02-ee2a534.patch`, backup-dir fallback exercised since `/var/backups` isn't writable as the workspace user); then `--discard-local` → upgraded to v0.4.2, conformance green, both WAL rows present with the patch path. Testlab ends exactly where it started.
- Unit tests (`tests/upgrade-drift-guard.test.ts`, throwaway git repo): clean HEAD no-drift, behind-target no-drift (normal upgrade), local hotfix → detected + listed + bundle contents verified.
- Full suite **320/320**.

Note the guard takes effect fleet-wide only once workspaces run a release containing it (the upgrade *from* v0.4.2 still uses v0.4.2's code) — one release of lag, same as the #259 wrapper migration.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--discard-local` to allow upgrades to proceed when local commits differ from the target release.
  * Local changes are preserved in a patch bundle before the upgrade continues.

* **Bug Fixes**
  * Upgrades now detect and prevent accidental overwriting of local commits.

* **Documentation**
  * Documented the new upgrade option and drift-related upgrade outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->