### PR TITLE
fix(runtime): retroactive-review findings — NaN timeout guards + approvals in security surface (#266)

### DIFF
--- a/docs/security-surface.md
+++ b/docs/security-surface.md
@@ -27,6 +27,8 @@ One Express server, port `NEXAAS_WORKER_PORT` (default 9090), bind address
 | `/api/skills/trigger` | POST | bearer | enqueue a registered skill |
 | `/api/pa/:user/notify` | POST | bearer | PA notification ingress |
 | `/api/drawers/inbound` | POST | bearer | write inbound drawers (triggers skills) |
+| `/api/approvals/:signal/resolve` | POST | bearer | resolve an approval — **executes the approved action**; edit decisions may carry `payload_override` |
+| `/api/approvals/by-message/:messageId` | GET | bearer | approval lookup — returns `payload_full` (may contain draft content) |
 | `/api/pa/message` | POST | bearer *(added #217)* | full PA conversation — **model spend** + palace reads |
 | `/api/ingest` | POST | bearer *(added #217)* | chunk + embed — Voyage spend + palace writes |
 | `/api/addons/activate` | POST | bearer *(added #217)* | **registers skills and MCP server commands — the most privileged endpoint on the box** |

--- a/packages/runtime/src/mcp/client.ts
+++ b/packages/runtime/src/mcp/client.ts
@@ -344,9 +344,12 @@ export class McpClient {
 
       // tools/call gets a long leash — real tools legitimately run for minutes
       // (M365 tenant audits, wp-toolkit backups). Handshake/list calls keep the
-      // short timeout so a wedged server still fails fast.
+      // short timeout so a wedged server still fails fast. NaN guard (#266
+      // review): setTimeout(cb, NaN) fires on the next tick, so a garbage env
+      // value would instantly "time out" every tool call.
+      const envToolMs = Number(process.env.NEXAAS_MCP_TOOL_TIMEOUT_MS);
       const timeoutMs = method === "tools/call"
-        ? Number(process.env.NEXAAS_MCP_TOOL_TIMEOUT_MS ?? 600_000)
+        ? (Number.isFinite(envToolMs) && envToolMs > 0 ? envToolMs : 600_000)
         : 30_000;
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id);

--- a/packages/runtime/src/models/agentic-loop.ts
+++ b/packages/runtime/src/models/agentic-loop.ts
@@ -54,12 +54,22 @@ function getClient(): Anthropic {
  */
 // 60s proved too aggressive: large tool-result contexts (SEO SERP payloads,
 // fleet JSON) legitimately take >60s of server-side prompt processing before
-// the first chunk (2026-07-03: killed a report run mid-flight). Env-tunable.
-const DEFAULT_CHUNK_IDLE_MS = Number(process.env.NEXAAS_STREAM_IDLE_MS ?? 180_000);
+// the first chunk (2026-07-03: killed a report run mid-flight). Env-tunable
+// via NEXAAS_STREAM_IDLE_MS (NEXAAS_CHUNK_IDLE_MS is the legacy alias and
+// wins when set). NaN-guarded at every layer (#266 review): a garbage env
+// value previously poisoned the module-load default itself, and
+// setTimeout(cb, NaN) fires immediately.
+const HARD_DEFAULT_CHUNK_IDLE_MS = 180_000;
+
+function positiveMs(raw: string | undefined): number | null {
+  const v = Number(raw);
+  return Number.isFinite(v) && v > 0 ? v : null;
+}
 
 function chunkIdleMs(): number {
-  const v = Number(process.env.NEXAAS_CHUNK_IDLE_MS ?? DEFAULT_CHUNK_IDLE_MS);
-  return Number.isFinite(v) && v > 0 ? v : DEFAULT_CHUNK_IDLE_MS;
+  return positiveMs(process.env.NEXAAS_CHUNK_IDLE_MS)
+    ?? positiveMs(process.env.NEXAAS_STREAM_IDLE_MS)
+    ?? HARD_DEFAULT_CHUNK_IDLE_MS;
 }
 
 /**


### PR DESCRIPTION
Fixes for the 3 findings from the #266 retroactive review (full per-commit review posted on the issue). Suite 320/320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented bearer-authenticated approval endpoints for resolving approvals, executing approved actions, and retrieving approvals by message ID.

- **Bug Fixes**
  - Improved timeout handling for streaming and MCP tool operations.
  - Invalid, missing, or non-positive timeout settings now safely fall back to reliable defaults.
  - MCP tool timeout settings can now be configured independently from other MCP requests.
  - Legacy streaming timeout configuration remains supported for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->