### PR TITLE
fix(upgrade): post-restart straggler re-flag closes the 028 backfill race (#239)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -116,6 +116,7 @@ Every `op:` string the framework writes to `nexaas_memory.wal`. Query shape:
 | `framework_upgraded` / `framework_rolled_back` | nexaas upgrade outcomes |
 | `upgrade_conformance_failed` | post-upgrade gate failed → auto-rollback |
 | `upgrade_drift_blocked` / `upgrade_drift_discarded` | local-drift guard (#287): HEAD carried commits not in the target release — upgrade refused, or proceeded via --discard-local (patch bundle preserved either way) |
+| `wal_exempt_straggler_flagged` | post-restart straggler repair (#239): a pre-#235 `palace_mcp_write` row written in the migrate→restart window was flagged integrity-exempt (mirrors migration 028; recompute-failing + pre-restart + canon v1 only) |
 | `framework_consistency_warning` | doctor/startup consistency finding |
 | `lock_acquired` / `lock_released` | concurrency-group mutex (#95) |
 | `workspace_genesis` | chain root anchor written by init (linkage-only) |

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -49,7 +49,7 @@ import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileS
 import { homedir } from "os";
 import { join } from "path";
 import pg from "pg";
-import { appendWal, getPool } from "@nexaas/palace";
+import { appendWal, getPool, repairMcpStragglers } from "@nexaas/palace";
 import { applyPendingMigrations, getPendingMigrations } from "./migrations.js";
 import { installCliBinary } from "./install-binary.js";
 
@@ -364,6 +364,27 @@ export async function run(args: string[]) {
     } else {
       console.log(`\n  ⚠ Upgraded to ${newCommit} but health check did not pass`);
       console.log("    Check: nexaas status");
+    }
+
+    // Step 7b: straggler re-flag (#239). Migration 028's exempt-backfill runs
+    // in the migrate→restart window, so a still-running pre-#235 palace MCP
+    // subprocess could write more bogus palace_mcp_write rows the backfill
+    // never saw. Flag them now — bounded to rows predating this restart —
+    // BEFORE the conformance gate, whose WAL verify would otherwise fail and
+    // auto-rollback over a row the upgrade itself is responsible for.
+    if (refChanged && healthy) {
+      try {
+        const restartInstant = new Date();
+        const repair = await repairMcpStragglers(workspace, restartInstant);
+        if (repair.flagged.length > 0) {
+          console.log(`  Flagged ${repair.flagged.length} straggler palace_mcp_write row(s) as integrity-exempt (#239): ${repair.flagged.join(", ")}`);
+        }
+        if (!repair.valid) {
+          console.log(`  ⚠ WAL window still fails verification at id ${repair.brokenAt} — NOT a known straggler; investigate with 'nexaas verify-wal'`);
+        }
+      } catch (err) {
+        console.log(`  ⚠ Straggler re-flag pass failed (non-fatal): ${(err as Error).message}`);
+      }
     }
   }
 

--- a/packages/palace/src/index.ts
+++ b/packages/palace/src/index.ts
@@ -15,7 +15,7 @@ export { type Closet } from "./closets.js";
 export { type WaitpointToken, type NotifyConfig } from "./waitpoints.js";
 
 // WAL
-export { appendWal, verifyWalChain, type WalEntry } from "./wal.js";
+export { appendWal, verifyWalChain, repairMcpStragglers, type WalEntry, type StragglerRepairResult } from "./wal.js";
 
 // Database
 export { createPool, getPool, sql, sqlOne, sqlInTransaction } from "./db.js";

--- a/packages/palace/src/wal.ts
+++ b/packages/palace/src/wal.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { sql, sqlInTransaction } from "./db.js";
+import { sql, sqlInTransaction, sqlOne } from "./db.js";
 
 export interface WalEntry {
   workspace: string;
@@ -236,4 +236,95 @@ function verifyBatch(
   }
 
   return { broken: null, exemptSkipped };
+}
+
+// ── Post-restart straggler repair (#239) ─────────────────────────────────
+
+export interface StragglerRepairResult {
+  /** WAL row ids flagged integrity_exempt by this pass. */
+  flagged: number[];
+  /** Chain verdict over the inspected window after the pass. */
+  valid: boolean;
+  /** Set when the window is still broken at a row this pass refuses to touch. */
+  brokenAt?: number;
+  error?: string;
+}
+
+/**
+ * Flag `palace_mcp_write` straggler rows written in an upgrade's
+ * migrate→restart window (#239). Migration 028 exempts the pre-#235 bogus
+ * backlog, but it runs BEFORE the worker restart — a still-running
+ * pre-#235 palace MCP subprocess can write more bogus rows after the
+ * backfill and before its respawn. This pass runs after the restart and
+ * closes exactly that window.
+ *
+ * Deliberately strict — a row is flagged ONLY when ALL hold:
+ *   - the chain verifier actually fails on it (hash recompute mismatch)
+ *   - op = 'palace_mcp_write' (the one historically-buggy writer)
+ *   - created_at <= `cutoff` (the restart instant — nothing after the
+ *     new code took over is ever exempted)
+ *   - canon_version = 1 (post-#254 appendWal rows are v2; a v2 row
+ *     failing recompute is real corruption, never a straggler)
+ *   - not already exempt
+ * Anything else that fails verification is left untouched and reported —
+ * this is a targeted repair, not a chain rewrite (WAL stays append-only;
+ * flagging mirrors migration 028's own mechanism).
+ *
+ * Scans a recent window (same default as `nexaas verify-wal`) — stragglers
+ * are by construction written moments before the restart.
+ */
+export async function repairMcpStragglers(
+  workspace: string,
+  cutoff: Date,
+  opts?: { window?: number; maxFlags?: number },
+): Promise<StragglerRepairResult> {
+  const window = opts?.window ?? 10_000;
+  const maxFlags = opts?.maxFlags ?? 100;
+
+  const anchor = await sqlOne<{ id: number }>(
+    `SELECT id FROM nexaas_memory.wal WHERE workspace = $1
+      ORDER BY id DESC LIMIT 1 OFFSET ${window - 1}`,
+    [workspace],
+  );
+  let fromId = anchor?.id;
+
+  const flagged: number[] = [];
+  for (;;) {
+    const v = await verifyWalChain(workspace, fromId);
+    if (v.valid) return { flagged, valid: true };
+    if (v.brokenAt == null || flagged.length >= maxFlags) {
+      return { flagged, valid: false, brokenAt: v.brokenAt, error: v.error };
+    }
+
+    const row = await sqlOne<{
+      id: number; op: string; created_at: Date; integrity_exempt: boolean; canon_version: number;
+    }>(
+      `SELECT id, op, created_at, integrity_exempt, canon_version
+         FROM nexaas_memory.wal WHERE workspace = $1 AND id = $2`,
+      [workspace, v.brokenAt],
+    );
+    const isStraggler =
+      row != null &&
+      row.op === "palace_mcp_write" &&
+      !row.integrity_exempt &&
+      Number(row.canon_version) === 1 &&
+      new Date(row.created_at) <= cutoff;
+    if (!isStraggler) {
+      return { flagged, valid: false, brokenAt: v.brokenAt, error: v.error };
+    }
+
+    await sql(
+      `UPDATE nexaas_memory.wal SET integrity_exempt = true WHERE id = $1`,
+      [row!.id],
+    );
+    await appendWal({
+      workspace,
+      op: "wal_exempt_straggler_flagged",
+      actor: "nexaas-upgrade",
+      payload: { id: row!.id, cutoff: cutoff.toISOString() },
+    });
+    flagged.push(row!.id);
+    // Resume verification at the row just flagged — the prefix is proven.
+    fromId = row!.id;
+  }
 }

--- a/tests/straggler-repair.test.ts
+++ b/tests/straggler-repair.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #239 — post-restart straggler repair. DB-gated. Builds a real per-workspace
+ * WAL chain, injects a pre-#235-style bogus `palace_mcp_write` row (bogus
+ * hash, canon v1 — exactly what a still-running old MCP wrote in the
+ * migrate→restart window), and proves the repair flags it, keeps the chain
+ * strict for everything else, and respects the restart cutoff.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  appendWal, getPool, repairMcpStragglers, sql, verifyWalChain,
+} from "../packages/palace/src/index.js";
+
+const hasDb = !!process.env.DATABASE_URL;
+
+afterAll(async () => {
+  if (!hasDb) return;
+  await sql(`DELETE FROM nexaas_memory.wal WHERE workspace LIKE 'vitest-239-%'`, []);
+  await getPool().end().catch(() => {});
+});
+
+async function seedChain(ws: string): Promise<void> {
+  await appendWal({ workspace: ws, op: "seed", actor: "t", payload: { n: 1 } });
+  await appendWal({ workspace: ws, op: "seed", actor: "t", payload: { n: 2 } });
+}
+
+/** Inject a row exactly as the pre-#235 MCP did: bogus hash, no canon. */
+async function injectBogus(ws: string, op: string, createdAt?: string): Promise<number> {
+  const prev = (await sql<{ hash: string }>(
+    `SELECT hash FROM nexaas_memory.wal WHERE workspace = $1 ORDER BY id DESC LIMIT 1`, [ws],
+  ))[0]!.hash;
+  const rows = await sql<{ id: number }>(
+    `INSERT INTO nexaas_memory.wal (workspace, op, actor, payload, prev_hash, hash, canon_version${createdAt ? ", created_at" : ""})
+     VALUES ($1, $2, 'palace-mcp', '{"x":1}'::jsonb, $3,
+             encode(digest('palace-write-' || now()::text || random()::text, 'sha256'), 'hex'), 1${createdAt ? `, '${createdAt}'::timestamptz` : ""})
+     RETURNING id`,
+    [ws, op, prev],
+  );
+  return rows[0]!.id;
+}
+
+describe.skipIf(!hasDb)("repairMcpStragglers (#239)", () => {
+  it("flags a pre-restart bogus palace_mcp_write straggler; chain verifies after", async () => {
+    const ws = `vitest-239-${randomUUID().slice(0, 8)}`;
+    await seedChain(ws);
+    const bogusId = await injectBogus(ws, "palace_mcp_write");
+    await appendWal({ workspace: ws, op: "seed", actor: "t", payload: { n: 3 } });
+
+    expect((await verifyWalChain(ws)).valid).toBe(false);
+
+    const cutoff = new Date(Date.now() + 5_000); // restart happened after the write
+    const result = await repairMcpStragglers(ws, cutoff);
+    expect(result.valid).toBe(true);
+    expect(result.flagged).toEqual([bogusId]);
+
+    const after = await verifyWalChain(ws);
+    expect(after.valid).toBe(true);
+    expect(after.exemptSkipped).toBeGreaterThanOrEqual(1);
+
+    // The repair itself is WAL-audited.
+    const audit = await sql<{ n: string }>(
+      `SELECT count(*) AS n FROM nexaas_memory.wal
+        WHERE workspace = $1 AND op = 'wal_exempt_straggler_flagged'
+          AND (payload->>'id')::int = $2`,
+      [ws, bogusId],
+    );
+    expect(Number(audit[0]!.n)).toBe(1);
+  });
+
+  it("refuses a broken row with a different op — real corruption stays loud", async () => {
+    const ws = `vitest-239-${randomUUID().slice(0, 8)}`;
+    await seedChain(ws);
+    const bogusId = await injectBogus(ws, "library_contribute");
+
+    const result = await repairMcpStragglers(ws, new Date(Date.now() + 5_000));
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(bogusId);
+    expect(result.flagged).toEqual([]);
+
+    const row = await sql<{ integrity_exempt: boolean }>(
+      `SELECT integrity_exempt FROM nexaas_memory.wal WHERE id = $1`, [bogusId],
+    );
+    expect(row[0]!.integrity_exempt).toBe(false);
+  });
+
+  it("refuses a palace_mcp_write row written AFTER the restart cutoff", async () => {
+    const ws = `vitest-239-${randomUUID().slice(0, 8)}`;
+    await seedChain(ws);
+    const bogusId = await injectBogus(ws, "palace_mcp_write");
+
+    // Restart happened a minute ago; this row post-dates it — the forward
+    // fix (#235) means a post-restart bogus write is NOT a straggler.
+    const result = await repairMcpStragglers(ws, new Date(Date.now() - 60_000));
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(bogusId);
+    expect(result.flagged).toEqual([]);
+  });
+
+  it("multiple stragglers all flagged in one pass", async () => {
+    const ws = `vitest-239-${randomUUID().slice(0, 8)}`;
+    await seedChain(ws);
+    const a = await injectBogus(ws, "palace_mcp_write");
+    await appendWal({ workspace: ws, op: "seed", actor: "t", payload: { n: 4 } });
+    const b = await injectBogus(ws, "palace_mcp_write");
+
+    const result = await repairMcpStragglers(ws, new Date(Date.now() + 5_000));
+    expect(result.valid).toBe(true);
+    expect(result.flagged).toEqual([a, b]);
+    expect((await verifyWalChain(ws)).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements option 1 from #239 (the lean): `nexaas upgrade` now runs a bounded exempt-backfill pass **after** the worker restart and **before** the conformance gate — closing the migrate→restart window where a still-running pre-#235 MCP subprocess could write bogus `palace_mcp_write` rows that migration 028's backfill (already run) never saw.

**Strictness is the design center.** `repairMcpStragglers` uses the real chain verifier and flags a row only when *all* hold: it fails hash recompute, `op='palace_mcp_write'`, it predates the restart instant, `canon_version=1` (a v2 row failing recompute is genuine corruption, never a straggler), and it isn't already exempt. Any other verification failure is left untouched and reported loudly. Each flag is WAL-audited (`wal_exempt_straggler_flagged`, in contracts.md — the drift guard enforces the row).

Placement matters: it runs before the conformance gate, whose WAL verify would otherwise fail over a row the upgrade itself is responsible for and auto-rollback.

Cost when clean: one verify walk over the recent 10k window (the verify-wal default), then silence.

**Honest scoping note**: the fleet is past the v0.3.5 window (Phoenix's one straggler was hand-flagged then), so this protects future deployments crossing old releases plus any recurrence of the class — it's deliberately cheap and strict rather than elaborate.

## Tests
`tests/straggler-repair.test.ts` (db-gated, real chains): straggler flagged + chain verifies + audit row present; wrong-op broken row refused (stays loud); post-cutoff `palace_mcp_write` refused (forward-fixed code gets no amnesty); two stragglers in one pass. Suite **325/325**.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repair for eligible post-restart MCP write records during upgrades.
  * Upgrade verification now confirms WAL integrity after repairs and reports any remaining issues.
  * Exposed the straggler repair operation and its results for supported integrations.

* **Documentation**
  * Documented the new WAL repair operation.

* **Tests**
  * Added coverage for repairing eligible records while preserving unrelated operations and chain integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->