### PR TITLE
feat(fleet): health summary in beat payload + published receiver contract (#216)

### DIFF
--- a/docs/fleet-heartbeat-contract.md
+++ b/docs/fleet-heartbeat-contract.md
@@ -1,0 +1,110 @@
+# Fleet Heartbeat — Receiver Contract
+
+**Status: published (#216).** The framework ships the *sender*
+(`packages/runtime/src/fleet/heartbeat.ts`); the *receiver* is
+operator-side infrastructure (for Nexmatic-managed fleets: the Ops
+Console — see the coordination issue on the Nexmatic repo). This document
+is the contract between them. `tests/fleet-payload.test.ts` guards the
+payload shape against this doc.
+
+Direct adopters: with `NEXAAS_FLEET_ENDPOINT` / `NEXAAS_FLEET_TOKEN`
+unset, everything below is a silent no-op. The local
+`nexaas_memory.framework_heartbeat` row is still maintained.
+
+## Endpoints (receiver implements)
+
+| Endpoint | Method | Body | Sender cadence |
+|---|---|---|---|
+| `${NEXAAS_FLEET_ENDPOINT}/heartbeat` | POST | beat payload (below) | every 5 min + once at worker startup |
+| `${NEXAAS_FLEET_ENDPOINT}/events` | POST | fleet event (below) | on occurrence |
+
+- **Auth**: `Authorization: Bearer ${NEXAAS_FLEET_TOKEN}` — the token is
+  workspace-scoped, issued by the receiver at provisioning. The receiver
+  MUST reject a token/workspace mismatch (a compromised VPS must not be
+  able to impersonate another workspace).
+- **Sender timeout**: 10s; any non-2xx or network error is recorded
+  locally (WAL `framework_heartbeat_failed` / `fleet_event_failed`) and
+  retried on the next natural occasion. The sender never queues or blocks.
+- 2xx bodies are ignored by the sender — receivers may return `{}`.
+
+## Beat payload (`payload_version: 3`)
+
+Every collector is best-effort: a broken subsystem nulls its field rather
+than blocking the beat — the beat must survive precisely the breakage it
+reports. Receivers MUST tolerate any nullable field being null and MUST
+ignore unknown fields (additive evolution; `payload_version` bumps only
+on breaking changes).
+
+| Field | Type | Notes |
+|---|---|---|
+| `payload_version` | `3` | |
+| `workspace` | string | |
+| `version` | string | VERSION file (release stamp) |
+| `commit_sha`, `branch`, `describe` | string \| null | git identity; `describe` is release-aware |
+| `channel` | string \| null | `stable` / `canary` / null (legacy tracking) |
+| `hostname` | string | |
+| `started_at` | ISO string | worker process start |
+| `now` | ISO string | beat emission time |
+| `worker_status` | `"running"` | see *Missed-beat semantics* — a stopped worker sends nothing |
+| `uptime_s` | number | |
+| `runs_24h` | object \| null | `{ completed, failed, skipped, success_rate_pct \| null }` |
+| `spend` | object \| null | `{ day, spent_usd, budget_usd \| null, paused }` (#215) |
+| `migrations` | object \| null | `{ applied, pending }` — `pending > 0` after an upgrade is a red flag |
+| `conformance` | object \| null | last `nexaas conformance` result (`{ passed, failed, skipped, at, … }` as recorded in `workspace_kv.last_conformance`) |
+| `queue` | object \| null | `{ waiting, active, delayed, failed, paused }` |
+| `health` | object \| null | `{ status: healthy\|degraded\|critical\|unknown, alerts, alert_components[], checked_at }` — latest in-process health-monitor report (≤5 min old on a healthy worker) |
+
+## Fleet events
+
+```json
+{
+  "payload_version": 3,
+  "workspace": "...", "hostname": "...", "at": "ISO",
+  "type": "silent_failure | spend_budget_exceeded | ...",
+  "severity": "page | digest",
+  "title": "...", "body": "...",
+  "dedupe_key": "optional receiver-side dedupe",
+  "data": { }
+}
+```
+
+**Severity discipline (solo-operator rule)** — the sender classifies, the
+receiver applies policy:
+
+| `severity` | Meaning | Receiver policy (recommended) |
+|---|---|---|
+| `page` | A client workspace is broken in a way it cannot report locally, or money/integrity is at stake | Immediate operator notification |
+| `digest` | Worth knowing, not worth waking for | Daily rollup |
+
+Current sender classifications: `silent_failure` → **page** (the
+workspace's own alert channel may be exactly what's broken);
+`spend_budget_exceeded` → **page**. New event types MUST be added to this
+table.
+
+## Missed-beat semantics (receiver-side liveness)
+
+The sender lives inside the worker process — **a stopped worker sends
+nothing**, which is by design the strongest signal. The receiver owns
+liveness detection:
+
+- Expect a beat per workspace every 5 min. Recommended: **flag at 3
+  consecutive misses (~15 min blind), page at 6 (~30 min)** — tolerant of
+  restarts/upgrades (an upgrade gap is one or two beats; the post-restart
+  beat fires at startup).
+- A beat with `health.status: "critical"` or `queue.paused: true` or
+  `migrations.pending > 0` is receiver-side judgment — the contract only
+  requires surfacing, not paging.
+- A cron-side out-of-process sender (beats even when the worker is down,
+  with `worker_status: "stopped"`) was considered and deferred: it dilutes
+  the missed-beat signal and adds a second delivery path to secure. The
+  receiver's missed-beat detection covers the stopped-worker case.
+
+## Local audit trail (sender side)
+
+| WAL op | When |
+|---|---|
+| `framework_heartbeat_sent` / `framework_heartbeat_failed` / `framework_heartbeat_skipped` | per beat (skipped = unconfigured, the direct-adopter steady state) |
+| `fleet_event_sent` / `fleet_event_failed` | per escalated event |
+
+Plus the single-row `nexaas_memory.framework_heartbeat` state (last push
+status/HTTP code) readable via `nexaas status`.

--- a/packages/runtime/src/fleet/heartbeat.ts
+++ b/packages/runtime/src/fleet/heartbeat.ts
@@ -215,6 +215,39 @@ async function collectConformance(workspace: string): Promise<Record<string, unk
   }
 }
 
+async function collectHealth(workspace: string): Promise<{
+  status: string;
+  alerts: number;
+  alert_components: string[];
+  checked_at: string;
+} | null> {
+  // The in-process health monitor (runAndRecord, every 5 min) writes its
+  // full report to ops/health/monitor — read the latest instead of
+  // re-running the checks (a fresh run costs a 1-token API probe per
+  // beat and couples the heartbeat to the Anthropic API's availability).
+  try {
+    const row = await sqlOne<{ content: string; created_at: Date }>(
+      `SELECT content, created_at FROM nexaas_memory.events
+        WHERE workspace = $1 AND wing = 'ops' AND hall = 'health' AND room = 'monitor'
+        ORDER BY created_at DESC LIMIT 1`,
+      [workspace],
+    );
+    if (!row) return null;
+    const report = JSON.parse(row.content) as {
+      status?: string;
+      alerts?: Array<{ component?: string }>;
+    };
+    return {
+      status: report.status ?? "unknown",
+      alerts: report.alerts?.length ?? 0,
+      alert_components: [...new Set((report.alerts ?? []).map((a) => a.component ?? "?"))].slice(0, 10),
+      checked_at: new Date(row.created_at).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function collectQueue(workspace: string): Promise<{
   waiting: number;
   active: number;
@@ -238,14 +271,16 @@ async function collectQueue(workspace: string): Promise<{
   }
 }
 
-async function buildPayloadV3(identity: FrameworkIdentity): Promise<Record<string, unknown>> {
-  const [channel, runs_24h, spend, migrations, conformance, queue] = await Promise.all([
+/** Exported for the schema test — the exact beat body the receiver sees. */
+export async function buildPayloadV3(identity: FrameworkIdentity): Promise<Record<string, unknown>> {
+  const [channel, runs_24h, spend, migrations, conformance, queue, health] = await Promise.all([
     collectChannel(identity.workspace),
     collectRuns24h(identity.workspace),
     collectSpend(identity.workspace),
     collectMigrations(identity.workspace),
     collectConformance(identity.workspace),
     collectQueue(identity.workspace),
+    collectHealth(identity.workspace),
   ]);
 
   return {
@@ -266,6 +301,7 @@ async function buildPayloadV3(identity: FrameworkIdentity): Promise<Record<strin
     migrations,
     conformance,
     queue,
+    health,
   };
 }
 

--- a/tests/fleet-payload.test.ts
+++ b/tests/fleet-payload.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #216 — fleet heartbeat payload v3 vs the published receiver contract.
+ * DB-gated (collectors hit palace + BullMQ). Two guards:
+ *   1. A real buildPayloadV3() output validates against a zod schema
+ *      transcribed from docs/fleet-heartbeat-contract.md.
+ *   2. Doc drift: every top-level payload field is named in the contract
+ *      doc (the #258 one-directional pattern — code may not grow
+ *      undocumented fields).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { buildPayloadV3, getFrameworkIdentity } from "../packages/runtime/src/fleet/heartbeat.js";
+import { getPool, sql, writeDrawerRaw } from "../packages/palace/src/index.js";
+
+const hasDb = !!process.env.DATABASE_URL && !!process.env.REDIS_URL;
+const WS = `vitest-216-${process.pid}`;
+
+const beatSchema = z.object({
+  payload_version: z.literal(3),
+  workspace: z.string(),
+  version: z.string(),
+  commit_sha: z.string().nullable(),
+  branch: z.string().nullable(),
+  describe: z.string().nullable(),
+  channel: z.string().nullable(),
+  hostname: z.string(),
+  started_at: z.string(),
+  now: z.string(),
+  worker_status: z.literal("running"),
+  uptime_s: z.number(),
+  runs_24h: z.object({
+    completed: z.number(), failed: z.number(), skipped: z.number(),
+    success_rate_pct: z.number().nullable(),
+  }).nullable(),
+  spend: z.object({
+    day: z.string(), spent_usd: z.number(),
+    budget_usd: z.number().nullable(), paused: z.boolean(),
+  }).nullable(),
+  migrations: z.object({ applied: z.number(), pending: z.number() }).nullable(),
+  conformance: z.record(z.unknown()).nullable(),
+  queue: z.object({
+    waiting: z.number(), active: z.number(), delayed: z.number(),
+    failed: z.number(), paused: z.boolean(),
+  }).nullable(),
+  health: z.object({
+    status: z.string(), alerts: z.number(),
+    alert_components: z.array(z.string()), checked_at: z.string(),
+  }).nullable(),
+}).strict();
+
+afterAll(async () => {
+  if (!hasDb) return;
+  await sql(`DELETE FROM nexaas_memory.events WHERE workspace = $1`, [WS]);
+  await getPool().end().catch(() => {});
+});
+
+describe.skipIf(!hasDb)("fleet heartbeat payload v3 (#216)", () => {
+  it("a real beat validates against the contract schema (health populated)", async () => {
+    // Seed a health-monitor report so the health collector has a drawer.
+    await writeDrawerRaw(
+      WS, { wing: "ops", hall: "health", room: "monitor" },
+      JSON.stringify({
+        status: "degraded",
+        alerts: [{ severity: "warning", component: "disk", message: "93%" }],
+        metrics: {},
+      }),
+      { eventType: "health-check", agentId: "health-monitor" },
+    );
+
+    const identity = { ...getFrameworkIdentity(), workspace: WS };
+    const payload = await buildPayloadV3(identity);
+
+    const parsed = beatSchema.safeParse(payload);
+    expect(parsed.success, JSON.stringify(parsed.success ? "" : parsed.error.issues, null, 2)).toBe(true);
+
+    const health = payload.health as { status: string; alerts: number; alert_components: string[] };
+    expect(health).not.toBeNull();
+    expect(health.status).toBe("degraded");
+    expect(health.alerts).toBe(1);
+    expect(health.alert_components).toEqual(["disk"]);
+  });
+
+  it("collectors null-degrade: unknown workspace still yields a valid beat", async () => {
+    const identity = { ...getFrameworkIdentity(), workspace: `vitest-216-empty-${randomUUID().slice(0, 6)}` };
+    const payload = await buildPayloadV3(identity);
+    expect(beatSchema.safeParse(payload).success).toBe(true);
+    expect(payload.health).toBeNull();
+  });
+
+  it("every payload field is documented in the receiver contract", async () => {
+    const contract = readFileSync(join(__dirname, "..", "docs", "fleet-heartbeat-contract.md"), "utf-8");
+    const identity = { ...getFrameworkIdentity(), workspace: WS };
+    const payload = await buildPayloadV3(identity);
+    for (const field of Object.keys(payload)) {
+      expect(
+        contract.includes(`\`${field}\``),
+        `payload field '${field}' missing from docs/fleet-heartbeat-contract.md`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes out **T4 (fleet observability)** of the production-hardening program. An audit against the issue's five deliverables found three already shipped (payload v3 collectors; `pushFleetEvent` with page/digest severity wired into the #69 silent-failure watchdog and #215 spend monitor; direct-adopter no-op) — this PR fills the gaps:

1. **`health` in the beat payload**: the latest in-process health-monitor report (status, alert count, distinct components, checked_at) read from the palace — deliberately NOT a fresh check, which would cost a 1-token API probe per beat and couple the heartbeat to Anthropic availability. ≤5 min stale on a healthy worker.
2. **`docs/fleet-heartbeat-contract.md`** — the receiver contract that the sender code has referenced since v0.2.0 *but which never existed*. Covers: endpoints + workspace-scoped bearer auth (mismatch MUST be rejected — a compromised VPS can't impersonate another client), the full versioned payload schema, cadence, **missed-beat semantics** (flag@3 ≈15 min blind, page@6 — a stopped worker sending nothing is the designed signal; the cron-side alternative sender is documented as considered-and-deferred), and the page/digest severity discipline for a solo operator.
3. **Schema + drift guards** (`tests/fleet-payload.test.ts`): a real beat validates against a strict zod transcription of the contract (undocumented fields fail); an empty workspace yields a valid all-nulls-degraded beat; every payload field must be named in the contract doc.
4. **Receiver coordination filed**: Nexmatic/nexmatic#61 (heads-up: the nexmatic repo has moved from `Systemsaholic` to the `Nexmatic` org — gh redirects still work).

## Acceptance mapping
- *Healthy beat validates against published schema* → test 1, live against a seeded health report.
- *Degraded VPS detectable via missed beats* → receiver-side semantics published; stopped-worker case explicitly documented.
- *Silent-failure fleet event on broken channel binding* → already wired (`silent-failure-watchdog.ts` → `pushFleetEvent`, severity `page`, fires regardless of channel-role binding); WAL-audited.
- *Phoenix zero change* → `NEXAAS_FLEET_ENDPOINT` unset → all paths no-op (existing `framework_heartbeat_skipped` steady state).

Suite **328/328**. No migrations, no new env vars, no new routes (the endpoints are receiver-side).

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heartbeat payloads now include a summary of the latest health status and alert conditions.
  * Health information degrades gracefully when unavailable, allowing heartbeat delivery to continue.
* **Documentation**
  * Added the published Fleet Heartbeat receiver contract, covering authentication, endpoints, payload fields, event severity, retries, timeouts, and missed-heartbeat handling.
* **Tests**
  * Added validation to ensure heartbeat payloads follow the documented format and correctly handle populated or unavailable health data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->